### PR TITLE
chore: Pin rust toolchain in ci

### DIFF
--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -14,9 +14,8 @@ runs:
   using: composite
   steps:
     - name: setup rust tool chain
-      uses: dtolnay/rust-toolchain@fcf085fcb4b4b8f63f96906cd713eb52181b5ea4  # stable
+      uses: dtolnay/rust-toolchain@1.86.0  # v1.86.0
       with:
-        toolchain: stable
         components: ${{ (inputs.components != '') && format('{0}, rustfmt, clippy', inputs.components) || 'rustfmt, clippy' }}
     - name: Install libsodium
       run: sudo apt-get update && sudo apt-get install -y libsodium-dev

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,12 @@
+[toolchain]
+channel = "1.86.0"
+profile = "minimal"
+components = [
+    "rustc",
+    "cargo",
+    "rustfmt",
+    "clippy",
+    "rust-docs",
+    "llvm-tools",
+    "rust-src",
+]


### PR DESCRIPTION
# Summary

- Pin rust version for lints in ci and for local testing to avoid non-determinism
