### PR TITLE
fix: Use unicode character for emoji

### DIFF
--- a/DOCKER_README.md
+++ b/DOCKER_README.md
@@ -1,6 +1,6 @@
 # OpenZeppelin Relayer
 
-> :warning: This software is in alpha. Use in production environments at your own risk.
+> ⚠️ This software is in alpha. Use in production environments at your own risk.
 
 This relayer service enables interaction with blockchain networks through transaction submissions. It offers multi-chain support and an extensible architecture for adding new chains.
 
@@ -17,7 +17,7 @@ This relayer service enables interaction with blockchain networks through transa
 - Configure Api key in `config/config.json` file. See how to set it up in [api key section](https://github.com/OpenZeppelin/openzeppelin-relayer?tab=readme-ov-file#configure-api-key) for more information.
 - Redis server running. See how to set it up in [redis section](https://github.com/OpenZeppelin/openzeppelin-relayer?tab=readme-ov-file#starting-redis-manually-without-docker-compose) for more information.
 
-> :warning: Redis is automatically started when using docker compose. If you are not using docker compose, you need to create a dedicated network and start redis manually.
+> ⚠️ Redis is automatically started when using docker compose. If you are not using docker compose, you need to create a dedicated network and start redis manually.
 
 ## How to use images pushed to DockerHub
 


### PR DESCRIPTION
# Summary

- Fix docker readme emoji with actual unicode char