### PR TITLE
docs: Update API docs. Fix Dockerfiles

### DIFF
--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -17,14 +17,6 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 # Setting up build directories
 FROM --platform=${BUILDPLATFORM} cgr.dev/chainguard/glibc-dynamic:latest-dev
 
-# Create a nonroot user and mimic those of a regular user on the linux host
-ARG UID=1000
-ARG GID=1000
-USER root
-
-RUN adduser -D -u $UID -g $GID defender
-USER defender
-
 WORKDIR /app
 COPY --from=base --chown=nonroot:nonroot /usr/app/bin/openzeppelin-relayer /app/openzeppelin-relayer
 

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -1,6 +1,7 @@
 # Base image
-FROM --platform=${BUILDPLATFORM} cgr.dev/chainguard/rust:latest AS base
+FROM --platform=${BUILDPLATFORM} cgr.dev/chainguard/rust:latest-dev AS base
 
+USER root
 RUN apk update && apk --no-cache add openssl-dev perl
 
 WORKDIR /usr/app
@@ -13,12 +14,6 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 
 # Setting up build directories
 FROM --platform=${BUILDPLATFORM} cgr.dev/chainguard/glibc-dynamic:latest
-
-# Create a nonroot user and mimic those of a regular user on the linux host
-ARG UID=1000
-ARG GID=1000
-RUN adduser -D -u $UID -g $GID defender
-USER defender
 
 WORKDIR /app
 COPY --from=base --chown=nonroot:nonroot /usr/app/bin/openzeppelin-relayer /app/openzeppelin-relayer

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -1,4 +1,5 @@
 * xref:index.adoc[User Documentation]
 * xref:quickstart.adoc[Quickstart]
+* xref:api_reference.adoc[API Reference]
 * xref:structure.adoc[Project Structure]
 * link:rust_docs/doc/openzeppelin_relayer/index.html[Technical Rust Documentation]

--- a/docs/modules/ROOT/pages/api_reference.adoc
+++ b/docs/modules/ROOT/pages/api_reference.adoc
@@ -1,0 +1,411 @@
+= API Reference
+:description: API reference document, including usage examples
+
+This document provides information on the implemented API, along with usage examples. 
+
+== Pre-requisites
+. API key
+This key is essential for most API calls. It can be set in `.env` file, under the `API_KEY` variable.
+In case of a change on the key, there is no need to rebuild docker images, as `docker compose` will pick up the changes the next time the container is started.
+
+This key should be sent as a header for most of the API calls:
+
+[source,json]
+----
+x-api-key: <my api key>
+----
+
+== Request format
+By default, the container listens on port `8080`. Calls should follow call the URL:
+`http://<server_address_or_IP>:8080/api/v1/relayers/<relayer_name>/rpc`
+
+NOTE: `relayer_name` is the name given to a relayer configuration in `./config/config.json` file.
+
+The payload should follow the format:
+[source,json]
+----
+{
+  "jsonrpc": "2.0",
+  "id": <id>,
+  "method": "<method_name>",
+  "params": { 
+    <parameter_list>
+  }
+} 
+----
+
+Where:
+- `method_name` - method to invoke. Please check sections bellow for available methods
+- `id` - unique id, used to correlate request to response
+- `parameter_list` - list of parameters required by chosen method
+
+== Environments
+- Solana
+- EVM
+
+== API Reference
+* xref:common_actions[Common Actions]
+* xref:solana_api[Solana]
+* xref:evm_api[EVM]
+
+[#common_actions]
+=== Common actions
+These are a set of REST calls common to both Solana and EVM relayers.
+
+NOTE: We are assuming a base url of `http://localhost:8080/` for these examples.
+
+- List relayers
+
+Request: `GET http://localhost:8080/api/v1/relayers/`
+
+Example request:
+[source,bash]
+----
+curl --location --request GET 'http://localhost:8080/api/v1/relayers/' \
+--header 'x-api-key: <my_api_key>'
+----
+
+Example response:
+[source,json]
+----
+{
+    "success": true,
+    "data": [
+        {
+            "id": "sepolia-example",
+            "name": "Sepolia Example",
+            "network": "sepolia",
+            "paused": false,
+            "network_type": "evm",
+            "signer_id": "local-signer",
+            "policies": {
+                "Evm": {
+                    "gas_price_cap": null,
+                    "whitelist_receivers": null,
+                    "eip1559_pricing": false,
+                    "private_transactions": false,
+                    "min_balance": 1
+                }
+            },
+            "address": "0xc834dcdc9a074dbbadcc71584789ae4b463db116",
+            "notification_id": "notification-example",
+            "system_disabled": false
+        }
+    ],
+    "error": null,
+    "pagination": {
+        "current_page": 1,
+        "per_page": 10,
+        "total_items": 1
+    }
+}
+----
+
+- Get relayer details
+
+Request: `GET http://localhost:8080/api/v1/relayers/<relayer_id>`
+
+* `relayer_id` can be found by listing relayers or checking the config file (`./config/config.json`)
+
+Example request:
+[source,bash]
+----
+curl --location --request GET 'http://localhost:8080/api/v1/relayers/<relayer_id>' \
+--header 'x-api-key: <my_api_key>'
+----
+
+Example response:
+[source,json]
+----
+{
+    "success": true,
+    "data": {
+        "id": "sepolia-example",
+        "name": "Sepolia Example",
+        "network": "sepolia",
+        "network_type": "evm",
+        "paused": false,
+        "policies": {
+            "eip1559_pricing": false,
+            "private_transactions": false,
+            "min_balance": 1
+        },
+        "address": "0xc834dcdc9a074dbbadcc71584789ae4b463db116",
+        "system_disabled": false
+    },
+    "error": null
+}
+----
+
+- Update Relayer
+
+Request: `PATCH http://localhost:8080/api/v1/relayers/<relayer_id>`
+
+Example requesti to pause a relayer:
+[source,bash]
+----
+curl --location --request PATCH 'http://localhost:8080/api/v1/relayers/<relayer_id>' \
+--header 'x-api-key: <my_api_key>' \
+--header 'Content-Type: application/json' \
+--data-raw '{
+    "paused": true
+}'
+----
+
+Example response:
+[source,json]
+----
+{
+    "success": true,
+    "data": {
+        "id": "sepolia-example",
+        "name": "Sepolia Example",
+        "network": "sepolia",
+        "paused": true,
+        "network_type": "evm",
+        "signer_id": "local-signer",
+        "policies": {
+            "Evm": {
+                "gas_price_cap": null,
+                "whitelist_receivers": null,
+                "eip1559_pricing": false,
+                "private_transactions": false,
+                "min_balance": 1
+            }
+        },
+        "address": "0xc834dcdc9a074dbbadcc71584789ae4b463db116",
+        "notification_id": "notification-example",
+        "system_disabled": false
+    },
+    "error": null
+}
+----
+
+- Get relayer balance
+Request: `GET http://localhost:8080/api/v1/relayers/<relayer_id>/balance`
+
+[#solana_api]
+=== Solana
+Solana API
+[cols="1,1,1,2"]
+|===
+|Method Name |Required Parameters |Result |Description
+
+|feeEstimate
+|`transaction`, `fee_token`
+|`estimated_fee`, `conversion_rate`
+|Estimate the fee for an arbitrary transaction using a specified token.
+
+|transferTransaction
+|`amount`, `token`, `source`, `destination`
+|`transaction`, `fee_in_spl`, `token`, `fee_in_lamports`, `valid_until_blockheight`
+|Create a transfer transaction for a specified token, sender, and recipient. The token supplied will be assumed to be the token to also be used for fees. Returns a partially signed transaction.
+
+|prepareTransaction
+|`transaction`, `fee_token`
+|`transaction`, `fee_in_spl`, `fee_token`, `fee_in_lamports`, `valid_until_blockheight`
+|Prepare a transaction by adding relayer-specific instructions. Returns a partially signed transaction.
+
+|signTransaction
+|`transaction`
+|`transaction`, `signature`
+|Sign a prepared transaction without submitting it to the blockchain.
+
+|signAndSendTransaction
+|`transaction`
+|`transaction`, `signature`
+|Sign and submit a transaction to the blockchain.
+
+|getSupportedTokens
+|(none)
+|`tokens[]` (list of token metadata)
+|Retrieve a list of tokens supported by the relayer for fee payments.
+
+|getFeaturesEnabled
+|(none)
+|`features[]` (list of enabled features)
+|Retrieve a list of features supported by the relayer.
+|===
+
+Key terminology
+[cols="1,2"]
+|===
+|Key |Description
+
+|`transaction`
+|Base64-encoded serialized Solana transaction. This could be a signed or unsigned transaction.
+
+|`signature`
+|Unique “transaction hash” that can be used to look up transaction status on-chain.
+
+|`source`
+|Source wallet address. The relayer is responsible for deriving and the TA.
+
+|`destination`
+|Destination wallet address. The relayer is responsible for deriving and creating the TA if necessary.
+
+|`fee_token`
+|Token mint address for the fee payment.
+
+|`fee_in_spl`
+|Fee amount the end user will pay to the relayer to process the transaction in spl tokens in the smallest unit of the spl token (no decimals)
+
+|`fee_in_lamports`
+|Fee amount in Lamports the Relayer estimates it will pay for the transaction.
+
+|`valid_until_block_height`
+|Expiration block height for time-sensitive operations.
+
+|`tokens[]`
+|Array of supported token metadata (e.g., symbol, mint, decimals).
+
+|`features[]`
+|Array of features enabled by the relayer (e.g., bundle support, sponsorship).
+|===
+
+[#solana_api_examples]
+==== Solana example calls
+
+NOTE: We are assuming a base url of `http://localhost:8080/` for these examples.
+
+* Get supported tokens
+Request:
+[source,bash]
+----
+curl --location --request POST 'http://localhost:8080/api/v1/relayers/<solana_relayer_id>/rpc' \
+--header 'x-api-key: <my_api_key>' \
+--header 'Content-Type: application/json' \
+--data-raw '{
+    "jsonrpc": "2.0",
+    "method": "getSupportedTokens",
+    "params": {},
+    "id": 2
+}'
+----
+
+Result:
+[source,json]
+----
+{
+    "jsonrpc": "2.0",
+    "result": {
+        "tokens": [
+            {
+                "conversion_slippage_percentage": null,
+                "decimals": 6,
+                "max_allowed_fee": 100000000,
+                "mint": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                "symbol": "USDC"
+            },
+            {
+                "conversion_slippage_percentage": null,
+                "decimals": 9,
+                "max_allowed_fee": null,
+                "mint": "So11111111111111111111111111111111111111112",
+                "symbol": "SOL"
+            }
+        ]
+    },
+    "id": 2
+}
+----
+
+* Fee estimate
+Request:
+[source,bash]
+----
+curl --location --request POST 'http://localhost:8080/api/v1/relayers/<solana_relayer_id>/rpc' \
+--header 'x-api-key: <my_api_key>' \
+--header 'Content-Type: application/json' \
+--data-raw '
+{
+  "jsonrpc": "2.0",
+  "method": "feeEstimate",
+  "params": {
+    "transaction": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAEDpNhTBS0w2fqEkg0sAghld4KIZNFW3kt5Co2TA75icpEAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAZzDKeiaRTZZ3ipAtgJOOmqCGhz1iUHo8A9xynrbleugBAgIAAQwCAAAAQEIPAAAAAAA=",
+    "fee_token": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+  },
+  "id": 3
+}'
+----
+
+Result:
+[source,json]
+----
+{
+    "jsonrpc": "2.0",
+    "result": {
+        "conversion_rate": "142.6",
+        "estimated_fee": "0.000713"
+    },
+    "id": 3
+}
+----
+
+* Sign transaction
+[source,bash]
+----
+curl --location --request POST 'http://localhost:8080/api/v1/relayers/<solana_relayer_id>/rpc' \
+--header 'x-api-key: <my_api_key>' \
+--header 'Content-Type: application/json' \
+--data-raw '{
+  "jsonrpc": "2.0",
+  "method": "signTransaction",
+  "params": {
+    "transaction": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAEDpNhTBS0w2fqEkg0sAghld4KIZNFW3kt5Co2TA75icpEAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/bKmYrYtPWWI7zwiXWqAC5iFnkAkRL2D8s6lPkoJJokBAgIAAQwCAAAAQEIPAAAAAAA="
+    
+  },
+  "id": 4
+}'
+----
+
+Result:
+[source,json]
+----
+{
+    "jsonrpc": "2.0",
+    "result": {
+        "signature": "2jg9xbGLtZRsiJBrDWQnz33JuLjDkiKSZuxZPdjJ3qrJbMeTEerXFAKynkPW63J88nq63cvosDNRsg9VqHtGixvP",
+        "transaction": "AVbRgFoUlj0XdlLP4gJJ2zwmr/2g2LOdeNqGPYTl4VFzY7lrX+nKNXUEU0DLJEA+2BW3uHvudQSXz5YBqd5d9gwBAAEDpNhTBS0w2fqEkg0sAghld4KIZNFW3kt5Co2TA75icpEAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/bKmYrYtPWWI7zwiXWqAC5iFnkAkRL2D8s6lPkoJJokBAgIAAQwCAAAAQEIPAAAAAAA="
+    },
+    "id": 4
+}
+----
+
+* Sign and send transaction
+[source,bash]
+----
+curl --location --request POST 'http://localhost:8080/api/v1/relayers/<solana_relayer_id>/rpc' \
+--header 'x-api-key: <my_api_key>' \
+--header 'Content-Type: application/json' \
+--data-raw '{
+  "jsonrpc": "2.0",
+  "method": "signAndSendTransaction",
+  "params": {
+    "transaction": "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAEDpNhTBS0w2fqEkg0sAghld4KIZNFW3kt5Co2TA75icpEAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/bKmYrYtPWWI7zwiXWqAC5iFnkAkRL2D8s6lPkoJJokBAgIAAQwCAAAAQEIPAAAAAAA="
+    
+  },
+  "id": 5
+}'
+----
+
+Result:
+[source,json]
+----
+{
+    "jsonrpc": "2.0",
+    "result": {
+        "signature": "2jg9xbGLtZRsiJBrDWQnz33JuLjDkiKSZuxZPdjJ3qrJbMeTEerXFAKynkPW63J88nq63cvosDNRsg9VqHtGixvP",
+        "transaction": "AVbRgFoUlj0XdlLP4gJJ2zwmr/2g2LOdeNqGPYTl4VFzY7lrX+nKNXUEU0DLJEA+2BW3uHvudQSXz5YBqd5d9gwBAAEDpNhTBS0w2fqEkg0sAghld4KIZNFW3kt5Co2TA75icpEAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/bKmYrYtPWWI7zwiXWqAC5iFnkAkRL2D8s6lPkoJJokBAgIAAQwCAAAAQEIPAAAAAAA="
+    },
+    "id": 5
+}
+----
+
+[#evm_api]
+=== EVM
+
+[#evm_api_examples]
+==== EVM example calls
+
+

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -3,6 +3,8 @@
 = OpenZeppelin Relayer
 :description: User guide for setting up and configuring OpenZeppelin Relayer.
 
+CAUTION: This software is in alpha stage. Use in production environments at your own risk.
+
 OpenZeppelin Relayer is a service that provides infrastructure to relay transactions to the EVM & Non-EVM networks. It is designed to be used as a backend for dApps that need to interact with these networks.
 
 **Features**
@@ -17,8 +19,8 @@ OpenZeppelin Relayer is a service that provides infrastructure to relay transact
 
 **Supported Networks**
 
-- EVM
 - Solana
+- EVM (Basic support for Ethereum)
 
 [NOTE]
 ====
@@ -91,24 +93,20 @@ The Relayer can be run as either a development or production container using the
 
 ==== Building the Image
 
-You can build using either standard Docker build or buildx:
+You can build using Docker Compose (v2).
 
 [source,bash]
 ----
-# Standard build
-docker build --tag <your_image_tag> -f Dockerfile.<development | production> --squash-all
+# Default build
+docker compose build
 
-# Or using buildx
-docker buildx build -f Dockerfile.<development | production> -t <name_of_image:tag> .
+# Or, for a leaner image (and using Dockerfile.production)
+DOCKERFILE=Dockerfile.production docker compose build
 ----
-
-The build process will include:
-
-* The appropriate .env file
 
 ==== Running the Container
 
-You can use Docker Compose to run the container:
+Use Docker Compose to run the container:
 
 [source,bash]
 ----
@@ -124,8 +122,27 @@ DOCKERFILE=Dockerfile.production docker compose up -d
 
 == Configuration References
 
-All configuration files should live under `./config`, including the signer configurations, under `./config/keys`.
+Most configuration files should live under `./config`, including the signer configurations, under `./config/keys`.
 Please ensure appropriate access permissions on all configuration files (for `./config/keys/*`, we recommend `0500`.
+
+=== Environment configuration (.env)
+
+This file is the exception and should live in the same directory as `docker-compose.yaml`. It defines some base configurations for the Relayer application:
+[source,json]
+----
+# For defaults see: ./docker-compose.yml
+# Create a .env file in the root of the project and add your environment variables there
+RUST_LOG=debug
+CONFIG_PATH=./config/config.json
+WEBHOOK_SIGNING_KEY=<my webhook signing key>
+API_KEY=<my api key>
+RATE_LIMIT_RPS=10
+RATE_LIMIT_BURST_SIZE=10
+METRICS_ENABLED=true
+----
+
+Make sure to, at least, choose your API key. Without it, you won't be able to interact with most of the API endpoints on the Relayer.
+If you change any of these value, you will need to restart the container to make them active. 
 
 === Main configuration file (config.json)
 

--- a/docs/modules/ROOT/pages/quickstart.adoc
+++ b/docs/modules/ROOT/pages/quickstart.adoc
@@ -21,18 +21,22 @@ git clone https://github.com/openzeppelin/openzeppelin-relayer
 cd openzeppelin-relayer
 ----
 
-. Modify the environment configuration file (`.env`) with your preferred verbosity level:
+. Modify the environment configuration file (`.env`) with your preferred verbosity level and set your API key:
 +
-1. Error
-2. Warn
-3. Info
-4. Debug
-5. Trace
+Verbosity levels:
+
++
+- Error
+- Warn
+- Info
+- Debug
+- Trace
 
 +
 [source,bash]
 ----
 RUST_LOG=info
+API_KEY=<enter your desired API key>
 ----
 
 . Create a new signer key and save it under `config/keys`.
@@ -97,6 +101,7 @@ By default docker compose command uses `Dockerfile.development` to build the ima
 DOCKERFILE=Dockerfile.production docker compose up -d
 ----
 
-== Examples
+== Using the relayer through the API
 
-TBD
+Please check our xref:api_reference.adoc[API guide] for a description and examples on using the Relayer.
+


### PR DESCRIPTION
# Summary
Updated API docs and smoothed some edges on documentation overall. 

Fixed dockerfiles. Being a distroless release, it is not simple (and probably not worth it) to create a specific defender user in docker - it depends on calling adduser and addgroup, which needs a shell installed (there isn't one). 

we can revisit this after the prealpha (and before the alpha release) but I don't really see a lot of benefits of doing it. 

## Testing Process
* Build both docker images `docker compose build; DOCKERFILE=Dockerfile.production docker compose build`
* Build Antora docs (makes it easier to review)

## Checklist

- [ ] Add a reference to related issues in the PR description.
- [ ] Add unit tests if applicable.
