### PR TITLE
feat: Add node support to environment 

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,6 @@
 target/
 logs/
 docs/
+
+# plugins dependencies
+plugins/**/node_modules

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,12 @@
 ---
 minimum_pre_commit_version: 3.5.0
-default_install_hook_types: [commit-msg, pre-commit, pre-push]
-default_stages: [pre-commit, pre-push]
+default_install_hook_types:
+  - commit-msg
+  - pre-commit
+  - pre-push
+default_stages:
+  - pre-commit
+  - pre-push
 ci:
   autofix_commit_msg: 'chore(pre-commit): autofix run'
   autoupdate_commit_msg: 'chore(pre-commit): autoupdate hooks'
@@ -19,7 +24,8 @@ repos:
         entry: cargo fmt
         pass_filenames: false
         language: system
-        types: [rust]
+        types:
+          - rust
       - id: clippy
         name: clippy
         entry: cargo clippy --all-targets --all-features -- -D warnings
@@ -29,6 +35,7 @@ repos:
     rev: v5.0.0
     hooks:
       - id: check-json
+        exclude: ^plugins/tsconfig\.json$
       - id: check-toml
       - id: check-merge-conflict
       - id: check-case-conflict
@@ -39,12 +46,15 @@ repos:
     rev: 1.17.0
     hooks:
       - id: yamlfix
-        args: [-c, .yamlfix.toml]
+        args:
+          - -c
+          - .yamlfix.toml
   - repo: https://github.com/crate-ci/committed
     rev: v1.1.5
     hooks:
       - id: committed
-        stages: [commit-msg]
+        stages:
+          - commit-msg
   - repo: https://github.com/crate-ci/typos
     rev: v1.29.4
     hooks:
@@ -53,5 +63,18 @@ repos:
     rev: v3.4.0
     hooks:
       - id: conventional-pre-commit
-        stages: [commit-msg]
-        args: [--strict, build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test]
+        stages:
+          - commit-msg
+        args:
+          - --strict
+          - build
+          - chore
+          - ci
+          - docs
+          - feat
+          - fix
+          - perf
+          - refactor
+          - revert
+          - style
+          - test

--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -27,11 +27,11 @@ COPY --from=base --chown=nonroot:nonroot /usr/app/bin/openzeppelin-relayer /app/
 
 # Install plugin dependencies
 ARG TARGETARCH
-ENV NODE_VERSION=20.19.2
+ENV NODE_VERSION=v20.19.2
 
 USER root
 RUN apk add --no-cache curl && \
-    curl -fsSL https://nodejs.org/download/release/v20.19.2/node-v20.19.2-linux-${TARGETARCH}.tar.xz \
+    curl -fsSL https://nodejs.org/download/release/${NODE_VERSION}/node-${NODE_VERSION}-linux-${TARGETARCH}.tar.xz \
     | tar -xJ --strip-components=1 -C /usr/local
 
 ENV PATH="/usr/local/bin:$PATH"

--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -29,13 +29,24 @@ COPY --from=base --chown=nonroot:nonroot /usr/app/bin/openzeppelin-relayer /app/
 ARG TARGETARCH
 ENV NODE_VERSION=v20.19.2
 
+# Install Node.js
 USER root
 RUN apk add --no-cache curl && \
     curl -fsSL https://nodejs.org/download/release/${NODE_VERSION}/node-${NODE_VERSION}-linux-${TARGETARCH}.tar.xz \
     | tar -xJ --strip-components=1 -C /usr/local
-
 ENV PATH="/usr/local/bin:$PATH"
+
+# Install pnpm and ts-node
 RUN npm install -g pnpm ts-node typescript
+
+# Copy plugins folder and install dependencies
+COPY ./plugins /app/plugins
+RUN chown -R nonroot:nonroot /app/plugins
+WORKDIR /app/plugins
+RUN pnpm install --frozen-lockfile
+
+# Return to app root
+WORKDIR /app
 
 ENV APP_PORT=8080
 ENV METRICS_PORT=8081

--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -25,6 +25,17 @@ WORKDIR /app
 
 COPY --from=base --chown=nonroot:nonroot /usr/app/bin/openzeppelin-relayer /app/openzeppelin-relayer
 
+# Install plugin dependencies
+ARG TARGETARCH
+ENV NODE_VERSION=20.19.2
+
+USER root
+RUN apk add --no-cache curl && \
+    curl -fsSL https://nodejs.org/download/release/v20.19.2/node-v20.19.2-linux-${TARGETARCH}.tar.xz \
+    | tar -xJ --strip-components=1 -C /usr/local
+
+ENV PATH="/usr/local/bin:$PATH"
+RUN npm install -g pnpm ts-node typescript
 
 ENV APP_PORT=8080
 ENV METRICS_PORT=8081

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -25,11 +25,11 @@ COPY --from=base /usr/lib/libcrypto.so.3 /usr/lib/libcrypto.so.3
 
 # Install plugin dependencies
 ARG TARGETARCH
-ENV NODE_VERSION=20.19.2
+ENV NODE_VERSION=v20.19.2
 
 USER root
 RUN apk add --no-cache curl && \
-    curl -fsSL https://nodejs.org/download/release/v20.19.2/node-v20.19.2-linux-${TARGETARCH}.tar.xz \
+    curl -fsSL https://nodejs.org/download/release/${NODE_VERSION}/node-${NODE_VERSION}-linux-${TARGETARCH}.tar.xz \
     | tar -xJ --strip-components=1 -C /usr/local
 
 ENV PATH="/usr/local/bin:$PATH"

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -23,6 +23,18 @@ COPY --from=base --chown=nonroot:nonroot /usr/app/bin/openzeppelin-relayer /app/
 COPY --from=base /usr/lib/libssl.so.3 /usr/lib/libssl.so.3
 COPY --from=base /usr/lib/libcrypto.so.3 /usr/lib/libcrypto.so.3
 
+# Install plugin dependencies
+ARG TARGETARCH
+ENV NODE_VERSION=20.19.2
+
+USER root
+RUN apk add --no-cache curl && \
+    curl -fsSL https://nodejs.org/download/release/v20.19.2/node-v20.19.2-linux-${TARGETARCH}.tar.xz \
+    | tar -xJ --strip-components=1 -C /usr/local
+
+ENV PATH="/usr/local/bin:$PATH"
+RUN npm install -g pnpm ts-node typescript
+
 ENV APP_PORT=8080
 ENV METRICS_PORT=8081
 

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -27,13 +27,25 @@ COPY --from=base /usr/lib/libcrypto.so.3 /usr/lib/libcrypto.so.3
 ARG TARGETARCH
 ENV NODE_VERSION=v20.19.2
 
+# Install Node.js
 USER root
 RUN apk add --no-cache curl && \
     curl -fsSL https://nodejs.org/download/release/${NODE_VERSION}/node-${NODE_VERSION}-linux-${TARGETARCH}.tar.xz \
     | tar -xJ --strip-components=1 -C /usr/local
-
 ENV PATH="/usr/local/bin:$PATH"
+
+# Install pnpm and ts-node
 RUN npm install -g pnpm ts-node typescript
+
+# Copy plugins folder and install dependencies
+COPY ./plugins /app/plugins
+RUN chown -R nonroot:nonroot /app/plugins
+WORKDIR /app/plugins
+RUN pnpm install --frozen-lockfile
+
+# Return to app root
+WORKDIR /app
+
 
 ENV APP_PORT=8080
 ENV METRICS_PORT=8081

--- a/plugins/example.ts
+++ b/plugins/example.ts
@@ -1,0 +1,13 @@
+import { ethers } from "ethers";
+
+function sleep(ms: number) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function main() {
+    console.log("Running plugin with ethers:", ethers.version);
+    await sleep(5000);
+    console.log("Plugin finished");
+}
+
+main();

--- a/plugins/package.json
+++ b/plugins/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "plugins",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "",
+  "dependencies": {
+    "ethers": "^6.14.3"
+  }
+}

--- a/plugins/pnpm-lock.yaml
+++ b/plugins/pnpm-lock.yaml
@@ -1,0 +1,66 @@
+---
+lockfileVersion: '9.0'
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+importers:
+  .:
+    dependencies:
+      ethers:
+        specifier: ^6.14.3
+        version: 6.14.3
+packages:
+  '@adraffy/ens-normalize@1.10.1':
+    resolution: {integrity: sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==}
+  '@noble/curves@1.2.0':
+    resolution: {integrity: sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==}
+  '@noble/hashes@1.3.2':
+    resolution: {integrity: sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==}
+    engines: {node: '>= 16'}
+  '@types/node@22.7.5':
+    resolution: {integrity: sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==}
+  aes-js@4.0.0-beta.5:
+    resolution: {integrity: sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==}
+  ethers@6.14.3:
+    resolution: {integrity: sha512-qq7ft/oCJohoTcsNPFaXSQUm457MA5iWqkf1Mb11ujONdg7jBI6sAOrHaTi3j0CBqIGFSCeR/RMc+qwRRub7IA==}
+    engines: {node: '>=14.0.0'}
+  tslib@2.7.0:
+    resolution: {integrity: sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==}
+  undici-types@6.19.8:
+    resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
+  ws@8.17.1:
+    resolution: {integrity: sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+snapshots:
+  '@adraffy/ens-normalize@1.10.1': {}
+  '@noble/curves@1.2.0':
+    dependencies:
+      '@noble/hashes': 1.3.2
+  '@noble/hashes@1.3.2': {}
+  '@types/node@22.7.5':
+    dependencies:
+      undici-types: 6.19.8
+  aes-js@4.0.0-beta.5: {}
+  ethers@6.14.3:
+    dependencies:
+      '@adraffy/ens-normalize': 1.10.1
+      '@noble/curves': 1.2.0
+      '@noble/hashes': 1.3.2
+      '@types/node': 22.7.5
+      aes-js: 4.0.0-beta.5
+      tslib: 2.7.0
+      ws: 8.17.1
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+  tslib@2.7.0: {}
+  undici-types@6.19.8: {}
+  ws@8.17.1: {}

--- a/plugins/tsconfig.json
+++ b/plugins/tsconfig.json
@@ -1,0 +1,113 @@
+{
+  "compilerOptions": {
+    /* Visit https://aka.ms/tsconfig to read more about this file */
+
+    /* Projects */
+    // "incremental": true,                              /* Save .tsbuildinfo files to allow for incremental compilation of projects. */
+    // "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
+    // "tsBuildInfoFile": "./.tsbuildinfo",              /* Specify the path to .tsbuildinfo incremental compilation file. */
+    // "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects. */
+    // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
+    // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
+
+    /* Language and Environment */
+    "target": "es2016",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+    // "jsx": "preserve",                                /* Specify what JSX code is generated. */
+    // "libReplacement": true,                           /* Enable lib replacement. */
+    // "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */
+    // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
+    // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'. */
+    // "jsxFragmentFactory": "",                         /* Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'. */
+    // "jsxImportSource": "",                            /* Specify module specifier used to import the JSX factory functions when using 'jsx: react-jsx*'. */
+    // "reactNamespace": "",                             /* Specify the object invoked for 'createElement'. This only applies when targeting 'react' JSX emit. */
+    // "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
+    // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
+    // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
+
+    /* Modules */
+    "module": "commonjs",                                /* Specify what module code is generated. */
+    // "rootDir": "./",                                  /* Specify the root folder within your source files. */
+    // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
+    // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
+    // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
+    // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
+    // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
+    // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
+    // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
+    // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
+    // "allowImportingTsExtensions": true,               /* Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set. */
+    // "rewriteRelativeImportExtensions": true,          /* Rewrite '.ts', '.tsx', '.mts', and '.cts' file extensions in relative import paths to their JavaScript equivalent in output files. */
+    // "resolvePackageJsonExports": true,                /* Use the package.json 'exports' field when resolving package imports. */
+    // "resolvePackageJsonImports": true,                /* Use the package.json 'imports' field when resolving imports. */
+    // "customConditions": [],                           /* Conditions to set in addition to the resolver-specific defaults when resolving imports. */
+    // "noUncheckedSideEffectImports": true,             /* Check side effect imports. */
+    // "resolveJsonModule": true,                        /* Enable importing .json files. */
+    // "allowArbitraryExtensions": true,                 /* Enable importing files with any extension, provided a declaration file is present. */
+    // "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
+
+    /* JavaScript Support */
+    // "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */
+    // "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
+    // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
+
+    /* Emit */
+    // "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
+    // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
+    // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
+    // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
+    // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
+    // "noEmit": true,                                   /* Disable emitting files from a compilation. */
+    // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
+    // "outDir": "./",                                   /* Specify an output folder for all emitted files. */
+    // "removeComments": true,                           /* Disable emitting comments. */
+    // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
+    // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
+    // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
+    // "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSources": true,                            /* Include source code in the sourcemaps inside the emitted JavaScript. */
+    // "emitBOM": true,                                  /* Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files. */
+    // "newLine": "crlf",                                /* Set the newline character for emitting files. */
+    // "stripInternal": true,                            /* Disable emitting declarations that have '@internal' in their JSDoc comments. */
+    // "noEmitHelpers": true,                            /* Disable generating custom helper functions like '__extends' in compiled output. */
+    // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
+    // "preserveConstEnums": true,                       /* Disable erasing 'const enum' declarations in generated code. */
+    // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
+
+    /* Interop Constraints */
+    // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
+    // "verbatimModuleSyntax": true,                     /* Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting. */
+    // "isolatedDeclarations": true,                     /* Require sufficient annotation on exports so other tools can trivially generate declaration files. */
+    // "erasableSyntaxOnly": true,                       /* Do not allow runtime constructs that are not part of ECMAScript. */
+    // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
+    "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
+    // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
+    "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
+
+    /* Type Checking */
+    "strict": true,                                      /* Enable all strict type-checking options. */
+    // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,                         /* When type checking, take into account 'null' and 'undefined'. */
+    // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
+    // "strictBindCallApply": true,                      /* Check that the arguments for 'bind', 'call', and 'apply' methods match the original function. */
+    // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
+    // "strictBuiltinIteratorReturn": true,              /* Built-in iterators are instantiated with a 'TReturn' type of 'undefined' instead of 'any'. */
+    // "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
+    // "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
+    // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
+    // "noUnusedLocals": true,                           /* Enable error reporting when local variables aren't read. */
+    // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */
+    // "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
+    // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
+    // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
+    // "noUncheckedIndexedAccess": true,                 /* Add 'undefined' to a type when accessed using an index. */
+    // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
+    // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type. */
+    // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
+    // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
+
+    /* Completeness */
+    // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
+    "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
+  }
+}


### PR DESCRIPTION
# Summary
- Adds nodejs dependencies required for Relayer plugins
- Adds a plugins folder containing the plugins dependencies and environment configs required for running.
    - Relayer operators can add plugins to this directory
        - before building the docker image OR
        - add typescript files to `/app/plugins` folder in pre-built images

## Testing Process
Run docker compose build + docker compose up - then open a terminal in docker container and run 
```
# verify ts-node was installed
ts-node -v

# verify typescript and dependencies work
ts-node --cwd /app/plugins example.ts
```

## Checklist

- [ ] Add a reference to related issues in the PR description.
- [ ] Add unit tests if applicable.
