### PR TITLE
fix: Semgrep CI integration

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -2,7 +2,7 @@ name: Semgrep
 
 on:
   # Scan changed files in PRs (diff-aware scanning):
-  pull_request: {}
+  pull_request_target: {}
   # Scan on-demand through GitHub Actions interface:
   workflow_dispatch: {}
   # Scan mainline branches and report all findings:
@@ -18,8 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       security-events: write
-      contents: read
-      actions: read
+      # contents: read
+      # actions: read
 
     container:
       image: semgrep/semgrep@sha256:85f9de554201cc891c470774bb93a7f4faf41ea198ddccc34a855b53f7a51443  # v1.127.1
@@ -39,6 +39,10 @@ jobs:
         env:
           # Connect to Semgrep AppSec Platform through your SEMGREP_APP_TOKEN.
           SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
+          # Do not check for new version
+          SEMGREP_ENABLE_VERSION_CHECK: 0
+          # No metrics
+          SEMGREP_SEND_METRICS: no
       - name: Upload SARIF file for GitHub Advanced Security Dashboard
         uses: github/codeql-action/upload-sarif@fca7ace96b7d713c7035871441bd52efbe39e27e  # v3.28.19
         with:


### PR DESCRIPTION
# Summary
Use `pull_request_target` instead of `pull_request` event to trigger the Semgrep SAST ([PS-13](https://linear.app/openzeppelin-development/issue/PS-13/semgrep-cicd-integration)). This will make the `SEMGREP_APP_TOKEN` available to forked repos.

Disclaimer: Using `pull_request_target` event has some [security implications](https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/). However, this workflow should be safe to use in this current state (A [live example](https://github.com/semgrep/semgrep/blob/develop/.github/workflows/semgrep.yml#L38) from Semgrep)

## Testing Process

## Checklist

- [x] Add a reference to related issues in the PR description.
- [ ] Add unit tests if applicable.
