### PR TITLE
revert: chore(deps): bump docker/build-push-action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -255,7 +255,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2  # v3.10.0
       - name: Build local container
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83  # v6.18.0
+        uses: docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1  # v6.16.0
         with:
           tags: openzeppelin-relayer-dev:${{ github.sha }}
           push: false

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Set Up Docker Buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2  # v3.10.0
       - name: Build Docker image
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83  # v6.18.0
+        uses: docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1  # v6.16.0
         id: build
         with:
           context: .


### PR DESCRIPTION
# Summary
This reverts commit f5e211a251aa269c7529884e4fa401b514cb8b4d.

For some reason it's failing here:
![CleanShot 2025-06-02 at 23 47 41@2x](https://github.com/user-attachments/assets/2ecef47a-987a-49ff-bcd4-8c8931cb610d)

Needs further research
