### PR TITLE
fix: Changing base image to wolfi, added node and npm

### DIFF
--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -7,7 +7,6 @@ RUN apk update && apk --no-cache add \
     perl \
     libsodium-dev
 
-
 ENV PKG_CONFIG_PATH=/usr/lib/pkgconfig
 
 WORKDIR /usr/app
@@ -20,7 +19,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     cargo install --root /usr/app --path . --debug --locked
 
 # Setting up build directories
-FROM --platform=${BUILDPLATFORM} cgr.dev/chainguard/glibc-dynamic:latest-dev
+FROM --platform=${BUILDPLATFORM} cgr.dev/chainguard/wolfi-base
 
 WORKDIR /app
 
@@ -28,21 +27,24 @@ COPY --from=base --chown=nonroot:nonroot /usr/app/bin/openzeppelin-relayer /app/
 
 # Install plugin dependencies
 ARG TARGETARCH
-ENV NODE_VERSION=v20.19.2
+ARG NODE_VERSION=20.19
 
 # Install Node.js
 USER root
-RUN apk add --no-cache curl && \
-    curl -fsSL https://nodejs.org/download/release/${NODE_VERSION}/node-${NODE_VERSION}-linux-${TARGETARCH}.tar.xz \
-    | tar -xJ --strip-components=1 -C /usr/local
+RUN apk add --no-cache nodejs=~${NODE_VERSION} npm
+
 ENV PATH="/usr/local/bin:$PATH"
 
 # Install pnpm and ts-node
 RUN npm install -g pnpm ts-node typescript
 
+# removes apk and unneeded wolfi-base tools.
+RUN apk del wolfi-base apk-tools
+
 # Copy plugins folder and install dependencies
-COPY ./plugins /app/plugins
-RUN chown -R nonroot:nonroot /app/plugins
+COPY --chown=nonroot:nonroot ./plugins /app/plugins
+
+USER nonroot
 WORKDIR /app/plugins
 RUN pnpm install --frozen-lockfile
 

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -15,7 +15,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     cargo install --root /usr/app --path . --debug --locked
 
 # Setting up build directories
-FROM --platform=${BUILDPLATFORM} cgr.dev/chainguard/glibc-dynamic:latest
+FROM --platform=${BUILDPLATFORM} cgr.dev/chainguard/wolfi-base
 
 WORKDIR /app
 COPY --from=base --chown=nonroot:nonroot /usr/app/bin/openzeppelin-relayer /app/openzeppelin-relayer
@@ -24,27 +24,27 @@ COPY --from=base /usr/lib/libcrypto.so.3 /usr/lib/libcrypto.so.3
 
 # Install plugin dependencies
 ARG TARGETARCH
-ENV NODE_VERSION=v20.19.2
+ARG NODE_VERSION=20.19
 
 # Install Node.js
 USER root
-RUN apk add --no-cache curl && \
-    curl -fsSL https://nodejs.org/download/release/${NODE_VERSION}/node-${NODE_VERSION}-linux-${TARGETARCH}.tar.xz \
-    | tar -xJ --strip-components=1 -C /usr/local
+RUN apk add --no-cache nodejs=~${NODE_VERSION} npm
 ENV PATH="/usr/local/bin:$PATH"
 
-# Install pnpm and ts-node
 RUN npm install -g pnpm ts-node typescript
 
+# removes apk and unneeded wolfi-base tools.
+RUN apk del wolfi-base apk-tools
+
 # Copy plugins folder and install dependencies
-COPY ./plugins /app/plugins
-RUN chown -R nonroot:nonroot /app/plugins
+COPY --chown=nonroot:nonroot ./plugins /app/plugins
+
+USER nonroot
 WORKDIR /app/plugins
 RUN pnpm install --frozen-lockfile
 
 # Return to app root
 WORKDIR /app
-
 
 ENV APP_PORT=8080
 ENV METRICS_PORT=8081


### PR DESCRIPTION
# Summary
Changed base image to use wolfi-base
installs nodejs, npm and, at the end, removes the wolfi-base packages, reducing footprint.

## Testing Process

## Checklist

- [ ] Add a reference to related issues in the PR description.
- [ ] Add unit tests if applicable.
