### PR TITLE
feat: enabling it to listen on all interfaces - allows for easy docker config

### DIFF
--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -1,0 +1,25 @@
+# Base image
+FROM cgr.dev/chainguard/rust as base
+EXPOSE 8080 
+
+# making the directory
+USER root
+RUN mkdir -p /usr/app && chown -R nonroot:nonroot /usr/app
+
+USER nonroot
+WORKDIR /usr/app
+
+# Setting up build directories
+RUN mkdir -p /tmp/relayer && chown -R nonroot:nonroot /tmp/relayer
+COPY --chown=nonroot:nonroot . /tmp/relayer
+
+# building the app
+WORKDIR /tmp/relayer
+RUN cargo install --root /usr/app --path . --debug 
+
+# cleaning up
+RUN rm -Rf /tmp/*
+
+# starting up
+ENTRYPOINT ["/usr/app/bin/openzeppelin-relayer"]
+

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -1,0 +1,25 @@
+# Base image
+FROM cgr.dev/chainguard/rust as base
+EXPOSE 8080 
+
+# making the directory
+USER root
+RUN mkdir -p /usr/app && chown -R nonroot:nonroot /usr/app
+
+USER nonroot
+WORKDIR /usr/app
+
+# Setting up build directories
+RUN mkdir -p /tmp/relayer && chown -R nonroot:nonroot /tmp/relayer
+COPY --chown=nonroot:nonroot . /tmp/relayer
+
+# building the app
+WORKDIR /tmp/relayer
+RUN cargo install --root /usr/app --path . 
+
+# cleaning up
+RUN rm -Rf /tmp/*
+
+# starting up
+ENTRYPOINT ["/usr/app/bin/openzeppelin-relayer"]
+

--- a/src/config/server_config.rs
+++ b/src/config/server_config.rs
@@ -9,7 +9,7 @@ pub struct ServerConfig {
 impl ServerConfig {
     pub fn from_env() -> Self {
         Self {
-            host: env::var("HOST").unwrap_or_else(|_| "127.0.0.1".to_string()),
+            host: env::var("HOST").unwrap_or_else(|_| "0.0.0.0".to_string()),
             port: env::var("PORT")
                 .unwrap_or_else(|_| "8080".to_string())
                 .parse()


### PR DESCRIPTION
# Summary
Adds initial docker files. 

## Testing Process
Standard `docker build --tag <tag> -f <dockerfile> --squash  will make it`

Changed the rust server default config to listen on 0.0.0.0 - so it is easier to use with docker.

