### PR TITLE
feat: Added resolve_plugin_path for script_path

### DIFF
--- a/src/services/plugins/mod.rs
+++ b/src/services/plugins/mod.rs
@@ -65,17 +65,27 @@ impl<R: PluginRunnerTrait> PluginService<R> {
         Self { runner }
     }
 
+    fn resolve_plugin_path(plugin_path: &str) -> String {
+        if plugin_path.starts_with("plugins/") {
+            plugin_path.to_string()
+        } else {
+            format!("plugins/{}", plugin_path)
+        }
+    }
+
     async fn call_plugin<J: JobProducerTrait + 'static>(
         &self,
-        code_path: String,
+        script_path: String,
         plugin_call_request: PluginCallRequest,
         state: Arc<web::ThinData<AppState<J>>>,
     ) -> Result<PluginCallResponse, PluginError> {
         let socket_path = format!("/tmp/{}.sock", Uuid::new_v4());
+        let resolved_script_path = Self::resolve_plugin_path(&script_path);
         let script_params = plugin_call_request.params.to_string();
+
         let result = self
             .runner
-            .run(&socket_path, code_path, script_params, state)
+            .run(&socket_path, resolved_script_path, script_params, state)
             .await;
 
         match result {
@@ -98,7 +108,7 @@ pub trait PluginServiceTrait<J: JobProducerTrait + 'static>: Send + Sync {
     fn new(runner: PluginRunner) -> Self;
     async fn call_plugin(
         &self,
-        code_path: String,
+        script_path: String,
         plugin_call_request: PluginCallRequest,
         state: Arc<web::ThinData<AppState<J>>>,
     ) -> Result<PluginCallResponse, PluginError>;
@@ -112,11 +122,11 @@ impl<J: JobProducerTrait + 'static> PluginServiceTrait<J> for PluginService<Plug
 
     async fn call_plugin(
         &self,
-        code_path: String,
+        script_path: String,
         plugin_call_request: PluginCallRequest,
         state: Arc<web::ThinData<AppState<J>>>,
     ) -> Result<PluginCallResponse, PluginError> {
-        self.call_plugin(code_path, plugin_call_request, state)
+        self.call_plugin(script_path, plugin_call_request, state)
             .await
     }
 }
@@ -129,6 +139,24 @@ mod tests {
     };
 
     use super::*;
+
+    #[test]
+    fn test_resolve_plugin_path() {
+        assert_eq!(
+            PluginService::<MockPluginRunnerTrait>::resolve_plugin_path("plugins/examples/test.ts"),
+            "plugins/examples/test.ts"
+        );
+
+        assert_eq!(
+            PluginService::<MockPluginRunnerTrait>::resolve_plugin_path("examples/test.ts"),
+            "plugins/examples/test.ts"
+        );
+
+        assert_eq!(
+            PluginService::<MockPluginRunnerTrait>::resolve_plugin_path("test.ts"),
+            "plugins/test.ts"
+        );
+    }
 
     #[tokio::test]
     async fn test_call_plugin() {


### PR DESCRIPTION
# Summary
The [documentation says](https://github.com/OpenZeppelin/openzeppelin-relayer/blob/main/plugins/README.md#3adding-to-config-file) that `The path to the plugin file - relative to the /plugins folder.` although currently it expects relative path to the repository root, not the plugins folder. Added a `resolve_plugin_path` function to automatically prepend "plugins/" to script paths when needed to resolve this issue.

## Changes:
* New `resolve_plugin_path` utility function
* Renamed `code_path` to `script_path` for clarity
* Added unit tests for path resolution logic

## Testing Process

## Checklist

- [ ] Add a reference to related issues in the PR description.
- [ ] Add unit tests if applicable.
