### PR TITLE
chore: update CODEOWNERS and remove dependabot reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,9 +11,6 @@ updates:
     commit-message:
       # Prefix all commit messages with "chore(deps): "
       prefix: 'chore(deps): '
-    reviewers:
-      - OpenZeppelin/defender-sre
-      - OpenZeppelin/defender-dev
 
   # Maintain dependencies for cargo
   - package-ecosystem: cargo
@@ -26,9 +23,6 @@ updates:
     commit-message:
       # Prefix all commit messages
       prefix: 'chore(deps): '
-    reviewers:
-      - OpenZeppelin/defender-dev
-      - OpenZeppelin/defender-sre
     labels:
       - dependabot
       - dependencies

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
-* @collins-w @d-carmo @dylankilkenny @nahimterrazas @zeljkoX @shahnami @tirumerla @LuisUrrutia
+* @OpenZeppelin/defender-sre @OpenZeppelin/defender-dev
 
-SECURITY.md @zeljkoX @tirumerla @son-oz
+SECURITY.md @OpenZeppelin/product-security @OpenZeppelin/defender-sre @OpenZeppelin/defender-dev


### PR DESCRIPTION
# Summary
Changes due the deprecation of `reviewers` field in `dependabot.yml`
https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/
