### PR TITLE
refactor: Changing base image - size is now 1/10s of the original one

### DIFF
--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -1,25 +1,20 @@
 # Base image
-FROM cgr.dev/chainguard/rust as base
-EXPOSE 8080 
+FROM cgr.dev/chainguard/rust:latest-dev as base
 
-# making the directory
-USER root
-RUN mkdir -p /usr/app && chown -R nonroot:nonroot /usr/app
-
-USER nonroot
 WORKDIR /usr/app
 
+USER root
+COPY . .
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/app/target \
+    cargo install --root /usr/app --path . --debug
+
 # Setting up build directories
-RUN mkdir -p /tmp/relayer && chown -R nonroot:nonroot /tmp/relayer
-COPY --chown=nonroot:nonroot . /tmp/relayer
+FROM cgr.dev/chainguard/glibc-dynamic
 
-# building the app
-WORKDIR /tmp/relayer
-RUN cargo install --root /usr/app --path . --debug 
-
-# cleaning up
-RUN rm -Rf /tmp/*
+WORKDIR /app
+COPY --from=base --chown=nonroot:nonroot /usr/app/bin/openzeppelin-relayer /app/openzeppelin-relayer
 
 # starting up
-ENTRYPOINT ["/usr/app/bin/openzeppelin-relayer"]
+ENTRYPOINT ["/app/openzeppelin-relayer"]
 

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -1,25 +1,21 @@
 # Base image
-FROM cgr.dev/chainguard/rust as base
-EXPOSE 8080 
+FROM cgr.dev/chainguard/rust:latest-dev as base
 
-# making the directory
-USER root
-RUN mkdir -p /usr/app && chown -R nonroot:nonroot /usr/app
-
-USER nonroot
 WORKDIR /usr/app
 
+USER root
+COPY . .
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/app/target \
+    cargo install --root /usr/app --path .
+
+
 # Setting up build directories
-RUN mkdir -p /tmp/relayer && chown -R nonroot:nonroot /tmp/relayer
-COPY --chown=nonroot:nonroot . /tmp/relayer
+FROM cgr.dev/chainguard/glibc-dynamic
 
-# building the app
-WORKDIR /tmp/relayer
-RUN cargo install --root /usr/app --path . 
-
-# cleaning up
-RUN rm -Rf /tmp/*
+WORKDIR /app
+COPY --from=base --chown=nonroot:nonroot /usr/app/bin/openzeppelin-relayer /app/openzeppelin-relayer
 
 # starting up
-ENTRYPOINT ["/usr/app/bin/openzeppelin-relayer"]
+ENTRYPOINT ["/app/openzeppelin-relayer"]
 


### PR DESCRIPTION
# Summary
Generated image size moved from 1.1Gb to 114Gb (20Mb in the case of the production version)
Application was also relocated to /app -> this should make future changes less error-prone. 

## Testing Process

## Checklist

- [ ] Add a reference to related issues in the PR description.
- [ ] Add unit tests if applicable.
