### PR TITLE
refactor: Add optimism changes

### DIFF
--- a/src/config/config_file/notification.rs
+++ b/src/config/config_file/notification.rs
@@ -37,47 +37,48 @@ pub struct NotificationFileConfig {
 impl NotificationFileConfig {
     fn validate_signing_key(&self) -> Result<(), ConfigFileError> {
         match &self.signing_key {
-            Some(signing_key) => match signing_key {
-                PlainOrEnvValue::Env { value } => {
-                    if value.is_empty() {
-                        return Err(ConfigFileError::MissingField(
-                            "Signing key environment variable name cannot be empty".into(),
-                        ));
-                    }
+            Some(signing_key) => {
+                match signing_key {
+                    PlainOrEnvValue::Env { value } => {
+                        if value.is_empty() {
+                            return Err(ConfigFileError::MissingField(
+                                "Signing key environment variable name cannot be empty".into(),
+                            ));
+                        }
 
-                    match std::env::var(value) {
-                        Ok(key_value) => {
-                            // Validate the key length
-                            if key_value.len() < MINIMUM_SECRET_VALUE_LENGTH {
-                                return Err(ConfigFileError::InvalidFormat(
-                                    format!("Signing key must be at least {} characters long (found {})", 
-                                        MINIMUM_SECRET_VALUE_LENGTH, key_value.len()).into(),
+                        match std::env::var(value) {
+                            Ok(key_value) => {
+                                // Validate the key length
+                                if key_value.len() < MINIMUM_SECRET_VALUE_LENGTH {
+                                    return Err(ConfigFileError::InvalidFormat(
+                                    format!("Signing key must be at least {} characters long (found {})",
+                                        MINIMUM_SECRET_VALUE_LENGTH, key_value.len()),
                                 ));
+                                }
+                            }
+                            Err(e) => {
+                                return Err(ConfigFileError::MissingEnvVar(format!(
+                                    "Environment variable '{}' not found: {}",
+                                    value, e
+                                )));
                             }
                         }
-                        Err(e) => {
-                            return Err(ConfigFileError::MissingEnvVar(format!(
-                                "Environment variable '{}' not found: {}",
-                                value, e
-                            )));
+                    }
+                    PlainOrEnvValue::Plain { value } => {
+                        if value.is_empty() {
+                            return Err(ConfigFileError::InvalidFormat(
+                                "Signing key value cannot be empty".into(),
+                            ));
+                        }
+
+                        if !value.has_minimum_length(MINIMUM_SECRET_VALUE_LENGTH) {
+                            return Err(ConfigFileError::InvalidFormat(
+                            format!("Security error: Signing key value must be at least {} characters long", MINIMUM_SECRET_VALUE_LENGTH)
+                        ));
                         }
                     }
                 }
-                PlainOrEnvValue::Plain { value } => {
-                    if value.is_empty() {
-                        return Err(ConfigFileError::InvalidFormat(
-                            "Signing key value cannot be empty".into(),
-                        ));
-                    }
-
-                    if !value.has_minimum_length(MINIMUM_SECRET_VALUE_LENGTH) {
-                        return Err(ConfigFileError::InvalidFormat(
-                            format!("Security error: Signing key value must be at least {} characters long", MINIMUM_SECRET_VALUE_LENGTH)
-                                .into(),
-                        ));
-                    }
-                }
-            },
+            }
             None => return Ok(()),
         }
 

--- a/src/models/network/evm/named_network.rs
+++ b/src/models/network/evm/named_network.rs
@@ -499,14 +499,8 @@ impl EvmNamedNetwork {
                 "https://testnet.snowtrace.io",
             ],
 
-            Optimism => &[
-                "https://api-optimistic.etherscan.io/api",
-                "https://optimistic.etherscan.io",
-            ],
-            OptimismSepolia => &[
-                "https://api-sepolia-optimistic.etherscan.io/api",
-                "https://sepolia-optimism.etherscan.io",
-            ],
+            Optimism => &["https://mainnet.optimism.io"],
+            OptimismSepolia => &["https://sepolia.optimism.io"],
 
             Fantom => &["https://api.ftmscan.com/api", "https://ftmscan.com"],
             FantomTestnet => &[

--- a/src/models/network/stellar/network.rs
+++ b/src/models/network/stellar/network.rs
@@ -244,12 +244,11 @@ mod tests {
         // Test average_blocktime returns an Option<Duration>
         let blocktime = network.average_blocktime();
         // We do not assume a concrete value; just that it returns Some(_) or None.
-        match blocktime {
-            Some(duration) => assert!(
+        if let Some(duration) = blocktime {
+            assert!(
                 duration > Duration::from_secs(0),
                 "Blocktime should be a positive duration"
-            ),
-            None => {} // Acceptable if the underlying implementation returns None.
+            )
         }
 
         // Test public RPC URLs.

--- a/src/services/provider/evm/mod.rs
+++ b/src/services/provider/evm/mod.rs
@@ -209,7 +209,7 @@ impl EvmProviderTrait for EvmProvider {
 
     async fn get_block_by_number(&self) -> Result<BlockResponse> {
         self.provider
-            .get_block_by_number(BlockNumberOrTag::Latest, BlockTransactionsKind::Full)
+            .get_block_by_number(BlockNumberOrTag::Latest, BlockTransactionsKind::Hashes)
             .await
             .map_err(|e| eyre!("Failed to get block by number: {}", e))?
             .ok_or_else(|| eyre!("Block not found"))


### PR DESCRIPTION
# Summary

- Adding public RPC endpoints for optimism mainnet and sepolia
- Changed `get_block_by_number` call to fetch only header and hashes vs full block. 
    - The reasoning for this is optimism based networks return a different shaped response from this call, when testing optimism and worldchain the response was erroring when trying to deserialise. There are 2 options here, change the call for fetching a block to return only header and hashes, or updated our provider logic to use the `AnyNetwork`, [example](https://alloy.rs/examples/advanced/any_network.html?highlight=AnyNetwork). I opted for only returning the header and hashes as this is all we need for relayers (we are fetching base fee), but we may run into other similar issues down the line so its good to consider AnyNetwork support

## Testing Process

## Checklist

- [ ] Add a reference to related issues in the PR description.
- [ ] Add unit tests if applicable.
