### PR TITLE
feat: plat-6215 add support for rpc failovers and retries

### DIFF
--- a/src/services/provider/rpc_selector.rs
+++ b/src/services/provider/rpc_selector.rs
@@ -56,7 +56,6 @@ impl ProviderHealth {
 
     // Mark a provider as failed
     fn mark_failed(&mut self, index: usize) {
-        println!("Marking provider {} as failed", index);
         let reset_time = Instant::now() + self.reset_duration;
         self.failed_provider_reset_times.insert(index, reset_time);
     }

--- a/src/services/provider/rpc_selector.rs
+++ b/src/services/provider/rpc_selector.rs
@@ -56,6 +56,7 @@ impl ProviderHealth {
 
     // Mark a provider as failed
     fn mark_failed(&mut self, index: usize) {
+        println!("Marking provider {} as failed", index);
         let reset_time = Instant::now() + self.reset_duration;
         self.failed_provider_reset_times.insert(index, reset_time);
     }

--- a/src/services/provider/solana/mod.rs
+++ b/src/services/provider/solana/mod.rs
@@ -456,8 +456,6 @@ impl SolanaProviderTrait for SolanaProvider {
         &self,
         pubkey: &Pubkey,
     ) -> Result<Account, SolanaProviderError> {
-        println!("Address2: {}", pubkey);
-
         self.retry_rpc_call("get_account_from_pubkey", |client| async move {
             client
                 .get_account(pubkey)


### PR DESCRIPTION
# Summary

This PR adds rpc retries and failover functionality to Solana

## Testing Process

## Checklist

- [ ] Add a reference to related issues in the PR description.
- [ ] Add unit tests if applicable.
