### PR TITLE
Update config.example.json

### DIFF
--- a/config/config.example.json
+++ b/config/config.example.json
@@ -23,11 +23,6 @@
       "policies": {
         "fee_payment_strategy": "user",
         "min_balance": 0,
-        "swap_config": {
-          "strategy": "jupiter-swap",
-          "cron_schedule": "0 0 * * *",
-          "min_balance_threshold": 0
-        },
         "allowed_programs": [
           "11111111111111111111111111111111",
           "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
@@ -35,12 +30,7 @@
         "allowed_tokens": [
           {
             "mint": "Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr",
-            "max_allowed_fee": 100000000,
-            "swap_config": {
-              "min_amount": 0,
-              "max_amount": 0,
-              "retain_min_amount": 0
-            }
+            "max_allowed_fee": 100000000
           },
           {
             "mint": "So11111111111111111111111111111111111111112"


### PR DESCRIPTION
# Summary
 Using the config example fails with a "JupiterSwap strategy is only supported on mainnet-beta" error