### PR TITLE
chore: Update msrv to 1.86

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -346,7 +346,7 @@ Note: if your pull request isn't getting enough attention, you can contact us on
 
 ## Coding Standards
 
-- Use **Rust 2021 edition**, version `1.85` or later.
+- Use **Rust 2021 edition**, version `1.86` or later.
 - Follow the [Rust API Guidelines](https://rust-lang.github.io/api-guidelines/).
 - Run pre-commit hooks on your code to ensure code quality.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "openzeppelin-relayer"
 version = "1.0.0"
 edition = "2021"
-rust-version = "1.85"         #MSRV
+rust-version = "1.86"         #MSRV
 
 [profile.release]
 opt-level = 0

--- a/docs/modules/ROOT/pages/evm.adoc
+++ b/docs/modules/ROOT/pages/evm.adoc
@@ -50,7 +50,7 @@ In production systems, hosted signers (AWS KMS, Google Cloud KMS, Turnkey) are r
 For a step-by-step setup, see xref:quickstart.adoc[Quick Start Guide].
 Key prerequisites:
 
-- Rust 2021, version `1.85` or later
+- Rust 2021, version `1.86` or later
 - Redis
 - Docker (optional)
 

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -212,7 +212,7 @@ For detailed information about each directory and its contents, see xref:structu
 
 === Prerequisites
 
-* Rust 2021 edition, version `1.85` or later
+* Rust 2021 edition, version `1.86` or later
 * Docker (optional, for containerized deployment)
 * Node.js, typescript and ts-node (optional, for plugins)
 

--- a/docs/modules/ROOT/pages/quickstart.adoc
+++ b/docs/modules/ROOT/pages/quickstart.adoc
@@ -6,7 +6,7 @@ This guide provides step-by-step instructions for setting up OpenZeppelin Relaye
 
 == Prerequisites
 
-* Rust 2021, version `1.85` or later.
+* Rust 2021, version `1.86` or later.
 * Redis
 * Docker (optional, for containerized deployment)
 * Node.js, typescript and ts-node (optional, for plugins)

--- a/docs/modules/ROOT/pages/solana.adoc
+++ b/docs/modules/ROOT/pages/solana.adoc
@@ -77,7 +77,7 @@ In production systems, hosted signers are recommended for the best security mode
 For a step-by-step setup, see xref:quickstart.adoc[Quick Start Guide].
 Key prerequisites:
 
-- Rust 2021, version `1.85` or later
+- Rust 2021, version `1.86` or later
 - Redis
 - Docker (optional)
 

--- a/docs/modules/ROOT/pages/stellar.adoc
+++ b/docs/modules/ROOT/pages/stellar.adoc
@@ -62,7 +62,7 @@ For detailed network configuration options, see the xref:network_configuration.a
 For a step-by-step setup, see xref:quickstart.adoc[Quick Start Guide].
 Key prerequisites:
 
-- Rust 2021, version `1.85` or later
+- Rust 2021, version `1.86` or later
 - Redis
 - Docker (optional)
 


### PR DESCRIPTION
# Summary
- Update MSRV to `1.86.0` because `aws-sdk-rust` in its last week update, set the MSRV to 1.86.0
