### PR TITLE
docs: Create plugins Readme docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ This relayer service enables interaction with blockchain networks through transa
 - **Configurable Network Policies**: Define and enforce network-specific policies for transaction processing.
 - **Metrics and Observability**: Monitor application performance using Prometheus and Grafana.
 - **Docker Support**: Deploy the relayer using Docker for both development and production environments.
+- **Relayer Plugins**: Extend the relayer functionality through TypeScript functions.
 
 ## Supported networks
 
@@ -95,6 +96,7 @@ flowchart TB
         subgraph "API Layer"
             api[API Routes & Controllers]
             middleware[Middleware]
+            plugins[Relayer Plugins]
         end
 
         subgraph "Domain Layer"
@@ -137,11 +139,13 @@ flowchart TB
     %% API Layer connections
     api -- "Processes requests" --> middleware
     middleware -- "Validates & routes" --> domain
+    middleware -- "Invokes" --> plugins
 
     %% Domain Layer connections
     domain -- "Uses" --> relayer
     domain -- "Enforces" --> policies
     relayer -- "Processes" --> transaction
+    plugins -- "Uses" --> relayer
 
     %% Services Layer connections
     transaction -- "Signs with" --> signer
@@ -169,7 +173,7 @@ flowchart TB
     classDef configClass fill:#fbb,stroke:#333,stroke-width:2px
     classDef externalClass fill:#ddd,stroke:#333,stroke-width:1px
 
-    class api,middleware apiClass
+    class api,middleware,plugins apiClass
     class domain,relayer,policies domainClass
     class repositories,jobs,signer,provider infraClass
     class transaction,vault,webhook,monitoring serviceClass
@@ -195,6 +199,7 @@ openzeppelin-relayer/
 │   ├── models/           # Data structures and types
 │   ├── repositories/     # Configuration storage
 │   ├── services/         # Services logic
+│   ├── plugins/          # Relayer plugins
 │   └── utils/            # Helper functions
 │
 ├── config/               # Configuration files
@@ -212,6 +217,7 @@ openzeppelin-relayer/
 - Rust
 - Redis
 - [Sodium](https://doc.libsodium.org/)
+- [Node.js + Typescript + ts-node](https://nodejs.org/) (v20+) for plugins.
 
 ### Setup
 
@@ -243,6 +249,15 @@ Run the following commands to install pre-commit hooks:
 
 - Install stable libsodium version from [here](https://download.libsodium.org/libsodium/releases/).
 - Follow steps to install libsodium from the [libsodium installation guide](https://doc.libsodium.org/installation).
+
+### Install Node.js
+
+- Install Node.js from [here](https://nodejs.org/).
+- Install Typescript and ts-node:
+
+  ```bash
+  npm install -g typescript ts-node
+  ```
 
 ### Run Tests
 
@@ -370,6 +385,10 @@ docker run -d \
 `--network relayer-net` attaches Redis to the network you created in step 1.
 
 > Note: Make sure to create a dedicated network for the relayer and Redis containers to communicate. You can create a network using the following command `docker network create relayer-net`.
+
+## Configure a plugin
+
+In order to create and run plugins please follow the [Plugins README](./plugins/README.md) file instructions.
 
 ## Running the relayer locally
 

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -1,0 +1,88 @@
+## Relayer Plugins
+
+Relayer plugins are TypeScript functions that can be invoked through the relayer HTTP API.
+
+Under the hood, the relayer will execute the plugin code in a separate process using `ts-node` and communicate with it through a Unix socket.
+
+## Setup
+
+#### 1. Writing your plugin
+
+```typescript
+import { Plugin, runPlugin } from "@relayer/plugins";
+
+type Args = {
+  foo: string;
+  bar: number;
+}
+
+async function myPlugin(plugin: Plugin, args: Args) {
+    console.log(args.foo);
+    console.log(args.bar);
+
+    const relayer = plugin.useRelayer("my-relayer");
+    await relayer.sendTransaction({
+        to: "0x1234567890123456789012345678901234567890",
+        value: 1000000000000000000,
+    });
+}
+
+runPlugin(myPlugin);
+```
+
+
+#### 2. Adding extra dependencies
+
+You can install any extra JS/TS dependencies in your plugins folder and access them upon execution.
+
+```bash
+npm install ethers
+```
+
+And then just import them in your plugin.
+
+```typescript
+import { ethers } from "ethers";
+```
+
+#### 3. Adding to config file
+
+- id: The id of the plugin. This is used to call a specific plugin through the HTTP API.
+- path: The path to the plugin file - relative to the `/plugins` folder.
+
+```yaml
+{
+  "plugins": [
+    {
+      "id": "my-plugin",
+      "path": "my-plugin.ts"
+    }
+  ]
+}
+```
+
+## Usage
+
+You can call your plugin through the HTTP API, passing your custom arguments as a JSON body.
+
+```bash
+curl -X POST http://localhost:8080/plugins/my-plugin/call -d '{ "params": { "foo": "bar", "bar": 123 } }'
+```
+
+Then the response will include:
+
+- `output`: The output of the plugin execution. Including all the logs from the plugin execution.
+- `error`: An error message if the plugin execution failed.
+- `traces`: A list of payloads that were sent between the plugin and the relayer. e.g. the `sendTransaction` payloads.
+
+Example response:
+
+```json
+{
+  "output": "Hello, world!",
+  "error": null,
+  "traces": [
+    "{ \"relayer_id\": \"my-relayer\", \"method\": \"sendTransaction\", \"params\": { \"to\": \"0x1234567890123456789012345678901234567890\", \"value\": \"0x1234567890123456789012345678901234567890\" } }"
+  ]
+}
+```


### PR DESCRIPTION
# Summary

Adds README docs for plugins serice including:
- A `README` file under `/plugins` folder including details for setting up and running plugins
- Modifications in root `README` file with Plugins references

## Testing Process

## Checklist

- [ ] Add a reference to related issues in the PR description.
- [ ] Add unit tests if applicable.
