### PR TITLE
fix: remove the ci job dependant from the test job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -148,7 +148,6 @@ jobs:
       contents: read
     needs:
       - changed_files
-      - ci
     runs-on: ubuntu-latest
     steps:
       # Checkout the repository


### PR DESCRIPTION
# Summary

Removes the ci job dependant from the test job

## Testing Process

## Checklist

- [ ] Add a reference to related issues in the PR description.
- [ ] Add unit tests if applicable.
