### PR TITLE
refactor: Fix mr conflicts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Get changed files
         id: changed-files-yaml
-        uses: tj-actions/changed-files@dcc7a0cba800f454d79fff4b993e8c3555bcc0a8  # v45.0.7
+        uses: tj-actions/changed-files@b74df86ccb65173a8e33ba5492ac1a2ca6b216fd  # v46.0.4
         with:
           files_yaml: |
             code:
@@ -168,7 +168,7 @@ jobs:
         continue-on-error: true
 
       - name: upload sarif artifact
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1  # v4.6.1
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: clippy-results.sarif
           path: clippy-results.sarif


### PR DESCRIPTION
# Summary

- Fix release -> main merge conflicts
- Use `refactor:` to skip releases