### PR TITLE
fix: TransactionRequest TryFrom fn

### DIFF
--- a/src/services/provider/evm/mod.rs
+++ b/src/services/provider/evm/mod.rs
@@ -450,7 +450,11 @@ impl TryFrom<&EvmTransactionData> for TransactionRequest {
             //         .map_err(|_| TransactionError::InvalidType("Invalid gas
             // limit".to_string()))?, ),
             value: Some(Uint::<256, 4>::from(tx.value)),
-            input: TransactionInput::from(tx.data.clone().unwrap_or("".to_string()).into_bytes()),
+            input: TransactionInput::from(
+                hex::decode(tx.data.clone().unwrap_or("".to_string()).into_bytes()).map_err(
+                    |e| TransactionError::InvalidType(format!("Invalid hex data: {}", e)),
+                )?,
+            ),
             nonce: Some(
                 Uint::<256, 4>::from(tx.nonce.ok_or_else(|| {
                     TransactionError::InvalidType("Nonce must be defined".to_string())


### PR DESCRIPTION
# Summary
We need to decode the calldata using hex::decode for TransactionInput, otherwise estimate_gas that converts EvmTransactionData to TransactionRequest will fail

## Testing Process

## Checklist

- [ ] Add a reference to related issues in the PR description.
- [ ] Add unit tests if applicable.
