### PR TITLE
feat: Types introduced for plugin params and result

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -9,27 +9,43 @@ Under the hood, the relayer will execute the plugin code in a separate process u
 #### 1. Writing your plugin
 
 ```typescript
-import { Plugin, runPlugin } from "./lib/plugin";
+import { Speed } from "@openzeppelin/relayer-sdk";
+import { PluginAPI, runPlugin } from "../lib/plugin";
 
-type Args = {
-  foo: string;
-  bar: number;
-}
+type Params = {
+    destinationAddress: string;
+};
 
-async function myPlugin(plugin: Plugin, args: Args) {
-    console.log(args.foo);
-    console.log(args.bar);
+async function example(api: PluginAPI, params: Params): Promise<string> {
+    console.info("Plugin started...");
+    /**
+     * Instances the relayer with the given id.
+     */
+    const relayer = api.useRelayer("sepolia-example");
 
-    const relayer = plugin.useRelayer("my-relayer");
-    await relayer.sendTransaction({
-        to: "0x1234567890123456789012345678901234567890",
-        value: 1000000000000000000,
+    /**
+     * Sends an arbitrary transaction through the relayer.
+     */
+    const result = await relayer.sendTransaction({
+        to: params.destinationAddress,
+        value: 1,
+        data: "0x",
+        gas_limit: 21000,
+        speed: Speed.FAST,
     });
+
+    /*
+    * Waits for the transaction to be mined on chain.
+    */
+    await result.wait();
 
     return "done!";
 }
 
-runPlugin(myPlugin);
+/**
+ * This is the entry point for the plugin
+ */
+runPlugin(example);
 ```
 
 
@@ -38,7 +54,7 @@ runPlugin(myPlugin);
 You can install any extra JS/TS dependencies in your plugins folder and access them upon execution.
 
 ```bash
-npm install ethers
+pnpm add ethers
 ```
 
 And then just import them in your plugin.
@@ -56,8 +72,8 @@ import { ethers } from "ethers";
 {
   "plugins": [
     {
-      "id": "my-plugin",
-      "path": "my-plugin.ts"
+      "id": "example",
+      "path": "examples/example.ts"
     }
   ]
 }
@@ -68,7 +84,14 @@ import { ethers } from "ethers";
 You can call your plugin through the HTTP API, passing your custom arguments as a JSON body.
 
 ```bash
-curl -X POST http://localhost:8080/plugins/my-plugin/call -d '{ "params": { "foo": "bar", "bar": 123 } }'
+curl -X POST "http://localhost:8080/api/v1/plugins/example/call" \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "params": {
+      "destinationAddress": "0xab5801a7d398351b8be11c439e05c5b3259aec9b"
+    }
+  }'
 ```
 
 Then the response will include:
@@ -82,27 +105,33 @@ Example response:
 
 ```json
 {
-  "logs": [
-    {
-      "level": "log",
-      "message": "bar"
-    },
-    {
-      "level": "log",
-      "message": "123"
-    }
-  ],
-  "return_value": "done!",
-  "error": null,
-  "traces": [
-    {
-      "relayer_id": "my-relayer",
-      "method": "sendTransaction",
-      "params": {
-        "to": "0x1234567890123456789012345678901234567890",
-        "value": "0x1234567890123456789012345678901234567890"
+  "success": true,
+  "data": {
+    "success": true,
+    "return_value": "\"done!\"",
+    "message": "Plugin called successfully",
+    "logs": [
+      {
+        "level": "info",
+        "message": "Plugin started..."
       }
-    }
-  ]
+    ],
+    "error": "",
+    "traces": [
+      {
+        "method": "sendTransaction",
+        "payload": {
+          "data": "0x",
+          "gas_limit": 21000,
+          "speed": "fast",
+          "to": "0xab5801a7d398351b8be11c439e05c5b3259aec9b",
+          "value": 1
+        },
+        "relayerId": "sepolia-example",
+        "requestId": "6c1f336f-3030-4f90-bd99-ada190a1235b"
+      }
+    ]
+  },
+  "error": null
 }
 ```

--- a/plugins/examples/example.ts
+++ b/plugins/examples/example.ts
@@ -1,7 +1,11 @@
 import { Speed } from "@openzeppelin/relayer-sdk";
 import { PluginAPI, runPlugin } from "../lib/plugin";
 
-async function example(api: PluginAPI) {
+type Params = {
+    destinationAddress: string;
+};
+
+async function example(api: PluginAPI, params: Params): Promise<string> {
     console.info("Plugin started...");
     /**
      * Instances the relayer with the given id.
@@ -12,7 +16,7 @@ async function example(api: PluginAPI) {
      * Sends an arbitrary transaction through the relayer.
      */
     const result = await relayer.sendTransaction({
-        to: "0xab5801a7d398351b8be11c439e05c5b3259aec9b",
+        to: params.destinationAddress,
         value: 1,
         data: "0x",
         gas_limit: 21000,
@@ -22,12 +26,12 @@ async function example(api: PluginAPI) {
     /*
     * Waits for the transaction to be mined on chain.
     */
-    const transaction = await result.wait();
+    await result.wait();
 
-    return transaction.hash;
+    return "done!";
 }
 
 /**
  * This is the entry point for the plugin
  */
-runPlugin(example)
+runPlugin(example);


### PR DESCRIPTION
# Summary

Although the plugins [README](https://github.com/OpenZeppelin/openzeppelin-relayer/tree/main/plugins#1writing-your-plugin) showed that plugin args can be typed, this was not the case so I adjusted the types to accept custom ones dynamically.

## Changes

* `getPluginParams()` result type made dynamic
* introduced the `Plugin` dynamic type for a plugin main function
* updated `example.ts` plugin
* readme changes:
  * added the actual `example.ts` plugin as an example
  * updated commands and responses
  * replaced `npm` command with `pnpm` (plugins set up to use `pnpm` by default)

## Testing Process

checking that the params can be set to a custom type without errors not just to `unknown`

## Checklist
- [x] Add a reference to related issues in the PR description.
- [ ] Add unit tests if applicable.
