### PR TITLE
fix: Use node image instead of curl download

### DIFF
--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -27,9 +27,9 @@ WORKDIR /app
 
 # Install pnpm and ts-node
 USER root
-RUN npm install -g pnpm ts-node typescript
+RUN npm install -g ts-node typescript
 
-COPY --from=base --chown=nonroot:nonroot /usr/app/bin/openzeppelin-relayer /app/openzeppelin-relayer
+COPY --from=base --chown=nobody:nobody /usr/app/bin/openzeppelin-relayer /app/openzeppelin-relayer
 
 # Copy plugins folder and install dependencies
 COPY --chown=nobody ./plugins /app/plugins

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -22,9 +22,9 @@ WORKDIR /app
 
 # Install pnpm and ts-node
 USER root
-RUN npm install -g pnpm ts-node typescript
+RUN npm install -g ts-node typescript
 
-COPY --from=base --chown=nonroot:nonroot /usr/app/bin/openzeppelin-relayer /app/openzeppelin-relayer
+COPY --from=base --chown=nobody:nobody /usr/app/bin/openzeppelin-relayer /app/openzeppelin-relayer
 COPY --from=base /usr/lib/libssl.so.3 /usr/lib/libssl.so.3
 COPY --from=base /usr/lib/libcrypto.so.3 /usr/lib/libcrypto.so.3
 


### PR DESCRIPTION
# Summary
Installs nodejs through the chainguards node image instead of using curl download for installation

## Testing Process
Run 
```sh
cargo build
docker compose build
docker compose up -d
```

Go to docker terminal and run
```sh
pnpm --version
```

## Checklist

- [ ] Add a reference to related issues in the PR description.
- [ ] Add unit tests if applicable.
