### PR TITLE
feat: Add status_reason field to transaction responses

### DIFF
--- a/src/models/transaction/response.rs
+++ b/src/models/transaction/response.rs
@@ -60,6 +60,7 @@ pub struct SolanaTransactionResponse {
     #[schema(nullable = false)]
     pub hash: Option<String>,
     pub status: TransactionStatus,
+    pub status_reason: Option<String>,
     pub created_at: String,
     #[schema(nullable = false)]
     pub sent_at: Option<String>,
@@ -75,6 +76,7 @@ pub struct StellarTransactionResponse {
     #[schema(nullable = false)]
     pub hash: Option<String>,
     pub status: TransactionStatus,
+    pub status_reason: Option<String>,
     pub created_at: String,
     #[schema(nullable = false)]
     pub sent_at: Option<String>,
@@ -116,6 +118,7 @@ impl From<TransactionRepoModel> for TransactionResponse {
                     id: model.id,
                     hash: solana_data.hash,
                     status: model.status,
+                    status_reason: model.status_reason,
                     created_at: model.created_at,
                     sent_at: model.sent_at,
                     confirmed_at: model.confirmed_at,
@@ -128,6 +131,7 @@ impl From<TransactionRepoModel> for TransactionResponse {
                     id: model.id,
                     hash: stellar_data.hash,
                     status: model.status,
+                    status_reason: model.status_reason,
                     created_at: model.created_at,
                     sent_at: model.sent_at,
                     confirmed_at: model.confirmed_at,


### PR DESCRIPTION
# Summary

- Added optional status_reason field to both Solana and Stellar transaction response structs.
- Updated the From implementation for TransactionResponse to include status_reason from the model.

## Testing Process

## Checklist

- [ ] Add a reference to related issues in the PR description.
- [ ] Add unit tests if applicable.
