### PR TITLE
feat: Plat-6684 add support for transaction entries expiration

### DIFF
--- a/src/api/routes/relayer.rs
+++ b/src/api/routes/relayer.rs
@@ -322,6 +322,7 @@ mod tests {
             network_type: NetworkType::Evm,
             noop_count: None,
             is_canceled: Some(false),
+            delete_at: None,
         };
         transaction_repo.create(test_transaction).await.unwrap();
 

--- a/src/config/server_config.rs
+++ b/src/config/server_config.rs
@@ -62,6 +62,8 @@ pub struct ServerConfig {
     pub reset_storage_on_start: bool,
     /// The encryption key for the storage.
     pub storage_encryption_key: Option<SecretString>,
+    /// Transaction expiration time in hours for transactions in final states.
+    pub transaction_expiration_hours: u64,
 }
 
 impl ServerConfig {
@@ -85,7 +87,59 @@ impl ServerConfig {
     /// - `PROVIDER_RETRY_MAX_DELAY_MS` defaults to `2000`.
     /// - `PROVIDER_MAX_FAILOVERS` defaults to `3`.
     /// - `REPOSITORY_STORAGE_TYPE` defaults to `"in_memory"`.
+    /// - `TRANSACTION_EXPIRATION_HOURS` defaults to `4`.
     pub fn from_env() -> Self {
+        Self {
+            host: Self::get_host(),
+            port: Self::get_port(),
+            redis_url: Self::get_redis_url(), // Uses panicking version as required
+            config_file_path: Self::get_config_file_path(),
+            api_key: Self::get_api_key(), // Uses panicking version as required
+            rate_limit_requests_per_second: Self::get_rate_limit_requests_per_second(),
+            rate_limit_burst_size: Self::get_rate_limit_burst_size(),
+            metrics_port: Self::get_metrics_port(),
+            enable_swagger: Self::get_enable_swagger(),
+            redis_connection_timeout_ms: Self::get_redis_connection_timeout_ms(),
+            redis_key_prefix: Self::get_redis_key_prefix(),
+            rpc_timeout_ms: Self::get_rpc_timeout_ms(),
+            provider_max_retries: Self::get_provider_max_retries(),
+            provider_retry_base_delay_ms: Self::get_provider_retry_base_delay_ms(),
+            provider_retry_max_delay_ms: Self::get_provider_retry_max_delay_ms(),
+            provider_max_failovers: Self::get_provider_max_failovers(),
+            repository_storage_type: Self::get_repository_storage_type(),
+            reset_storage_on_start: Self::get_reset_storage_on_start(),
+            storage_encryption_key: Self::get_storage_encryption_key(),
+            transaction_expiration_hours: Self::get_transaction_expiration_hours(),
+        }
+    }
+
+    // Individual getter methods for each configuration field
+
+    /// Gets the host from environment variable or default
+    pub fn get_host() -> String {
+        env::var("HOST").unwrap_or_else(|_| "0.0.0.0".to_string())
+    }
+
+    /// Gets the port from environment variable or default
+    pub fn get_port() -> u16 {
+        env::var("APP_PORT")
+            .unwrap_or_else(|_| "8080".to_string())
+            .parse()
+            .unwrap_or(8080)
+    }
+
+    /// Gets the Redis URL from environment variable (panics if not set)
+    pub fn get_redis_url() -> String {
+        env::var("REDIS_URL").expect("REDIS_URL must be set")
+    }
+
+    /// Gets the Redis URL from environment variable or returns None if not set
+    pub fn get_redis_url_optional() -> Option<String> {
+        env::var("REDIS_URL").ok()
+    }
+
+    /// Gets the config file path from environment variables or default
+    pub fn get_config_file_path() -> String {
         let conf_dir = if env::var("IN_DOCKER")
             .map(|val| val == "true")
             .unwrap_or(false)
@@ -96,14 +150,14 @@ impl ServerConfig {
         };
 
         let conf_dir = format!("{}/", conf_dir.trim_end_matches('/'));
-
-        // Get config filename (default: config.json), applies to both local and Docker
         let config_file_name =
             env::var("CONFIG_FILE_NAME").unwrap_or_else(|_| "config.json".to_string());
 
-        // Construct full path
-        let config_file_path = format!("{}{}", conf_dir, config_file_name);
+        format!("{}{}", conf_dir, config_file_name)
+    }
 
+    /// Gets the API key from environment variable (panics if not set or too short)
+    pub fn get_api_key() -> SecretString {
         let api_key = SecretString::new(&env::var("API_KEY").expect("API_KEY must be set"));
 
         if !api_key.has_minimum_length(MINIMUM_SECRET_VALUE_LENGTH) {
@@ -113,67 +167,129 @@ impl ServerConfig {
             );
         }
 
-        Self {
-            host: env::var("HOST").unwrap_or_else(|_| "0.0.0.0".to_string()),
-            port: env::var("APP_PORT")
-                .unwrap_or_else(|_| "8080".to_string())
-                .parse()
-                .unwrap_or(8080),
-            redis_url: env::var("REDIS_URL").expect("REDIS_URL must be set"),
-            config_file_path,
-            api_key,
-            rate_limit_requests_per_second: env::var("RATE_LIMIT_REQUESTS_PER_SECOND")
-                .unwrap_or_else(|_| "100".to_string())
-                .parse()
-                .unwrap_or(100),
-            rate_limit_burst_size: env::var("RATE_LIMIT_BURST_SIZE")
-                .unwrap_or_else(|_| "300".to_string())
-                .parse()
-                .unwrap_or(300),
-            metrics_port: env::var("METRICS_PORT")
-                .unwrap_or_else(|_| "8081".to_string())
-                .parse()
-                .unwrap_or(8081),
-            enable_swagger: env::var("ENABLE_SWAGGER")
-                .map(|v| v.to_lowercase() == "true")
-                .unwrap_or(false),
-            redis_connection_timeout_ms: env::var("REDIS_CONNECTION_TIMEOUT_MS")
-                .unwrap_or_else(|_| "10000".to_string())
-                .parse()
-                .unwrap_or(10000),
-            redis_key_prefix: env::var("REDIS_KEY_PREFIX")
-                .unwrap_or_else(|_| "oz-relayer".to_string()),
-            rpc_timeout_ms: env::var("RPC_TIMEOUT_MS")
-                .unwrap_or_else(|_| "10000".to_string())
-                .parse()
-                .unwrap_or(10000),
-            provider_max_retries: env::var("PROVIDER_MAX_RETRIES")
-                .unwrap_or_else(|_| "3".to_string())
-                .parse()
-                .unwrap_or(3),
-            provider_retry_base_delay_ms: env::var("PROVIDER_RETRY_BASE_DELAY_MS")
-                .unwrap_or_else(|_| "100".to_string())
-                .parse()
-                .unwrap_or(100),
-            provider_retry_max_delay_ms: env::var("PROVIDER_RETRY_MAX_DELAY_MS")
-                .unwrap_or_else(|_| "2000".to_string())
-                .parse()
-                .unwrap_or(2000),
-            provider_max_failovers: env::var("PROVIDER_MAX_FAILOVERS")
-                .unwrap_or_else(|_| "3".to_string())
-                .parse()
-                .unwrap_or(3),
-            repository_storage_type: env::var("REPOSITORY_STORAGE_TYPE")
-                .unwrap_or_else(|_| "in_memory".to_string())
-                .parse()
-                .unwrap_or(RepositoryStorageType::InMemory),
-            reset_storage_on_start: env::var("RESET_STORAGE_ON_START")
-                .map(|v| v.to_lowercase() == "true")
-                .unwrap_or(false),
-            storage_encryption_key: env::var("STORAGE_ENCRYPTION_KEY")
-                .map(|v| SecretString::new(&v))
-                .ok(),
-        }
+        api_key
+    }
+
+    /// Gets the API key from environment variable or returns None if not set or invalid
+    pub fn get_api_key_optional() -> Option<SecretString> {
+        env::var("API_KEY")
+            .ok()
+            .map(|key| SecretString::new(&key))
+            .filter(|key| key.has_minimum_length(MINIMUM_SECRET_VALUE_LENGTH))
+    }
+
+    /// Gets the rate limit requests per second from environment variable or default
+    pub fn get_rate_limit_requests_per_second() -> u64 {
+        env::var("RATE_LIMIT_REQUESTS_PER_SECOND")
+            .unwrap_or_else(|_| "100".to_string())
+            .parse()
+            .unwrap_or(100)
+    }
+
+    /// Gets the rate limit burst size from environment variable or default
+    pub fn get_rate_limit_burst_size() -> u32 {
+        env::var("RATE_LIMIT_BURST_SIZE")
+            .unwrap_or_else(|_| "300".to_string())
+            .parse()
+            .unwrap_or(300)
+    }
+
+    /// Gets the metrics port from environment variable or default
+    pub fn get_metrics_port() -> u16 {
+        env::var("METRICS_PORT")
+            .unwrap_or_else(|_| "8081".to_string())
+            .parse()
+            .unwrap_or(8081)
+    }
+
+    /// Gets the enable swagger setting from environment variable or default
+    pub fn get_enable_swagger() -> bool {
+        env::var("ENABLE_SWAGGER")
+            .map(|v| v.to_lowercase() == "true")
+            .unwrap_or(false)
+    }
+
+    /// Gets the Redis connection timeout from environment variable or default
+    pub fn get_redis_connection_timeout_ms() -> u64 {
+        env::var("REDIS_CONNECTION_TIMEOUT_MS")
+            .unwrap_or_else(|_| "10000".to_string())
+            .parse()
+            .unwrap_or(10000)
+    }
+
+    /// Gets the Redis key prefix from environment variable or default
+    pub fn get_redis_key_prefix() -> String {
+        env::var("REDIS_KEY_PREFIX").unwrap_or_else(|_| "oz-relayer".to_string())
+    }
+
+    /// Gets the RPC timeout from environment variable or default
+    pub fn get_rpc_timeout_ms() -> u64 {
+        env::var("RPC_TIMEOUT_MS")
+            .unwrap_or_else(|_| "10000".to_string())
+            .parse()
+            .unwrap_or(10000)
+    }
+
+    /// Gets the provider max retries from environment variable or default
+    pub fn get_provider_max_retries() -> u8 {
+        env::var("PROVIDER_MAX_RETRIES")
+            .unwrap_or_else(|_| "3".to_string())
+            .parse()
+            .unwrap_or(3)
+    }
+
+    /// Gets the provider retry base delay from environment variable or default
+    pub fn get_provider_retry_base_delay_ms() -> u64 {
+        env::var("PROVIDER_RETRY_BASE_DELAY_MS")
+            .unwrap_or_else(|_| "100".to_string())
+            .parse()
+            .unwrap_or(100)
+    }
+
+    /// Gets the provider retry max delay from environment variable or default
+    pub fn get_provider_retry_max_delay_ms() -> u64 {
+        env::var("PROVIDER_RETRY_MAX_DELAY_MS")
+            .unwrap_or_else(|_| "2000".to_string())
+            .parse()
+            .unwrap_or(2000)
+    }
+
+    /// Gets the provider max failovers from environment variable or default
+    pub fn get_provider_max_failovers() -> u8 {
+        env::var("PROVIDER_MAX_FAILOVERS")
+            .unwrap_or_else(|_| "3".to_string())
+            .parse()
+            .unwrap_or(3)
+    }
+
+    /// Gets the repository storage type from environment variable or default
+    pub fn get_repository_storage_type() -> RepositoryStorageType {
+        env::var("REPOSITORY_STORAGE_TYPE")
+            .unwrap_or_else(|_| "in_memory".to_string())
+            .parse()
+            .unwrap_or(RepositoryStorageType::InMemory)
+    }
+
+    /// Gets the reset storage on start setting from environment variable or default
+    pub fn get_reset_storage_on_start() -> bool {
+        env::var("RESET_STORAGE_ON_START")
+            .map(|v| v.to_lowercase() == "true")
+            .unwrap_or(false)
+    }
+
+    /// Gets the storage encryption key from environment variable or None
+    pub fn get_storage_encryption_key() -> Option<SecretString> {
+        env::var("STORAGE_ENCRYPTION_KEY")
+            .map(|v| SecretString::new(&v))
+            .ok()
+    }
+
+    /// Gets the transaction expiration hours from environment variable or default
+    pub fn get_transaction_expiration_hours() -> u64 {
+        env::var("TRANSACTION_EXPIRATION_HOURS")
+            .unwrap_or_else(|_| "4".to_string())
+            .parse()
+            .unwrap_or(4)
     }
 }
 
@@ -209,6 +325,7 @@ mod tests {
         env::remove_var("PROVIDER_MAX_FAILOVERS");
         env::remove_var("REPOSITORY_STORAGE_TYPE");
         env::remove_var("RESET_STORAGE_ON_START");
+        env::remove_var("TRANSACTION_EXPIRATION_HOURS");
         // Set required variables for most tests
         env::set_var("REDIS_URL", "redis://localhost:6379");
         env::set_var("API_KEY", "7EF1CB7C-5003-4696-B384-C72AF8C3E15D");
@@ -247,6 +364,7 @@ mod tests {
             RepositoryStorageType::InMemory
         );
         assert!(!config.reset_storage_on_start);
+        assert_eq!(config.transaction_expiration_hours, 4);
     }
 
     #[test]
@@ -270,6 +388,7 @@ mod tests {
         env::set_var("PROVIDER_MAX_FAILOVERS", "invalid");
         env::set_var("REPOSITORY_STORAGE_TYPE", "invalid");
         env::set_var("RESET_STORAGE_ON_START", "invalid");
+        env::set_var("TRANSACTION_EXPIRATION_HOURS", "invalid");
         let config = ServerConfig::from_env();
 
         // Should fall back to defaults when parsing fails
@@ -288,6 +407,7 @@ mod tests {
             RepositoryStorageType::InMemory
         );
         assert!(!config.reset_storage_on_start);
+        assert_eq!(config.transaction_expiration_hours, 4);
     }
 
     #[test]
@@ -315,6 +435,7 @@ mod tests {
         env::set_var("PROVIDER_MAX_FAILOVERS", "4");
         env::set_var("REPOSITORY_STORAGE_TYPE", "in_memory");
         env::set_var("RESET_STORAGE_ON_START", "true");
+        env::set_var("TRANSACTION_EXPIRATION_HOURS", "6");
         let config = ServerConfig::from_env();
 
         assert_eq!(config.host, "127.0.0.1");
@@ -339,6 +460,7 @@ mod tests {
             RepositoryStorageType::InMemory
         );
         assert!(config.reset_storage_on_start);
+        assert_eq!(config.transaction_expiration_hours, 6);
     }
 
     #[test]
@@ -355,9 +477,250 @@ mod tests {
         env::set_var("RATE_LIMIT_REQUESTS_PER_SECOND", "100");
         env::set_var("RATE_LIMIT_BURST_SIZE", "300");
         env::set_var("METRICS_PORT", "9091");
+        env::set_var("TRANSACTION_EXPIRATION_HOURS", "4");
 
         let _ = ServerConfig::from_env();
 
         panic!("Test should have panicked before reaching here");
+    }
+
+    // Tests for individual getter methods
+    #[test]
+    fn test_individual_getters_with_defaults() {
+        let _lock = match ENV_MUTEX.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+
+        // Clear all environment variables to test defaults
+        env::remove_var("HOST");
+        env::remove_var("APP_PORT");
+        env::remove_var("REDIS_URL");
+        env::remove_var("CONFIG_DIR");
+        env::remove_var("CONFIG_FILE_NAME");
+        env::remove_var("API_KEY");
+        env::remove_var("RATE_LIMIT_REQUESTS_PER_SECOND");
+        env::remove_var("RATE_LIMIT_BURST_SIZE");
+        env::remove_var("METRICS_PORT");
+        env::remove_var("ENABLE_SWAGGER");
+        env::remove_var("REDIS_CONNECTION_TIMEOUT_MS");
+        env::remove_var("REDIS_KEY_PREFIX");
+        env::remove_var("RPC_TIMEOUT_MS");
+        env::remove_var("PROVIDER_MAX_RETRIES");
+        env::remove_var("PROVIDER_RETRY_BASE_DELAY_MS");
+        env::remove_var("PROVIDER_RETRY_MAX_DELAY_MS");
+        env::remove_var("PROVIDER_MAX_FAILOVERS");
+        env::remove_var("REPOSITORY_STORAGE_TYPE");
+        env::remove_var("RESET_STORAGE_ON_START");
+        env::remove_var("STORAGE_ENCRYPTION_KEY");
+        env::remove_var("TRANSACTION_EXPIRATION_HOURS");
+
+        // Test individual getters with defaults
+        assert_eq!(ServerConfig::get_host(), "0.0.0.0");
+        assert_eq!(ServerConfig::get_port(), 8080);
+        assert_eq!(ServerConfig::get_redis_url_optional(), None);
+        assert_eq!(ServerConfig::get_config_file_path(), "./config/config.json");
+        assert_eq!(ServerConfig::get_api_key_optional(), None);
+        assert_eq!(ServerConfig::get_rate_limit_requests_per_second(), 100);
+        assert_eq!(ServerConfig::get_rate_limit_burst_size(), 300);
+        assert_eq!(ServerConfig::get_metrics_port(), 8081);
+        assert!(!ServerConfig::get_enable_swagger());
+        assert_eq!(ServerConfig::get_redis_connection_timeout_ms(), 10000);
+        assert_eq!(ServerConfig::get_redis_key_prefix(), "oz-relayer");
+        assert_eq!(ServerConfig::get_rpc_timeout_ms(), 10000);
+        assert_eq!(ServerConfig::get_provider_max_retries(), 3);
+        assert_eq!(ServerConfig::get_provider_retry_base_delay_ms(), 100);
+        assert_eq!(ServerConfig::get_provider_retry_max_delay_ms(), 2000);
+        assert_eq!(ServerConfig::get_provider_max_failovers(), 3);
+        assert_eq!(
+            ServerConfig::get_repository_storage_type(),
+            RepositoryStorageType::InMemory
+        );
+        assert!(!ServerConfig::get_reset_storage_on_start());
+        assert!(ServerConfig::get_storage_encryption_key().is_none());
+        assert_eq!(ServerConfig::get_transaction_expiration_hours(), 4);
+    }
+
+    #[test]
+    fn test_individual_getters_with_custom_values() {
+        let _lock = match ENV_MUTEX.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+
+        // Set custom values
+        env::set_var("HOST", "192.168.1.1");
+        env::set_var("APP_PORT", "9999");
+        env::set_var("REDIS_URL", "redis://custom:6379");
+        env::set_var("CONFIG_DIR", "/custom/config");
+        env::set_var("CONFIG_FILE_NAME", "custom.json");
+        env::set_var("API_KEY", "7EF1CB7C-5003-4696-B384-C72AF8C3E15D");
+        env::set_var("RATE_LIMIT_REQUESTS_PER_SECOND", "500");
+        env::set_var("RATE_LIMIT_BURST_SIZE", "1000");
+        env::set_var("METRICS_PORT", "9999");
+        env::set_var("ENABLE_SWAGGER", "true");
+        env::set_var("REDIS_CONNECTION_TIMEOUT_MS", "5000");
+        env::set_var("REDIS_KEY_PREFIX", "custom-prefix");
+        env::set_var("RPC_TIMEOUT_MS", "15000");
+        env::set_var("PROVIDER_MAX_RETRIES", "5");
+        env::set_var("PROVIDER_RETRY_BASE_DELAY_MS", "200");
+        env::set_var("PROVIDER_RETRY_MAX_DELAY_MS", "5000");
+        env::set_var("PROVIDER_MAX_FAILOVERS", "10");
+        env::set_var("REPOSITORY_STORAGE_TYPE", "redis");
+        env::set_var("RESET_STORAGE_ON_START", "true");
+        env::set_var("STORAGE_ENCRYPTION_KEY", "my-encryption-key");
+        env::set_var("TRANSACTION_EXPIRATION_HOURS", "12");
+
+        // Test individual getters with custom values
+        assert_eq!(ServerConfig::get_host(), "192.168.1.1");
+        assert_eq!(ServerConfig::get_port(), 9999);
+        assert_eq!(
+            ServerConfig::get_redis_url_optional(),
+            Some("redis://custom:6379".to_string())
+        );
+        assert_eq!(
+            ServerConfig::get_config_file_path(),
+            "/custom/config/custom.json"
+        );
+        assert!(ServerConfig::get_api_key_optional().is_some());
+        assert_eq!(ServerConfig::get_rate_limit_requests_per_second(), 500);
+        assert_eq!(ServerConfig::get_rate_limit_burst_size(), 1000);
+        assert_eq!(ServerConfig::get_metrics_port(), 9999);
+        assert!(ServerConfig::get_enable_swagger());
+        assert_eq!(ServerConfig::get_redis_connection_timeout_ms(), 5000);
+        assert_eq!(ServerConfig::get_redis_key_prefix(), "custom-prefix");
+        assert_eq!(ServerConfig::get_rpc_timeout_ms(), 15000);
+        assert_eq!(ServerConfig::get_provider_max_retries(), 5);
+        assert_eq!(ServerConfig::get_provider_retry_base_delay_ms(), 200);
+        assert_eq!(ServerConfig::get_provider_retry_max_delay_ms(), 5000);
+        assert_eq!(ServerConfig::get_provider_max_failovers(), 10);
+        assert_eq!(
+            ServerConfig::get_repository_storage_type(),
+            RepositoryStorageType::Redis
+        );
+        assert!(ServerConfig::get_reset_storage_on_start());
+        assert!(ServerConfig::get_storage_encryption_key().is_some());
+        assert_eq!(ServerConfig::get_transaction_expiration_hours(), 12);
+    }
+
+    #[test]
+    #[should_panic(expected = "REDIS_URL must be set")]
+    fn test_get_redis_url_panics_when_not_set() {
+        let _lock = match ENV_MUTEX.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+
+        env::remove_var("REDIS_URL");
+        let _ = ServerConfig::get_redis_url();
+    }
+
+    #[test]
+    #[should_panic(expected = "API_KEY must be set")]
+    fn test_get_api_key_panics_when_not_set() {
+        let _lock = match ENV_MUTEX.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+
+        env::remove_var("API_KEY");
+        let _ = ServerConfig::get_api_key();
+    }
+
+    #[test]
+    fn test_optional_getters_return_none_safely() {
+        let _lock = match ENV_MUTEX.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+
+        env::remove_var("REDIS_URL");
+        env::remove_var("API_KEY");
+        env::remove_var("STORAGE_ENCRYPTION_KEY");
+
+        assert!(ServerConfig::get_redis_url_optional().is_none());
+        assert!(ServerConfig::get_api_key_optional().is_none());
+        assert!(ServerConfig::get_storage_encryption_key().is_none());
+    }
+
+    #[test]
+    fn test_refactored_from_env_equivalence() {
+        let _lock = match ENV_MUTEX.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        setup();
+
+        // Set custom values to test both default and custom paths
+        env::set_var("HOST", "custom-host");
+        env::set_var("APP_PORT", "7777");
+        env::set_var("RATE_LIMIT_REQUESTS_PER_SECOND", "250");
+        env::set_var("METRICS_PORT", "7778");
+        env::set_var("ENABLE_SWAGGER", "true");
+        env::set_var("PROVIDER_MAX_RETRIES", "7");
+        env::set_var("TRANSACTION_EXPIRATION_HOURS", "8");
+
+        let config = ServerConfig::from_env();
+
+        // Verify the refactored from_env() produces the same results as individual getters
+        assert_eq!(config.host, ServerConfig::get_host());
+        assert_eq!(config.port, ServerConfig::get_port());
+        assert_eq!(config.redis_url, ServerConfig::get_redis_url());
+        assert_eq!(
+            config.config_file_path,
+            ServerConfig::get_config_file_path()
+        );
+        assert_eq!(config.api_key, ServerConfig::get_api_key());
+        assert_eq!(
+            config.rate_limit_requests_per_second,
+            ServerConfig::get_rate_limit_requests_per_second()
+        );
+        assert_eq!(
+            config.rate_limit_burst_size,
+            ServerConfig::get_rate_limit_burst_size()
+        );
+        assert_eq!(config.metrics_port, ServerConfig::get_metrics_port());
+        assert_eq!(config.enable_swagger, ServerConfig::get_enable_swagger());
+        assert_eq!(
+            config.redis_connection_timeout_ms,
+            ServerConfig::get_redis_connection_timeout_ms()
+        );
+        assert_eq!(
+            config.redis_key_prefix,
+            ServerConfig::get_redis_key_prefix()
+        );
+        assert_eq!(config.rpc_timeout_ms, ServerConfig::get_rpc_timeout_ms());
+        assert_eq!(
+            config.provider_max_retries,
+            ServerConfig::get_provider_max_retries()
+        );
+        assert_eq!(
+            config.provider_retry_base_delay_ms,
+            ServerConfig::get_provider_retry_base_delay_ms()
+        );
+        assert_eq!(
+            config.provider_retry_max_delay_ms,
+            ServerConfig::get_provider_retry_max_delay_ms()
+        );
+        assert_eq!(
+            config.provider_max_failovers,
+            ServerConfig::get_provider_max_failovers()
+        );
+        assert_eq!(
+            config.repository_storage_type,
+            ServerConfig::get_repository_storage_type()
+        );
+        assert_eq!(
+            config.reset_storage_on_start,
+            ServerConfig::get_reset_storage_on_start()
+        );
+        assert_eq!(
+            config.storage_encryption_key,
+            ServerConfig::get_storage_encryption_key()
+        );
+        assert_eq!(
+            config.transaction_expiration_hours,
+            ServerConfig::get_transaction_expiration_hours()
+        );
     }
 }

--- a/src/constants/mod.rs
+++ b/src/constants/mod.rs
@@ -31,3 +31,6 @@ pub use retry::*;
 
 mod plugins;
 pub use plugins::*;
+
+mod transactions;
+pub use transactions::*;

--- a/src/constants/transactions.rs
+++ b/src/constants/transactions.rs
@@ -1,0 +1,33 @@
+//! Transaction-related constants
+
+use crate::models::TransactionStatus;
+
+/// Transaction statuses that are considered final states.
+pub const FINAL_TRANSACTION_STATUSES: &[TransactionStatus] = &[
+    TransactionStatus::Canceled,
+    TransactionStatus::Confirmed,
+    TransactionStatus::Failed,
+    TransactionStatus::Expired,
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_final_transaction_statuses_contains_expected_values() {
+        assert_eq!(FINAL_TRANSACTION_STATUSES.len(), 4);
+        assert!(FINAL_TRANSACTION_STATUSES.contains(&TransactionStatus::Canceled));
+        assert!(FINAL_TRANSACTION_STATUSES.contains(&TransactionStatus::Confirmed));
+        assert!(FINAL_TRANSACTION_STATUSES.contains(&TransactionStatus::Failed));
+        assert!(FINAL_TRANSACTION_STATUSES.contains(&TransactionStatus::Expired));
+    }
+
+    #[test]
+    fn test_final_transaction_statuses_excludes_non_final_states() {
+        assert!(!FINAL_TRANSACTION_STATUSES.contains(&TransactionStatus::Pending));
+        assert!(!FINAL_TRANSACTION_STATUSES.contains(&TransactionStatus::Sent));
+        assert!(!FINAL_TRANSACTION_STATUSES.contains(&TransactionStatus::Submitted));
+        assert!(!FINAL_TRANSACTION_STATUSES.contains(&TransactionStatus::Mined));
+    }
+}

--- a/src/domain/transaction/evm/evm_transaction.rs
+++ b/src/domain/transaction/evm/evm_transaction.rs
@@ -864,6 +864,7 @@ mod tests {
             sent_at: None,
             confirmed_at: None,
             valid_until: None,
+            delete_at: None,
             network_type: NetworkType::Evm,
             network_data: NetworkTransactionData::Evm(EvmTransactionData {
                 chain_id: 1,

--- a/src/domain/transaction/evm/status.rs
+++ b/src/domain/transaction/evm/status.rs
@@ -427,6 +427,7 @@ mod tests {
             sent_at: None,
             confirmed_at: None,
             valid_until: None,
+            delete_at: None,
             network_type: NetworkType::Evm,
             network_data: NetworkTransactionData::Evm(EvmTransactionData {
                 chain_id: 1,

--- a/src/domain/transaction/evm/test_helpers.rs
+++ b/src/domain/transaction/evm/test_helpers.rs
@@ -80,6 +80,7 @@ pub mod test_utils {
             hashes: Vec::new(),
             noop_count: None,
             is_canceled: Some(false),
+            delete_at: None,
         }
     }
 

--- a/src/domain/transaction/evm/utils.rs
+++ b/src/domain/transaction/evm/utils.rs
@@ -194,6 +194,7 @@ mod tests {
             hashes: vec![], // Start with no attempts
             noop_count: None,
             is_canceled: Some(false),
+            delete_at: None,
         };
 
         // Test with no attempts
@@ -240,6 +241,7 @@ mod tests {
             hashes: vec![],
             noop_count: None,
             is_canceled: Some(false),
+            delete_at: None,
         };
 
         // Test with no NOOP attempts
@@ -417,6 +419,7 @@ mod tests {
             hashes: vec![],
             noop_count: None,
             is_canceled: Some(false),
+            delete_at: None,
         };
 
         let age_result = get_age_of_sent_at(&tx);
@@ -458,6 +461,7 @@ mod tests {
             hashes: vec![],
             noop_count: None,
             is_canceled: Some(false),
+            delete_at: None,
         };
 
         let result = get_age_of_sent_at(&tx);
@@ -502,6 +506,7 @@ mod tests {
             hashes: vec![],
             noop_count: None,
             is_canceled: Some(false),
+            delete_at: None,
         };
 
         let result = get_age_of_sent_at(&tx);

--- a/src/domain/transaction/stellar/prepare/operations.rs
+++ b/src/domain/transaction/stellar/prepare/operations.rs
@@ -117,6 +117,7 @@ mod tests {
             network_type: NetworkType::Stellar,
             noop_count: None,
             is_canceled: Some(false),
+            delete_at: None,
         }
     }
 

--- a/src/domain/transaction/stellar/test_helpers.rs
+++ b/src/domain/transaction/stellar/test_helpers.rs
@@ -79,6 +79,7 @@ pub fn create_test_transaction(relayer_id: &str) -> TransactionRepoModel {
         noop_count: None,
         is_canceled: Some(false),
         status_reason: None,
+        delete_at: None,
     }
 }
 

--- a/src/jobs/handlers/mod.rs
+++ b/src/jobs/handlers/mod.rs
@@ -19,6 +19,9 @@ pub use transaction_status_handler::*;
 mod solana_swap_request_handler;
 pub use solana_swap_request_handler::*;
 
+mod transaction_cleanup_handler;
+pub use transaction_cleanup_handler::*;
+
 pub fn handle_result(
     result: Result<(), Report>,
     attempt: Attempt,

--- a/src/jobs/handlers/transaction_cleanup_handler.rs
+++ b/src/jobs/handlers/transaction_cleanup_handler.rs
@@ -1,0 +1,997 @@
+//! Transaction cleanup worker implementation.
+//!
+//! This module implements the transaction cleanup worker that processes
+//! expired transactions marked for deletion. It runs as a cron job to
+//! automatically clean up transactions that have passed their delete_at timestamp.
+
+use actix_web::web::ThinData;
+use apalis::prelude::{Attempt, Data, *};
+use chrono::{DateTime, Utc};
+use eyre::Result;
+use log::{debug, error, info, warn};
+use std::sync::Arc;
+
+use crate::{
+    constants::{FINAL_TRANSACTION_STATUSES, WORKER_DEFAULT_MAXIMUM_RETRIES},
+    jobs::handle_result,
+    models::{DefaultAppState, RelayerRepoModel, TransactionRepoModel},
+    repositories::{Repository, TransactionRepository},
+};
+
+/// Maximum number of relayers to process concurrently
+const MAX_CONCURRENT_RELAYERS: usize = 10;
+
+/// Maximum number of transactions to process concurrently per relayer
+const MAX_CONCURRENT_TRANSACTIONS_PER_RELAYER: usize = 50;
+
+/// Handles periodic transaction cleanup jobs from the queue.
+///
+/// This function processes expired transactions by:
+/// 1. Fetching all relayers from the system
+/// 2. For each relayer, finding transactions with final statuses
+/// 3. Checking if their delete_at timestamp has passed
+/// 4. Validating transactions are in final states before deletion
+/// 5. Deleting transactions that have expired (in parallel)
+///
+/// # Arguments
+/// * `job` - The cron reminder job triggering the cleanup
+/// * `data` - Application state containing repositories
+/// * `attempt` - Current attempt number for retry logic
+///
+/// # Returns
+/// * `Result<(), Error>` - Success or failure of cleanup processing
+pub async fn transaction_cleanup_handler(
+    job: TransactionCleanupCronReminder,
+    data: Data<ThinData<DefaultAppState>>,
+    attempt: Attempt,
+) -> Result<(), Error> {
+    let result = handle_request(job, data, attempt.clone()).await;
+
+    handle_result(
+        result,
+        attempt,
+        "TransactionCleanup",
+        WORKER_DEFAULT_MAXIMUM_RETRIES,
+    )
+}
+
+/// Represents a cron reminder job for triggering cleanup operations.
+#[derive(Default, Debug, Clone)]
+pub struct TransactionCleanupCronReminder();
+
+/// Handles the actual transaction cleanup request logic.
+///
+/// # Arguments
+/// * `_job` - The cron reminder job (currently unused)
+/// * `data` - Application state containing repositories
+/// * `_attempt` - Current attempt number (currently unused)
+///
+/// # Returns
+/// * `Result<()>` - Success or failure of the cleanup operation
+async fn handle_request(
+    _job: TransactionCleanupCronReminder,
+    data: Data<ThinData<DefaultAppState>>,
+    _attempt: Attempt,
+) -> Result<()> {
+    let now = Utc::now();
+    info!(
+        "Executing transaction cleanup from storage at: {}",
+        now.to_rfc3339()
+    );
+
+    let transaction_repo = data.transaction_repository();
+    let relayer_repo = data.relayer_repository();
+
+    // Fetch all relayers
+    let relayers = relayer_repo.list_all().await.map_err(|e| {
+        error!("Failed to fetch relayers for cleanup: {}", e);
+        eyre::eyre!("Failed to fetch relayers: {}", e)
+    })?;
+
+    info!("Found {} relayers to process for cleanup", relayers.len());
+
+    // Process relayers in parallel batches
+    let cleanup_results = process_relayers_in_batches(relayers, transaction_repo, now).await;
+
+    // Aggregate and report results
+    report_cleanup_results(cleanup_results).await
+}
+
+/// Processes multiple relayers in parallel batches for cleanup.
+///
+/// # Arguments
+/// * `relayers` - List of relayers to process
+/// * `transaction_repo` - Reference to the transaction repository
+/// * `now` - Current UTC timestamp for comparison
+///
+/// # Returns
+/// * `Vec<RelayerCleanupResult>` - Results from processing each relayer
+async fn process_relayers_in_batches(
+    relayers: Vec<RelayerRepoModel>,
+    transaction_repo: Arc<impl TransactionRepository + Repository<TransactionRepoModel, String>>,
+    now: DateTime<Utc>,
+) -> Vec<RelayerCleanupResult> {
+    use futures::stream::{self, StreamExt};
+
+    // Process relayers with limited concurrency to avoid overwhelming the system
+    let results: Vec<RelayerCleanupResult> = stream::iter(relayers)
+        .map(|relayer| {
+            let repo_clone = Arc::clone(&transaction_repo);
+            async move { process_single_relayer(relayer, repo_clone, now).await }
+        })
+        .buffer_unordered(MAX_CONCURRENT_RELAYERS)
+        .collect()
+        .await;
+
+    results
+}
+
+/// Result of processing a single relayer's transactions.
+#[derive(Debug)]
+struct RelayerCleanupResult {
+    relayer_id: String,
+    cleaned_count: usize,
+    error: Option<String>,
+}
+
+/// Processes cleanup for a single relayer.
+///
+/// # Arguments
+/// * `relayer` - The relayer to process
+/// * `transaction_repo` - Reference to the transaction repository
+/// * `now` - Current UTC timestamp for comparison
+///
+/// # Returns
+/// * `RelayerCleanupResult` - Result of processing this relayer
+async fn process_single_relayer(
+    relayer: RelayerRepoModel,
+    transaction_repo: Arc<impl TransactionRepository + Repository<TransactionRepoModel, String>>,
+    now: DateTime<Utc>,
+) -> RelayerCleanupResult {
+    debug!("Processing cleanup for relayer: {}", relayer.id);
+
+    match fetch_final_transactions(&relayer.id, &transaction_repo).await {
+        Ok(final_transactions) => {
+            debug!(
+                "Found {} transactions with final statuses for relayer: {}",
+                final_transactions.len(),
+                relayer.id
+            );
+
+            let cleaned_count = process_transactions_for_cleanup(
+                final_transactions,
+                &transaction_repo,
+                &relayer.id,
+                now,
+            )
+            .await;
+
+            if cleaned_count > 0 {
+                info!(
+                    "Cleaned up {} expired transactions for relayer: {}",
+                    cleaned_count, relayer.id
+                );
+            }
+
+            RelayerCleanupResult {
+                relayer_id: relayer.id,
+                cleaned_count,
+                error: None,
+            }
+        }
+        Err(e) => {
+            error!(
+                "Failed to fetch final transactions for relayer {}: {}",
+                relayer.id, e
+            );
+            RelayerCleanupResult {
+                relayer_id: relayer.id,
+                cleaned_count: 0,
+                error: Some(e.to_string()),
+            }
+        }
+    }
+}
+
+/// Fetches all transactions with final statuses for a specific relayer.
+///
+/// # Arguments
+/// * `relayer_id` - ID of the relayer
+/// * `transaction_repo` - Reference to the transaction repository
+///
+/// # Returns
+/// * `Result<Vec<TransactionRepoModel>>` - List of transactions with final statuses or error
+async fn fetch_final_transactions(
+    relayer_id: &str,
+    transaction_repo: &Arc<impl TransactionRepository>,
+) -> Result<Vec<TransactionRepoModel>> {
+    transaction_repo
+        .find_by_status(relayer_id, FINAL_TRANSACTION_STATUSES)
+        .await
+        .map_err(|e| {
+            eyre::eyre!(
+                "Failed to fetch final transactions for relayer {}: {}",
+                relayer_id,
+                e
+            )
+        })
+}
+
+/// Processes a list of transactions for cleanup in parallel, deleting expired ones.
+///
+/// This function validates that transactions are in final states before deletion,
+/// ensuring data integrity by preventing accidental deletion of active transactions.
+///
+/// # Arguments
+/// * `transactions` - List of transactions to process
+/// * `transaction_repo` - Reference to the transaction repository
+/// * `relayer_id` - ID of the relayer (for logging)
+/// * `now` - Current UTC timestamp for comparison
+///
+/// # Returns
+/// * `usize` - Number of transactions successfully cleaned up
+async fn process_transactions_for_cleanup(
+    transactions: Vec<TransactionRepoModel>,
+    transaction_repo: &Arc<impl Repository<TransactionRepoModel, String>>,
+    relayer_id: &str,
+    now: DateTime<Utc>,
+) -> usize {
+    use futures::stream::{self, StreamExt};
+
+    if transactions.is_empty() {
+        return 0;
+    }
+
+    debug!(
+        "Processing {} transactions in parallel for relayer: {}",
+        transactions.len(),
+        relayer_id
+    );
+
+    // Filter expired transactions first (this is fast and synchronous)
+    let expired_transactions: Vec<TransactionRepoModel> = transactions
+        .into_iter()
+        .filter(|tx| should_delete_transaction(tx, now))
+        .collect();
+
+    if expired_transactions.is_empty() {
+        debug!("No expired transactions found for relayer: {}", relayer_id);
+        return 0;
+    }
+
+    debug!(
+        "Found {} expired transactions to delete for relayer: {}",
+        expired_transactions.len(),
+        relayer_id
+    );
+
+    // Process deletions in parallel with limited concurrency
+    let deletion_results: Vec<bool> = stream::iter(expired_transactions)
+        .map(|transaction| {
+            let repo_clone = Arc::clone(transaction_repo);
+            let relayer_id = relayer_id.to_string();
+            async move {
+                match delete_expired_transaction(&transaction, &repo_clone, &relayer_id).await {
+                    Ok(()) => true,
+                    Err(e) => {
+                        error!(
+                            "Failed to delete expired transaction {}: {}",
+                            transaction.id, e
+                        );
+                        false
+                    }
+                }
+            }
+        })
+        .buffer_unordered(MAX_CONCURRENT_TRANSACTIONS_PER_RELAYER)
+        .collect()
+        .await;
+
+    // Count successful deletions
+    let cleaned_count = deletion_results.iter().filter(|&&success| success).count();
+
+    debug!(
+        "Successfully deleted {}/{} expired transactions for relayer: {}",
+        cleaned_count,
+        deletion_results.len(),
+        relayer_id
+    );
+
+    cleaned_count
+}
+
+/// Determines if a transaction should be deleted based on its delete_at timestamp.
+///
+/// # Arguments
+/// * `transaction` - The transaction to check
+/// * `now` - Current UTC timestamp for comparison
+///
+/// # Returns
+/// * `bool` - True if the transaction should be deleted, false otherwise
+fn should_delete_transaction(transaction: &TransactionRepoModel, now: DateTime<Utc>) -> bool {
+    transaction
+        .delete_at
+        .as_ref()
+        .and_then(|delete_at_str| DateTime::parse_from_rfc3339(delete_at_str).ok())
+        .map(|delete_at| {
+            let is_expired = now >= delete_at.with_timezone(&Utc);
+            if is_expired {
+                debug!(
+                    "Transaction {} is expired (expired at: {})",
+                    transaction.id,
+                    delete_at.to_rfc3339()
+                );
+            }
+            is_expired
+        })
+        .unwrap_or_else(|| {
+            if transaction.delete_at.is_some() {
+                warn!(
+                    "Transaction {} has invalid delete_at timestamp",
+                    transaction.id
+                );
+            }
+            false
+        })
+}
+
+/// Deletes an expired transaction from the repository.
+///
+/// # Arguments
+/// * `transaction` - The transaction to delete
+/// * `transaction_repo` - Reference to the transaction repository
+/// * `relayer_id` - ID of the relayer (for logging)
+///
+/// # Returns
+/// * `Result<()>` - Success or failure of the deletion
+async fn delete_expired_transaction(
+    transaction: &TransactionRepoModel,
+    transaction_repo: &Arc<impl Repository<TransactionRepoModel, String>>,
+    relayer_id: &str,
+) -> Result<()> {
+    // Validate that the transaction is in a final state before deletion
+    if !FINAL_TRANSACTION_STATUSES.contains(&transaction.status) {
+        return Err(eyre::eyre!(
+            "Transaction {} is not in a final state (current: {:?})",
+            transaction.id,
+            transaction.status
+        ));
+    }
+
+    debug!(
+        "Deleting expired transaction {} (status: {:?}) for relayer: {}",
+        transaction.id, transaction.status, relayer_id
+    );
+
+    transaction_repo
+        .delete_by_id(transaction.id.clone())
+        .await
+        .map_err(|e| eyre::eyre!("Failed to delete transaction {}: {}", transaction.id, e))?;
+
+    info!(
+        "Successfully deleted expired transaction: {} (status: {:?}) for relayer: {}",
+        transaction.id, transaction.status, relayer_id
+    );
+
+    Ok(())
+}
+
+/// Reports the aggregated results of the cleanup operation.
+///
+/// # Arguments
+/// * `cleanup_results` - Results from processing all relayers
+///
+/// # Returns
+/// * `Result<()>` - Success if all went well, error if there were failures
+async fn report_cleanup_results(cleanup_results: Vec<RelayerCleanupResult>) -> Result<()> {
+    let total_cleaned: usize = cleanup_results.iter().map(|r| r.cleaned_count).sum();
+    let total_errors = cleanup_results.iter().filter(|r| r.error.is_some()).count();
+    let total_relayers = cleanup_results.len();
+
+    // Log detailed results for relayers with errors
+    for result in &cleanup_results {
+        if let Some(error) = &result.error {
+            error!(
+                "Failed to cleanup transactions for relayer {}: {}",
+                result.relayer_id, error
+            );
+        }
+    }
+
+    if total_errors > 0 {
+        warn!(
+            "Transaction cleanup completed with {} errors out of {} relayers. Successfully cleaned {} transactions.",
+            total_errors, total_relayers, total_cleaned
+        );
+
+        // Return error if there were failures, but don't fail the entire job
+        // This allows for partial success and retry of failed relayers
+        Err(eyre::eyre!(
+            "Cleanup completed with {} errors out of {} relayers",
+            total_errors,
+            total_relayers
+        ))
+    } else {
+        info!(
+            "Transaction cleanup completed successfully. Cleaned {} transactions from {} relayers.",
+            total_cleaned, total_relayers
+        );
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+    use crate::{
+        models::{
+            NetworkType, RelayerEvmPolicy, RelayerNetworkPolicy, RelayerRepoModel,
+            TransactionRepoModel, TransactionStatus,
+        },
+        repositories::{InMemoryTransactionRepository, Repository},
+        utils::mocks::mockutils::create_mock_transaction,
+    };
+    use chrono::{Duration, Utc};
+
+    fn create_test_transaction(
+        id: &str,
+        relayer_id: &str,
+        status: TransactionStatus,
+        delete_at: Option<String>,
+    ) -> TransactionRepoModel {
+        let mut tx = create_mock_transaction();
+        tx.id = id.to_string();
+        tx.relayer_id = relayer_id.to_string();
+        tx.status = status;
+        tx.delete_at = delete_at;
+        tx
+    }
+
+    #[tokio::test]
+    async fn test_should_delete_transaction_expired() {
+        let now = Utc::now();
+        let expired_delete_at = (now - Duration::hours(1)).to_rfc3339();
+
+        let transaction = create_test_transaction(
+            "test-tx",
+            "test-relayer",
+            TransactionStatus::Confirmed,
+            Some(expired_delete_at),
+        );
+
+        assert!(should_delete_transaction(&transaction, now));
+    }
+
+    #[tokio::test]
+    async fn test_should_delete_transaction_not_expired() {
+        let now = Utc::now();
+        let future_delete_at = (now + Duration::hours(1)).to_rfc3339();
+
+        let transaction = create_test_transaction(
+            "test-tx",
+            "test-relayer",
+            TransactionStatus::Confirmed,
+            Some(future_delete_at),
+        );
+
+        assert!(!should_delete_transaction(&transaction, now));
+    }
+
+    #[tokio::test]
+    async fn test_should_delete_transaction_no_delete_at() {
+        let now = Utc::now();
+
+        let transaction = create_test_transaction(
+            "test-tx",
+            "test-relayer",
+            TransactionStatus::Confirmed,
+            None,
+        );
+
+        assert!(!should_delete_transaction(&transaction, now));
+    }
+
+    #[tokio::test]
+    async fn test_should_delete_transaction_invalid_timestamp() {
+        let now = Utc::now();
+
+        let transaction = create_test_transaction(
+            "test-tx",
+            "test-relayer",
+            TransactionStatus::Confirmed,
+            Some("invalid-timestamp".to_string()),
+        );
+
+        assert!(!should_delete_transaction(&transaction, now));
+    }
+
+    #[tokio::test]
+    async fn test_process_transactions_for_cleanup_parallel() {
+        let transaction_repo = Arc::new(InMemoryTransactionRepository::new());
+        let relayer_id = "test-relayer";
+        let now = Utc::now();
+
+        // Create test transactions
+        let expired_delete_at = (now - Duration::hours(1)).to_rfc3339();
+        let future_delete_at = (now + Duration::hours(1)).to_rfc3339();
+
+        let expired_tx = create_test_transaction(
+            "expired-tx",
+            relayer_id,
+            TransactionStatus::Confirmed,
+            Some(expired_delete_at),
+        );
+        let future_tx = create_test_transaction(
+            "future-tx",
+            relayer_id,
+            TransactionStatus::Failed,
+            Some(future_delete_at),
+        );
+        let no_delete_tx = create_test_transaction(
+            "no-delete-tx",
+            relayer_id,
+            TransactionStatus::Canceled,
+            None,
+        );
+
+        // Store transactions
+        transaction_repo.create(expired_tx.clone()).await.unwrap();
+        transaction_repo.create(future_tx.clone()).await.unwrap();
+        transaction_repo.create(no_delete_tx.clone()).await.unwrap();
+
+        let transactions = vec![expired_tx, future_tx, no_delete_tx];
+
+        // Process transactions
+        let cleaned_count =
+            process_transactions_for_cleanup(transactions, &transaction_repo, relayer_id, now)
+                .await;
+
+        // Should have cleaned up 1 expired transaction
+        assert_eq!(cleaned_count, 1);
+
+        // Verify expired transaction was deleted
+        assert!(transaction_repo
+            .get_by_id("expired-tx".to_string())
+            .await
+            .is_err());
+
+        // Verify non-expired transactions still exist
+        assert!(transaction_repo
+            .get_by_id("future-tx".to_string())
+            .await
+            .is_ok());
+        assert!(transaction_repo
+            .get_by_id("no-delete-tx".to_string())
+            .await
+            .is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_delete_expired_transaction() {
+        let transaction_repo = Arc::new(InMemoryTransactionRepository::new());
+        let relayer_id = "test-relayer";
+
+        let transaction = create_test_transaction(
+            "test-tx",
+            relayer_id,
+            TransactionStatus::Confirmed, // Final status
+            Some(Utc::now().to_rfc3339()),
+        );
+
+        // Store transaction
+        transaction_repo.create(transaction.clone()).await.unwrap();
+
+        // Verify it exists
+        assert!(transaction_repo
+            .get_by_id("test-tx".to_string())
+            .await
+            .is_ok());
+
+        // Delete it
+        let result = delete_expired_transaction(&transaction, &transaction_repo, relayer_id).await;
+        assert!(result.is_ok());
+
+        // Verify it was deleted
+        assert!(transaction_repo
+            .get_by_id("test-tx".to_string())
+            .await
+            .is_err());
+    }
+
+    #[tokio::test]
+    async fn test_delete_expired_transaction_validates_final_status() {
+        let transaction_repo = Arc::new(InMemoryTransactionRepository::new());
+        let relayer_id = "test-relayer";
+
+        let transaction = create_test_transaction(
+            "test-tx",
+            relayer_id,
+            TransactionStatus::Pending, // Non-final status
+            Some(Utc::now().to_rfc3339()),
+        );
+
+        // Store transaction
+        transaction_repo.create(transaction.clone()).await.unwrap();
+
+        // Verify it exists
+        assert!(transaction_repo
+            .get_by_id("test-tx".to_string())
+            .await
+            .is_ok());
+
+        // Try to delete it - should fail due to validation
+        let result = delete_expired_transaction(&transaction, &transaction_repo, relayer_id).await;
+        assert!(result.is_err());
+
+        let error_message = result.unwrap_err().to_string();
+        assert!(error_message.contains("is not in a final state"));
+        assert!(error_message.contains("Pending"));
+
+        // Verify it still exists (wasn't deleted)
+        assert!(transaction_repo
+            .get_by_id("test-tx".to_string())
+            .await
+            .is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_delete_expired_transaction_validates_all_final_statuses() {
+        let transaction_repo = Arc::new(InMemoryTransactionRepository::new());
+        let relayer_id = "test-relayer";
+
+        // Test each final status to ensure they all pass validation
+        let final_statuses = vec![
+            TransactionStatus::Confirmed,
+            TransactionStatus::Failed,
+            TransactionStatus::Canceled,
+            TransactionStatus::Expired,
+        ];
+
+        for (i, status) in final_statuses.iter().enumerate() {
+            let tx_id = format!("test-tx-{}", i);
+            let transaction = create_test_transaction(
+                &tx_id,
+                relayer_id,
+                status.clone(),
+                Some(Utc::now().to_rfc3339()),
+            );
+
+            // Store transaction
+            transaction_repo.create(transaction.clone()).await.unwrap();
+
+            // Delete it - should succeed for all final statuses
+            let result =
+                delete_expired_transaction(&transaction, &transaction_repo, relayer_id).await;
+            assert!(
+                result.is_ok(),
+                "Failed to delete transaction with status: {:?}",
+                status
+            );
+
+            // Verify it was deleted
+            assert!(transaction_repo.get_by_id(tx_id).await.is_err());
+        }
+    }
+
+    #[tokio::test]
+    async fn test_fetch_final_transactions() {
+        let transaction_repo = Arc::new(InMemoryTransactionRepository::new());
+        let relayer_id = "test-relayer";
+
+        // Create transactions with different statuses
+        let confirmed_tx = create_test_transaction(
+            "confirmed-tx",
+            relayer_id,
+            TransactionStatus::Confirmed,
+            None,
+        );
+        let pending_tx =
+            create_test_transaction("pending-tx", relayer_id, TransactionStatus::Pending, None);
+        let failed_tx =
+            create_test_transaction("failed-tx", relayer_id, TransactionStatus::Failed, None);
+
+        // Store transactions
+        transaction_repo.create(confirmed_tx).await.unwrap();
+        transaction_repo.create(pending_tx).await.unwrap();
+        transaction_repo.create(failed_tx).await.unwrap();
+
+        // Fetch final transactions
+        let final_transactions = fetch_final_transactions(relayer_id, &transaction_repo)
+            .await
+            .unwrap();
+
+        // Should only return transactions with final statuses (Confirmed, Failed)
+        assert_eq!(final_transactions.len(), 2);
+        let final_ids: Vec<&String> = final_transactions.iter().map(|tx| &tx.id).collect();
+        assert!(final_ids.contains(&&"confirmed-tx".to_string()));
+        assert!(final_ids.contains(&&"failed-tx".to_string()));
+        assert!(!final_ids.contains(&&"pending-tx".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_report_cleanup_results_success() {
+        let results = vec![
+            RelayerCleanupResult {
+                relayer_id: "relayer-1".to_string(),
+                cleaned_count: 2,
+                error: None,
+            },
+            RelayerCleanupResult {
+                relayer_id: "relayer-2".to_string(),
+                cleaned_count: 1,
+                error: None,
+            },
+        ];
+
+        let result = report_cleanup_results(results).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_report_cleanup_results_with_errors() {
+        let results = vec![
+            RelayerCleanupResult {
+                relayer_id: "relayer-1".to_string(),
+                cleaned_count: 2,
+                error: None,
+            },
+            RelayerCleanupResult {
+                relayer_id: "relayer-2".to_string(),
+                cleaned_count: 0,
+                error: Some("Database error".to_string()),
+            },
+        ];
+
+        let result = report_cleanup_results(results).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_process_single_relayer_success() {
+        let transaction_repo = Arc::new(InMemoryTransactionRepository::new());
+        let relayer = RelayerRepoModel {
+            id: "test-relayer".to_string(),
+            name: "Test Relayer".to_string(),
+            network: "ethereum".to_string(),
+            paused: false,
+            network_type: NetworkType::Evm,
+            signer_id: "test-signer".to_string(),
+            policies: RelayerNetworkPolicy::Evm(RelayerEvmPolicy::default()),
+            address: "0x1234567890123456789012345678901234567890".to_string(),
+            notification_id: None,
+            system_disabled: false,
+            custom_rpc_urls: None,
+        };
+        let now = Utc::now();
+
+        // Create expired and non-expired transactions
+        let expired_tx = create_test_transaction(
+            "expired-tx",
+            &relayer.id,
+            TransactionStatus::Confirmed,
+            Some((now - Duration::hours(1)).to_rfc3339()),
+        );
+        let future_tx = create_test_transaction(
+            "future-tx",
+            &relayer.id,
+            TransactionStatus::Failed,
+            Some((now + Duration::hours(1)).to_rfc3339()),
+        );
+
+        transaction_repo.create(expired_tx).await.unwrap();
+        transaction_repo.create(future_tx).await.unwrap();
+
+        let result = process_single_relayer(relayer.clone(), transaction_repo.clone(), now).await;
+
+        assert_eq!(result.relayer_id, relayer.id);
+        assert_eq!(result.cleaned_count, 1);
+        assert!(result.error.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_process_single_relayer_no_transactions() {
+        // Create a relayer with no transactions in the repo
+        let transaction_repo = Arc::new(InMemoryTransactionRepository::new());
+        let relayer = RelayerRepoModel {
+            id: "empty-relayer".to_string(),
+            name: "Empty Relayer".to_string(),
+            network: "ethereum".to_string(),
+            paused: false,
+            network_type: NetworkType::Evm,
+            signer_id: "test-signer".to_string(),
+            policies: RelayerNetworkPolicy::Evm(RelayerEvmPolicy::default()),
+            address: "0x1234567890123456789012345678901234567890".to_string(),
+            notification_id: None,
+            system_disabled: false,
+            custom_rpc_urls: None,
+        };
+        let now = Utc::now();
+
+        // This should succeed but find no transactions
+        let result = process_single_relayer(relayer.clone(), transaction_repo, now).await;
+
+        assert_eq!(result.relayer_id, relayer.id);
+        assert_eq!(result.cleaned_count, 0);
+        assert!(result.error.is_none()); // No error, just no transactions found
+    }
+
+    #[tokio::test]
+    async fn test_process_transactions_with_empty_list() {
+        let transaction_repo = Arc::new(InMemoryTransactionRepository::new());
+        let relayer_id = "test-relayer";
+        let now = Utc::now();
+        let transactions = vec![];
+
+        let cleaned_count =
+            process_transactions_for_cleanup(transactions, &transaction_repo, relayer_id, now)
+                .await;
+
+        assert_eq!(cleaned_count, 0);
+    }
+
+    #[tokio::test]
+    async fn test_process_transactions_with_no_expired() {
+        let transaction_repo = Arc::new(InMemoryTransactionRepository::new());
+        let relayer_id = "test-relayer";
+        let now = Utc::now();
+
+        // Create only non-expired transactions
+        let future_tx1 = create_test_transaction(
+            "future-tx-1",
+            relayer_id,
+            TransactionStatus::Confirmed,
+            Some((now + Duration::hours(1)).to_rfc3339()),
+        );
+        let future_tx2 = create_test_transaction(
+            "future-tx-2",
+            relayer_id,
+            TransactionStatus::Failed,
+            Some((now + Duration::hours(2)).to_rfc3339()),
+        );
+        let no_delete_tx = create_test_transaction(
+            "no-delete-tx",
+            relayer_id,
+            TransactionStatus::Canceled,
+            None,
+        );
+
+        let transactions = vec![future_tx1, future_tx2, no_delete_tx];
+
+        let cleaned_count =
+            process_transactions_for_cleanup(transactions, &transaction_repo, relayer_id, now)
+                .await;
+
+        assert_eq!(cleaned_count, 0);
+    }
+
+    #[tokio::test]
+    async fn test_should_delete_transaction_exactly_at_expiry_time() {
+        let now = Utc::now();
+        let exact_expiry_time = now.to_rfc3339();
+
+        let transaction = create_test_transaction(
+            "test-tx",
+            "test-relayer",
+            TransactionStatus::Confirmed,
+            Some(exact_expiry_time),
+        );
+
+        // Should be considered expired when exactly at expiry time
+        assert!(should_delete_transaction(&transaction, now));
+    }
+
+    #[tokio::test]
+    async fn test_parallel_processing_with_mixed_results() {
+        let transaction_repo = Arc::new(InMemoryTransactionRepository::new());
+        let relayer_id = "test-relayer";
+        let now = Utc::now();
+
+        // Create multiple expired transactions
+        let expired_tx1 = create_test_transaction(
+            "expired-tx-1",
+            relayer_id,
+            TransactionStatus::Confirmed,
+            Some((now - Duration::hours(1)).to_rfc3339()),
+        );
+        let expired_tx2 = create_test_transaction(
+            "expired-tx-2",
+            relayer_id,
+            TransactionStatus::Failed,
+            Some((now - Duration::hours(2)).to_rfc3339()),
+        );
+        let expired_tx3 = create_test_transaction(
+            "expired-tx-3",
+            relayer_id,
+            TransactionStatus::Canceled,
+            Some((now - Duration::hours(3)).to_rfc3339()),
+        );
+
+        // Store only some transactions (others will fail deletion due to NotFound)
+        transaction_repo.create(expired_tx1.clone()).await.unwrap();
+        transaction_repo.create(expired_tx2.clone()).await.unwrap();
+        // Don't store expired_tx3 - it will fail deletion
+
+        let transactions = vec![expired_tx1, expired_tx2, expired_tx3];
+
+        let cleaned_count =
+            process_transactions_for_cleanup(transactions, &transaction_repo, relayer_id, now)
+                .await;
+
+        // Should have cleaned 2 out of 3 transactions (one failed due to NotFound)
+        assert_eq!(cleaned_count, 2);
+    }
+
+    #[tokio::test]
+    async fn test_delete_expired_transaction_repository_error() {
+        let transaction_repo = Arc::new(InMemoryTransactionRepository::new());
+        let relayer_id = "test-relayer";
+
+        let transaction = create_test_transaction(
+            "nonexistent-tx",
+            relayer_id,
+            TransactionStatus::Confirmed,
+            Some(Utc::now().to_rfc3339()),
+        );
+
+        // Don't store the transaction, so delete will fail with NotFound
+        let result = delete_expired_transaction(&transaction, &transaction_repo, relayer_id).await;
+
+        assert!(result.is_err());
+        let error_message = result.unwrap_err().to_string();
+        assert!(error_message.contains("Failed to delete transaction"));
+    }
+
+    #[tokio::test]
+    async fn test_report_cleanup_results_empty() {
+        let results = vec![];
+        let result = report_cleanup_results(results).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_fetch_final_transactions_with_mixed_statuses() {
+        let transaction_repo = Arc::new(InMemoryTransactionRepository::new());
+        let relayer_id = "test-relayer";
+
+        // Create transactions with all possible statuses
+        let confirmed_tx = create_test_transaction(
+            "confirmed-tx",
+            relayer_id,
+            TransactionStatus::Confirmed,
+            None,
+        );
+        let failed_tx =
+            create_test_transaction("failed-tx", relayer_id, TransactionStatus::Failed, None);
+        let canceled_tx =
+            create_test_transaction("canceled-tx", relayer_id, TransactionStatus::Canceled, None);
+        let expired_tx =
+            create_test_transaction("expired-tx", relayer_id, TransactionStatus::Expired, None);
+        let pending_tx =
+            create_test_transaction("pending-tx", relayer_id, TransactionStatus::Pending, None);
+        let sent_tx = create_test_transaction("sent-tx", relayer_id, TransactionStatus::Sent, None);
+
+        // Store all transactions
+        transaction_repo.create(confirmed_tx).await.unwrap();
+        transaction_repo.create(failed_tx).await.unwrap();
+        transaction_repo.create(canceled_tx).await.unwrap();
+        transaction_repo.create(expired_tx).await.unwrap();
+        transaction_repo.create(pending_tx).await.unwrap();
+        transaction_repo.create(sent_tx).await.unwrap();
+
+        // Fetch final transactions
+        let final_transactions = fetch_final_transactions(relayer_id, &transaction_repo)
+            .await
+            .unwrap();
+
+        // Should only return the 4 final status transactions
+        assert_eq!(final_transactions.len(), 4);
+        let final_ids: Vec<&String> = final_transactions.iter().map(|tx| &tx.id).collect();
+        assert!(final_ids.contains(&&"confirmed-tx".to_string()));
+        assert!(final_ids.contains(&&"failed-tx".to_string()));
+        assert!(final_ids.contains(&&"canceled-tx".to_string()));
+        assert!(final_ids.contains(&&"expired-tx".to_string()));
+        assert!(!final_ids.contains(&&"pending-tx".to_string()));
+        assert!(!final_ids.contains(&&"sent-tx".to_string()));
+    }
+}

--- a/src/jobs/handlers/transaction_cleanup_handler.rs
+++ b/src/jobs/handlers/transaction_cleanup_handler.rs
@@ -108,7 +108,7 @@ async fn handle_request(
 /// * `Vec<RelayerCleanupResult>` - Results from processing each relayer
 async fn process_relayers_in_batches(
     relayers: Vec<RelayerRepoModel>,
-    transaction_repo: Arc<impl TransactionRepository + Repository<TransactionRepoModel, String>>,
+    transaction_repo: Arc<impl TransactionRepository>,
     now: DateTime<Utc>,
 ) -> Vec<RelayerCleanupResult> {
     use futures::stream::{self, StreamExt};
@@ -145,7 +145,7 @@ struct RelayerCleanupResult {
 /// * `RelayerCleanupResult` - Result of processing this relayer
 async fn process_single_relayer(
     relayer: RelayerRepoModel,
-    transaction_repo: Arc<impl TransactionRepository + Repository<TransactionRepoModel, String>>,
+    transaction_repo: Arc<impl TransactionRepository>,
     now: DateTime<Utc>,
 ) -> RelayerCleanupResult {
     debug!("Processing cleanup for relayer: {}", relayer.id);
@@ -641,7 +641,7 @@ mod tests {
         let relayer_id = "test-relayer";
 
         // Test each final status to ensure they all pass validation
-        let final_statuses = vec![
+        let final_statuses = [
             TransactionStatus::Confirmed,
             TransactionStatus::Failed,
             TransactionStatus::Canceled,

--- a/src/jobs/queue.rs
+++ b/src/jobs/queue.rs
@@ -41,8 +41,9 @@ impl Queue {
     }
 
     pub async fn setup() -> Result<Self> {
-        let redis_url = ServerConfig::from_env().redis_url.clone();
-        let redis_connection_timeout_ms = ServerConfig::from_env().redis_connection_timeout_ms;
+        let config = ServerConfig::from_env();
+        let redis_url = config.redis_url.clone();
+        let redis_connection_timeout_ms = config.redis_connection_timeout_ms;
         let conn = match timeout(Duration::from_millis(redis_connection_timeout_ms), apalis_redis::connect(redis_url.clone())).await {
             Ok(result) => result.map_err(|e| {
                 error!("Failed to connect to Redis at {}: {}", redis_url, e);

--- a/src/models/transaction/repository.rs
+++ b/src/models/transaction/repository.rs
@@ -119,10 +119,10 @@ impl TransactionRepoModel {
     }
 
     /// Apply partial updates to this transaction model
-    /// 
+    ///
     /// This method encapsulates the business logic for updating transaction fields,
     /// ensuring consistency across all repository implementations.
-    /// 
+    ///
     /// # Arguments
     /// * `update` - The partial update request containing the fields to update
     pub fn apply_partial_update(&mut self, update: TransactionUpdateRequest) {
@@ -2760,12 +2760,24 @@ mod tests {
 
         // Verify the updates were applied
         assert_eq!(transaction.status, TransactionStatus::Confirmed);
-        assert_eq!(transaction.status_reason, Some("Transaction confirmed".to_string()));
-        assert_eq!(transaction.sent_at, Some("2023-01-01T12:00:00Z".to_string()));
-        assert_eq!(transaction.confirmed_at, Some("2023-01-01T12:05:00Z".to_string()));
-        assert_eq!(transaction.hashes, vec!["0x123".to_string(), "0x456".to_string()]);
+        assert_eq!(
+            transaction.status_reason,
+            Some("Transaction confirmed".to_string())
+        );
+        assert_eq!(
+            transaction.sent_at,
+            Some("2023-01-01T12:00:00Z".to_string())
+        );
+        assert_eq!(
+            transaction.confirmed_at,
+            Some("2023-01-01T12:05:00Z".to_string())
+        );
+        assert_eq!(
+            transaction.hashes,
+            vec!["0x123".to_string(), "0x456".to_string()]
+        );
         assert_eq!(transaction.is_canceled, Some(false));
-        
+
         // Verify that delete_at was set because status changed to final
         assert!(transaction.delete_at.is_some());
     }
@@ -2802,13 +2814,19 @@ mod tests {
 
         // Verify only status changed, other fields preserved
         assert_eq!(transaction.status, TransactionStatus::Sent);
-        assert_eq!(transaction.status_reason, Some("Initial reason".to_string()));
-        assert_eq!(transaction.sent_at, Some("2023-01-01T10:00:00Z".to_string()));
+        assert_eq!(
+            transaction.status_reason,
+            Some("Initial reason".to_string())
+        );
+        assert_eq!(
+            transaction.sent_at,
+            Some("2023-01-01T10:00:00Z".to_string())
+        );
         assert_eq!(transaction.confirmed_at, None);
         assert_eq!(transaction.hashes, vec!["0xoriginal".to_string()]);
         assert_eq!(transaction.noop_count, Some(5));
         assert_eq!(transaction.is_canceled, Some(true));
-        
+
         // Status is not final, so delete_at should remain None
         assert!(transaction.delete_at.is_none());
     }
@@ -2826,7 +2844,10 @@ mod tests {
         // Verify nothing changed
         assert_eq!(transaction.id, original_transaction.id);
         assert_eq!(transaction.status, original_transaction.status);
-        assert_eq!(transaction.status_reason, original_transaction.status_reason);
+        assert_eq!(
+            transaction.status_reason,
+            original_transaction.status_reason
+        );
         assert_eq!(transaction.sent_at, original_transaction.sent_at);
         assert_eq!(transaction.confirmed_at, original_transaction.confirmed_at);
         assert_eq!(transaction.hashes, original_transaction.hashes);

--- a/src/models/transaction/repository.rs
+++ b/src/models/transaction/repository.rs
@@ -1,6 +1,10 @@
 use super::evm::Speed;
 use crate::{
-    constants::{DEFAULT_GAS_LIMIT, DEFAULT_TRANSACTION_SPEED},
+    config::ServerConfig,
+    constants::{
+        DEFAULT_GAS_LIMIT, DEFAULT_TRANSACTION_SPEED, FINAL_TRANSACTION_STATUSES,
+        STELLAR_DEFAULT_MAX_FEE, STELLAR_DEFAULT_TRANSACTION_FEE,
+    },
     domain::{
         evm::PriceParams,
         stellar::validation::{validate_operations, validate_soroban_memo_restriction},
@@ -24,7 +28,7 @@ use alloy::{
     rpc::types::AccessList,
 };
 
-use chrono::Utc;
+use chrono::{Duration, Utc};
 use serde::{Deserialize, Serialize};
 use std::{convert::TryFrom, str::FromStr};
 use strum::Display;
@@ -32,7 +36,6 @@ use strum::Display;
 use utoipa::ToSchema;
 use uuid::Uuid;
 
-use crate::constants::{STELLAR_DEFAULT_MAX_FEE, STELLAR_DEFAULT_TRANSACTION_FEE};
 use soroban_rs::xdr::{
     Transaction as SorobanTransaction, TransactionEnvelope, TransactionV1Envelope, VecM,
 };
@@ -65,6 +68,8 @@ pub struct TransactionUpdateRequest {
     pub noop_count: Option<u32>,
     /// Whether the transaction is canceled
     pub is_canceled: Option<bool>,
+    /// Timestamp when this transaction should be deleted (for final states)
+    pub delete_at: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -77,6 +82,8 @@ pub struct TransactionRepoModel {
     pub sent_at: Option<String>,
     pub confirmed_at: Option<String>,
     pub valid_until: Option<String>,
+    /// Timestamp when this transaction should be deleted (for final states)
+    pub delete_at: Option<String>,
     pub network_data: NetworkTransactionData,
     /// Timestamp when gas price was determined
     pub priced_at: Option<String>,
@@ -95,6 +102,62 @@ impl TransactionRepoModel {
     /// * `Err(TransactionError)` if validation fails
     pub fn validate(&self) -> Result<(), TransactionError> {
         Ok(())
+    }
+
+    /// Calculate when this transaction should be deleted based on its status and expiration hours
+    fn calculate_delete_at(expiration_hours: u64) -> Option<String> {
+        let delete_time = Utc::now() + Duration::hours(expiration_hours as i64);
+        Some(delete_time.to_rfc3339())
+    }
+
+    /// Update delete_at field if status changed to a final state
+    pub fn update_delete_at_if_final_status(&mut self) {
+        if self.delete_at.is_none() && FINAL_TRANSACTION_STATUSES.contains(&self.status) {
+            let expiration_hours = ServerConfig::get_transaction_expiration_hours();
+            self.delete_at = Self::calculate_delete_at(expiration_hours);
+        }
+    }
+
+    /// Apply partial updates to this transaction model
+    /// 
+    /// This method encapsulates the business logic for updating transaction fields,
+    /// ensuring consistency across all repository implementations.
+    /// 
+    /// # Arguments
+    /// * `update` - The partial update request containing the fields to update
+    pub fn apply_partial_update(&mut self, update: TransactionUpdateRequest) {
+        // Apply partial updates
+        if let Some(status) = update.status {
+            self.status = status;
+            self.update_delete_at_if_final_status();
+        }
+        if let Some(status_reason) = update.status_reason {
+            self.status_reason = Some(status_reason);
+        }
+        if let Some(sent_at) = update.sent_at {
+            self.sent_at = Some(sent_at);
+        }
+        if let Some(confirmed_at) = update.confirmed_at {
+            self.confirmed_at = Some(confirmed_at);
+        }
+        if let Some(network_data) = update.network_data {
+            self.network_data = network_data;
+        }
+        if let Some(priced_at) = update.priced_at {
+            self.priced_at = Some(priced_at);
+        }
+        if let Some(hashes) = update.hashes {
+            self.hashes = hashes;
+        }
+        if let Some(noop_count) = update.noop_count {
+            self.noop_count = Some(noop_count);
+        }
+        if let Some(is_canceled) = update.is_canceled {
+            self.is_canceled = Some(is_canceled);
+        }
+        if let Some(delete_at) = update.delete_at {
+            self.delete_at = Some(delete_at);
+        }
     }
 }
 
@@ -307,6 +370,7 @@ impl Default for TransactionRepoModel {
             sent_at: None,
             confirmed_at: None,
             valid_until: None,
+            delete_at: None,
             network_data: NetworkTransactionData::Evm(EvmTransactionData::default()),
             network_type: NetworkType::Evm,
             priced_at: None,
@@ -680,6 +744,7 @@ impl
                     sent_at: None,
                     confirmed_at: None,
                     valid_until: evm_request.valid_until.clone(),
+                    delete_at: None,
                     network_type: NetworkType::Evm,
                     network_data: NetworkTransactionData::Evm(EvmTransactionData {
                         gas_price: evm_request.gas_price,
@@ -712,6 +777,7 @@ impl
                 sent_at: None,
                 confirmed_at: None,
                 valid_until: None,
+                delete_at: None,
                 network_type: NetworkType::Solana,
                 network_data: NetworkTransactionData::Solana(SolanaTransactionData {
                     recent_blockhash: None,
@@ -753,6 +819,7 @@ impl
                     sent_at: None,
                     confirmed_at: None,
                     valid_until: None,
+                    delete_at: None,
                     network_type: NetworkType::Stellar,
                     network_data: NetworkTransactionData::Stellar(stellar_data),
                     priced_at: None,
@@ -923,7 +990,9 @@ impl From<&[u8; 65]> for EvmTransactionDataSignature {
 
 #[cfg(test)]
 mod tests {
+    use lazy_static::lazy_static;
     use soroban_rs::xdr::{BytesM, Signature, SignatureHint};
+    use std::sync::Mutex;
 
     use super::*;
     use crate::{
@@ -938,6 +1007,11 @@ mod tests {
             transaction::stellar::AssetSpec,
         },
     };
+
+    // Use a mutex to ensure tests don't run in parallel when modifying env vars
+    lazy_static! {
+        static ref ENV_MUTEX: Mutex<()> = Mutex::new(());
+    }
 
     #[test]
     fn test_signature_from_bytes() {
@@ -1736,6 +1810,7 @@ mod tests {
         assert_eq!(default_model.sent_at, None);
         assert_eq!(default_model.confirmed_at, None);
         assert_eq!(default_model.valid_until, None);
+        assert_eq!(default_model.delete_at, None);
         assert_eq!(default_model.network_type, NetworkType::Evm);
         assert_eq!(default_model.priced_at, None);
         assert_eq!(default_model.hashes.len(), 0);
@@ -2347,5 +2422,416 @@ mod tests {
         let request = NetworkTransactionRequest::Stellar(stellar_request);
         let result = TransactionRepoModel::try_from((&request, &relayer_model, &network_model));
         assert!(result.is_ok(), "Payment operation with memo should succeed");
+    }
+
+    #[test]
+    fn test_update_delete_at_if_final_status_does_not_update_when_delete_at_already_set() {
+        let _lock = match ENV_MUTEX.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+
+        use std::env;
+
+        // Set custom expiration hours for test
+        env::set_var("TRANSACTION_EXPIRATION_HOURS", "6");
+
+        let mut transaction = create_test_transaction();
+        transaction.delete_at = Some("2024-01-01T00:00:00Z".to_string());
+        transaction.status = TransactionStatus::Confirmed; // Final status
+
+        let original_delete_at = transaction.delete_at.clone();
+
+        transaction.update_delete_at_if_final_status();
+
+        // Should not change delete_at when it's already set
+        assert_eq!(transaction.delete_at, original_delete_at);
+
+        // Cleanup
+        env::remove_var("TRANSACTION_EXPIRATION_HOURS");
+    }
+
+    #[test]
+    fn test_update_delete_at_if_final_status_does_not_update_when_status_not_final() {
+        let _lock = match ENV_MUTEX.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+
+        use std::env;
+
+        // Set custom expiration hours for test
+        env::set_var("TRANSACTION_EXPIRATION_HOURS", "6");
+
+        let mut transaction = create_test_transaction();
+        transaction.delete_at = None;
+        transaction.status = TransactionStatus::Pending; // Non-final status
+
+        transaction.update_delete_at_if_final_status();
+
+        // Should not set delete_at for non-final status
+        assert!(transaction.delete_at.is_none());
+
+        // Cleanup
+        env::remove_var("TRANSACTION_EXPIRATION_HOURS");
+    }
+
+    #[test]
+    fn test_update_delete_at_if_final_status_sets_delete_at_for_final_statuses() {
+        let _lock = match ENV_MUTEX.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+
+        use crate::config::ServerConfig;
+        use chrono::{DateTime, Duration, Utc};
+        use std::env;
+
+        // Set custom expiration hours for test
+        env::set_var("TRANSACTION_EXPIRATION_HOURS", "3"); // Use 3 hours for this test
+
+        // Verify the env var is actually set correctly
+        let actual_hours = ServerConfig::get_transaction_expiration_hours();
+        assert_eq!(
+            actual_hours, 3,
+            "Environment variable should be set to 3 hours"
+        );
+
+        let final_statuses = vec![
+            TransactionStatus::Canceled,
+            TransactionStatus::Confirmed,
+            TransactionStatus::Failed,
+            TransactionStatus::Expired,
+        ];
+
+        for status in final_statuses {
+            let mut transaction = create_test_transaction();
+            transaction.delete_at = None;
+            transaction.status = status.clone();
+
+            let before_update = Utc::now();
+            transaction.update_delete_at_if_final_status();
+
+            // Should set delete_at for final status
+            assert!(
+                transaction.delete_at.is_some(),
+                "delete_at should be set for status: {:?}",
+                status
+            );
+
+            // Verify the timestamp is reasonable
+            let delete_at_str = transaction.delete_at.unwrap();
+            let delete_at = DateTime::parse_from_rfc3339(&delete_at_str)
+                .expect("delete_at should be valid RFC3339")
+                .with_timezone(&Utc);
+
+            // Should be approximately 3 hours from before_update
+            let duration_from_before = delete_at.signed_duration_since(before_update);
+            let expected_duration = Duration::hours(3);
+            let tolerance = Duration::minutes(5); // Allow 5 minutes tolerance
+
+            // Debug information
+            let actual_hours_at_runtime = ServerConfig::get_transaction_expiration_hours();
+
+            assert!(
+                duration_from_before >= expected_duration - tolerance &&
+                duration_from_before <= expected_duration + tolerance,
+                "delete_at should be approximately 3 hours from now for status: {:?}. Duration from start: {:?}, Expected: {:?}, Config hours at runtime: {}",
+                status, duration_from_before, expected_duration, actual_hours_at_runtime
+            );
+        }
+
+        // Cleanup
+        env::remove_var("TRANSACTION_EXPIRATION_HOURS");
+    }
+
+    #[test]
+    fn test_update_delete_at_if_final_status_uses_default_expiration_hours() {
+        let _lock = match ENV_MUTEX.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+
+        use chrono::{DateTime, Duration, Utc};
+        use std::env;
+
+        // Remove env var to test default behavior
+        env::remove_var("TRANSACTION_EXPIRATION_HOURS");
+
+        let mut transaction = create_test_transaction();
+        transaction.delete_at = None;
+        transaction.status = TransactionStatus::Confirmed;
+
+        let before_update = Utc::now();
+        transaction.update_delete_at_if_final_status();
+
+        // Should set delete_at using default value (4 hours)
+        assert!(transaction.delete_at.is_some());
+
+        let delete_at_str = transaction.delete_at.unwrap();
+        let delete_at = DateTime::parse_from_rfc3339(&delete_at_str)
+            .expect("delete_at should be valid RFC3339")
+            .with_timezone(&Utc);
+
+        // Should be approximately 4 hours from before_update (default value)
+        let duration_from_before = delete_at.signed_duration_since(before_update);
+        let expected_duration = Duration::hours(4);
+        let tolerance = Duration::minutes(5); // Allow 5 minutes tolerance
+
+        assert!(
+            duration_from_before >= expected_duration - tolerance &&
+            duration_from_before <= expected_duration + tolerance,
+            "delete_at should be approximately 4 hours from now (default). Duration from start: {:?}, Expected: {:?}",
+            duration_from_before, expected_duration
+        );
+    }
+
+    #[test]
+    fn test_update_delete_at_if_final_status_with_custom_expiration_hours() {
+        let _lock = match ENV_MUTEX.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+
+        use chrono::{DateTime, Duration, Utc};
+        use std::env;
+
+        // Test with various custom expiration hours
+        let test_cases = vec![1, 2, 6, 12]; // 1 hour, 2 hours, 6 hours, 12 hours
+
+        for expiration_hours in test_cases {
+            env::set_var("TRANSACTION_EXPIRATION_HOURS", expiration_hours.to_string());
+
+            let mut transaction = create_test_transaction();
+            transaction.delete_at = None;
+            transaction.status = TransactionStatus::Failed;
+
+            let before_update = Utc::now();
+            transaction.update_delete_at_if_final_status();
+
+            assert!(
+                transaction.delete_at.is_some(),
+                "delete_at should be set for {} hours",
+                expiration_hours
+            );
+
+            let delete_at_str = transaction.delete_at.unwrap();
+            let delete_at = DateTime::parse_from_rfc3339(&delete_at_str)
+                .expect("delete_at should be valid RFC3339")
+                .with_timezone(&Utc);
+
+            let duration_from_before = delete_at.signed_duration_since(before_update);
+            let expected_duration = Duration::hours(expiration_hours as i64);
+            let tolerance = Duration::minutes(5); // Allow 5 minutes tolerance
+
+            assert!(
+                duration_from_before >= expected_duration - tolerance &&
+                duration_from_before <= expected_duration + tolerance,
+                "delete_at should be approximately {} hours from now. Duration from start: {:?}, Expected: {:?}",
+                expiration_hours, duration_from_before, expected_duration
+            );
+        }
+
+        // Cleanup
+        env::remove_var("TRANSACTION_EXPIRATION_HOURS");
+    }
+
+    #[test]
+    fn test_calculate_delete_at_with_various_hours() {
+        use chrono::{DateTime, Utc};
+
+        let test_cases = vec![0, 1, 6, 12, 24, 48];
+
+        for hours in test_cases {
+            let before_calc = Utc::now();
+            let result = TransactionRepoModel::calculate_delete_at(hours);
+            let after_calc = Utc::now();
+
+            assert!(
+                result.is_some(),
+                "calculate_delete_at should return Some for {} hours",
+                hours
+            );
+
+            let delete_at_str = result.unwrap();
+            let delete_at = DateTime::parse_from_rfc3339(&delete_at_str)
+                .expect("Result should be valid RFC3339")
+                .with_timezone(&Utc);
+
+            let expected_min =
+                before_calc + chrono::Duration::hours(hours as i64) - chrono::Duration::seconds(1);
+            let expected_max =
+                after_calc + chrono::Duration::hours(hours as i64) + chrono::Duration::seconds(1);
+
+            assert!(
+                delete_at >= expected_min && delete_at <= expected_max,
+                "Calculated delete_at should be approximately {} hours from now. Got: {}, Expected between: {} and {}",
+                hours, delete_at, expected_min, expected_max
+            );
+        }
+    }
+
+    #[test]
+    fn test_update_delete_at_if_final_status_idempotent() {
+        let _lock = match ENV_MUTEX.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+
+        use std::env;
+
+        env::set_var("TRANSACTION_EXPIRATION_HOURS", "8");
+
+        let mut transaction = create_test_transaction();
+        transaction.delete_at = None;
+        transaction.status = TransactionStatus::Confirmed;
+
+        // First call should set delete_at
+        transaction.update_delete_at_if_final_status();
+        let first_delete_at = transaction.delete_at.clone();
+        assert!(first_delete_at.is_some());
+
+        // Second call should not change delete_at (idempotent)
+        transaction.update_delete_at_if_final_status();
+        assert_eq!(transaction.delete_at, first_delete_at);
+
+        // Third call should not change delete_at (idempotent)
+        transaction.update_delete_at_if_final_status();
+        assert_eq!(transaction.delete_at, first_delete_at);
+
+        // Cleanup
+        env::remove_var("TRANSACTION_EXPIRATION_HOURS");
+    }
+
+    /// Helper function to create a test transaction for testing delete_at functionality
+    fn create_test_transaction() -> TransactionRepoModel {
+        TransactionRepoModel {
+            id: "test-transaction-id".to_string(),
+            relayer_id: "test-relayer-id".to_string(),
+            status: TransactionStatus::Pending,
+            status_reason: None,
+            created_at: "2024-01-01T00:00:00Z".to_string(),
+            sent_at: None,
+            confirmed_at: None,
+            valid_until: None,
+            delete_at: None,
+            network_data: NetworkTransactionData::Evm(EvmTransactionData {
+                gas_price: None,
+                gas_limit: Some(21000),
+                nonce: Some(0),
+                value: U256::from(0),
+                data: None,
+                from: "0x1234567890123456789012345678901234567890".to_string(),
+                to: Some("0x0987654321098765432109876543210987654321".to_string()),
+                chain_id: 1,
+                hash: None,
+                signature: None,
+                speed: None,
+                max_fee_per_gas: None,
+                max_priority_fee_per_gas: None,
+                raw: None,
+            }),
+            priced_at: None,
+            hashes: vec![],
+            network_type: NetworkType::Evm,
+            noop_count: None,
+            is_canceled: None,
+        }
+    }
+
+    #[test]
+    fn test_apply_partial_update() {
+        // Create a test transaction
+        let mut transaction = create_test_transaction();
+
+        // Create a partial update request
+        let update = TransactionUpdateRequest {
+            status: Some(TransactionStatus::Confirmed),
+            status_reason: Some("Transaction confirmed".to_string()),
+            sent_at: Some("2023-01-01T12:00:00Z".to_string()),
+            confirmed_at: Some("2023-01-01T12:05:00Z".to_string()),
+            hashes: Some(vec!["0x123".to_string(), "0x456".to_string()]),
+            is_canceled: Some(false),
+            ..Default::default()
+        };
+
+        // Apply the partial update
+        transaction.apply_partial_update(update);
+
+        // Verify the updates were applied
+        assert_eq!(transaction.status, TransactionStatus::Confirmed);
+        assert_eq!(transaction.status_reason, Some("Transaction confirmed".to_string()));
+        assert_eq!(transaction.sent_at, Some("2023-01-01T12:00:00Z".to_string()));
+        assert_eq!(transaction.confirmed_at, Some("2023-01-01T12:05:00Z".to_string()));
+        assert_eq!(transaction.hashes, vec!["0x123".to_string(), "0x456".to_string()]);
+        assert_eq!(transaction.is_canceled, Some(false));
+        
+        // Verify that delete_at was set because status changed to final
+        assert!(transaction.delete_at.is_some());
+    }
+
+    #[test]
+    fn test_apply_partial_update_preserves_unchanged_fields() {
+        // Create a test transaction with initial values
+        let mut transaction = TransactionRepoModel {
+            id: "test-tx".to_string(),
+            relayer_id: "test-relayer".to_string(),
+            status: TransactionStatus::Pending,
+            status_reason: Some("Initial reason".to_string()),
+            created_at: Utc::now().to_rfc3339(),
+            sent_at: Some("2023-01-01T10:00:00Z".to_string()),
+            confirmed_at: None,
+            valid_until: None,
+            delete_at: None,
+            network_data: NetworkTransactionData::Evm(EvmTransactionData::default()),
+            priced_at: None,
+            hashes: vec!["0xoriginal".to_string()],
+            network_type: NetworkType::Evm,
+            noop_count: Some(5),
+            is_canceled: Some(true),
+        };
+
+        // Create a partial update that only changes status
+        let update = TransactionUpdateRequest {
+            status: Some(TransactionStatus::Sent),
+            ..Default::default()
+        };
+
+        // Apply the partial update
+        transaction.apply_partial_update(update);
+
+        // Verify only status changed, other fields preserved
+        assert_eq!(transaction.status, TransactionStatus::Sent);
+        assert_eq!(transaction.status_reason, Some("Initial reason".to_string()));
+        assert_eq!(transaction.sent_at, Some("2023-01-01T10:00:00Z".to_string()));
+        assert_eq!(transaction.confirmed_at, None);
+        assert_eq!(transaction.hashes, vec!["0xoriginal".to_string()]);
+        assert_eq!(transaction.noop_count, Some(5));
+        assert_eq!(transaction.is_canceled, Some(true));
+        
+        // Status is not final, so delete_at should remain None
+        assert!(transaction.delete_at.is_none());
+    }
+
+    #[test]
+    fn test_apply_partial_update_empty_update() {
+        // Create a test transaction
+        let mut transaction = create_test_transaction();
+        let original_transaction = transaction.clone();
+
+        // Apply an empty update
+        let update = TransactionUpdateRequest::default();
+        transaction.apply_partial_update(update);
+
+        // Verify nothing changed
+        assert_eq!(transaction.id, original_transaction.id);
+        assert_eq!(transaction.status, original_transaction.status);
+        assert_eq!(transaction.status_reason, original_transaction.status_reason);
+        assert_eq!(transaction.sent_at, original_transaction.sent_at);
+        assert_eq!(transaction.confirmed_at, original_transaction.confirmed_at);
+        assert_eq!(transaction.hashes, original_transaction.hashes);
+        assert_eq!(transaction.noop_count, original_transaction.noop_count);
+        assert_eq!(transaction.is_canceled, original_transaction.is_canceled);
+        assert_eq!(transaction.delete_at, original_transaction.delete_at);
     }
 }

--- a/src/models/transaction/response.rs
+++ b/src/models/transaction/response.rs
@@ -194,6 +194,7 @@ mod tests {
             network_type: NetworkType::Evm,
             noop_count: None,
             is_canceled: Some(false),
+            delete_at: None,
         };
 
         let response = TransactionResponse::from(model.clone());
@@ -241,6 +242,7 @@ mod tests {
             network_type: NetworkType::Solana,
             noop_count: None,
             is_canceled: Some(false),
+            delete_at: None,
         };
 
         let response = TransactionResponse::from(model.clone());
@@ -290,6 +292,7 @@ mod tests {
             network_type: NetworkType::Stellar,
             noop_count: None,
             is_canceled: Some(false),
+            delete_at: None,
         };
 
         let response = TransactionResponse::from(model.clone());
@@ -343,6 +346,7 @@ mod tests {
             network_type: NetworkType::Stellar,
             noop_count: None,
             is_canceled: Some(false),
+            delete_at: None,
         };
 
         let response = TransactionResponse::from(model.clone());
@@ -386,6 +390,7 @@ mod tests {
             network_type: NetworkType::Solana,
             noop_count: None,
             is_canceled: Some(false),
+            delete_at: None,
         };
 
         let response = TransactionResponse::from(model);

--- a/src/repositories/transaction/mod.rs
+++ b/src/repositories/transaction/mod.rs
@@ -388,6 +388,7 @@ mod tests {
             hashes: Some(vec!["test_hash".to_string()]),
             noop_count: None,
             is_canceled: None,
+            delete_at: None,
         }
     }
 

--- a/src/repositories/transaction/transaction_in_memory.rs
+++ b/src/repositories/transaction/transaction_in_memory.rs
@@ -307,17 +307,17 @@ impl Default for InMemoryTransactionRepository {
 mod tests {
     use crate::models::{evm::Speed, EvmTransactionData, NetworkType};
     use lazy_static::lazy_static;
-    use std::{str::FromStr, sync::Mutex};
+    use std::str::FromStr;
 
     use crate::models::U256;
 
     use super::*;
 
-    // Use a mutex to ensure tests don't run in parallel when modifying env vars
+    use tokio::sync::Mutex;
+
     lazy_static! {
         static ref ENV_MUTEX: Mutex<()> = Mutex::new(());
     }
-
     // Helper function to create test transactions
     fn create_test_transaction(id: &str) -> TransactionRepoModel {
         TransactionRepoModel {
@@ -949,10 +949,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_update_status_sets_delete_at_for_final_statuses() {
-        let _lock = match ENV_MUTEX.lock() {
-            Ok(guard) => guard,
-            Err(poisoned) => poisoned.into_inner(),
-        };
+        let _lock = ENV_MUTEX.lock().await;
 
         use chrono::{DateTime, Duration, Utc};
         use std::env;
@@ -962,7 +959,7 @@ mod tests {
 
         let repo = InMemoryTransactionRepository::new();
 
-        let final_statuses = vec![
+        let final_statuses = [
             TransactionStatus::Canceled,
             TransactionStatus::Confirmed,
             TransactionStatus::Failed,
@@ -1017,10 +1014,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_update_status_does_not_set_delete_at_for_non_final_statuses() {
-        let _lock = match ENV_MUTEX.lock() {
-            Ok(guard) => guard,
-            Err(poisoned) => poisoned.into_inner(),
-        };
+        let _lock = ENV_MUTEX.lock().await;
 
         use std::env;
 
@@ -1028,7 +1022,7 @@ mod tests {
 
         let repo = InMemoryTransactionRepository::new();
 
-        let non_final_statuses = vec![
+        let non_final_statuses = [
             TransactionStatus::Pending,
             TransactionStatus::Sent,
             TransactionStatus::Submitted,
@@ -1061,10 +1055,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_partial_update_sets_delete_at_for_final_statuses() {
-        let _lock = match ENV_MUTEX.lock() {
-            Ok(guard) => guard,
-            Err(poisoned) => poisoned.into_inner(),
-        };
+        let _lock = ENV_MUTEX.lock().await;
 
         use chrono::{DateTime, Duration, Utc};
         use std::env;
@@ -1131,10 +1122,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_update_status_preserves_existing_delete_at() {
-        let _lock = match ENV_MUTEX.lock() {
-            Ok(guard) => guard,
-            Err(poisoned) => poisoned.into_inner(),
-        };
+        let _lock = ENV_MUTEX.lock().await;
 
         use std::env;
 
@@ -1171,10 +1159,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_partial_update_without_status_change_preserves_delete_at() {
-        let _lock = match ENV_MUTEX.lock() {
-            Ok(guard) => guard,
-            Err(poisoned) => poisoned.into_inner(),
-        };
+        let _lock = ENV_MUTEX.lock().await;
 
         use std::env;
 
@@ -1230,10 +1215,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_update_status_multiple_updates_idempotent() {
-        let _lock = match ENV_MUTEX.lock() {
-            Ok(guard) => guard,
-            Err(poisoned) => poisoned.into_inner(),
-        };
+        let _lock = ENV_MUTEX.lock().await;
 
         use std::env;
 

--- a/src/repositories/transaction/transaction_in_memory.rs
+++ b/src/repositories/transaction/transaction_in_memory.rs
@@ -240,9 +240,11 @@ impl TransactionRepository for InMemoryTransactionRepository {
         tx_id: String,
         status: TransactionStatus,
     ) -> Result<TransactionRepoModel, RepositoryError> {
-        let mut tx = self.get_by_id(tx_id.clone()).await?;
-        tx.status = status;
-        self.update(tx_id, tx).await
+        let update = TransactionUpdateRequest {
+            status: Some(status),
+            ..Default::default()
+        };
+        self.partial_update(tx_id, update).await
     }
 
     async fn partial_update(
@@ -253,27 +255,8 @@ impl TransactionRepository for InMemoryTransactionRepository {
         let mut store = Self::acquire_lock(&self.store).await?;
 
         if let Some(tx) = store.get_mut(&tx_id) {
-            if let Some(status) = update.status {
-                tx.status = status;
-            }
-            if let Some(status_reason) = update.status_reason {
-                tx.status_reason = Some(status_reason);
-            }
-            if let Some(sent_at) = update.sent_at {
-                tx.sent_at = Some(sent_at);
-            }
-            if let Some(confirmed_at) = update.confirmed_at {
-                tx.confirmed_at = Some(confirmed_at);
-            }
-            if let Some(network_data) = update.network_data {
-                tx.network_data = network_data;
-            }
-            if let Some(hashes) = update.hashes {
-                tx.hashes = hashes;
-            }
-            if let Some(is_canceled) = update.is_canceled {
-                tx.is_canceled = Some(is_canceled);
-            }
+            // Apply partial updates using the model's business logic
+            tx.apply_partial_update(update);
             Ok(tx.clone())
         } else {
             Err(RepositoryError::NotFound(format!(
@@ -323,11 +306,17 @@ impl Default for InMemoryTransactionRepository {
 #[cfg(test)]
 mod tests {
     use crate::models::{evm::Speed, EvmTransactionData, NetworkType};
-    use std::str::FromStr;
+    use lazy_static::lazy_static;
+    use std::{str::FromStr, sync::Mutex};
 
     use crate::models::U256;
 
     use super::*;
+
+    // Use a mutex to ensure tests don't run in parallel when modifying env vars
+    lazy_static! {
+        static ref ENV_MUTEX: Mutex<()> = Mutex::new(());
+    }
 
     // Helper function to create test transactions
     fn create_test_transaction(id: &str) -> TransactionRepoModel {
@@ -340,6 +329,7 @@ mod tests {
             sent_at: Some("2025-01-27T15:31:10.777083+00:00".to_string()),
             confirmed_at: Some("2025-01-27T15:31:10.777083+00:00".to_string()),
             valid_until: None,
+            delete_at: None,
             network_type: NetworkType::Evm,
             priced_at: None,
             hashes: vec![],
@@ -374,6 +364,7 @@ mod tests {
             sent_at: None,
             confirmed_at: None,
             valid_until: None,
+            delete_at: None,
             network_type: NetworkType::Evm,
             priced_at: None,
             hashes: vec![],
@@ -516,6 +507,7 @@ mod tests {
             priced_at: None,
             noop_count: None,
             is_canceled: None,
+            delete_at: None,
         };
         let updated_tx1 = repo
             .partial_update("test-tx-id".to_string(), update1)
@@ -535,6 +527,7 @@ mod tests {
             priced_at: None,
             noop_count: None,
             is_canceled: None,
+            delete_at: None,
         };
         let updated_tx2 = repo
             .partial_update("test-tx-id".to_string(), update2)
@@ -561,6 +554,7 @@ mod tests {
             priced_at: None,
             noop_count: None,
             is_canceled: None,
+            delete_at: None,
         };
         let result = repo
             .partial_update("non-existent-id".to_string(), update3)
@@ -949,5 +943,332 @@ mod tests {
 
         repo.drop_all_entries().await.unwrap();
         assert!(!repo.has_entries().await.unwrap());
+    }
+
+    // Tests for delete_at field setting on final status updates
+
+    #[tokio::test]
+    async fn test_update_status_sets_delete_at_for_final_statuses() {
+        let _lock = match ENV_MUTEX.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+
+        use chrono::{DateTime, Duration, Utc};
+        use std::env;
+
+        // Use a unique test environment variable to avoid conflicts
+        env::set_var("TRANSACTION_EXPIRATION_HOURS", "6");
+
+        let repo = InMemoryTransactionRepository::new();
+
+        let final_statuses = vec![
+            TransactionStatus::Canceled,
+            TransactionStatus::Confirmed,
+            TransactionStatus::Failed,
+            TransactionStatus::Expired,
+        ];
+
+        for (i, status) in final_statuses.iter().enumerate() {
+            let tx_id = format!("test-final-{}", i);
+            let tx = create_test_transaction_pending_state(&tx_id);
+
+            // Ensure transaction has no delete_at initially
+            assert!(tx.delete_at.is_none());
+
+            repo.create(tx).await.unwrap();
+
+            let before_update = Utc::now();
+
+            // Update to final status
+            let updated = repo
+                .update_status(tx_id.clone(), status.clone())
+                .await
+                .unwrap();
+
+            // Should have delete_at set
+            assert!(
+                updated.delete_at.is_some(),
+                "delete_at should be set for status: {:?}",
+                status
+            );
+
+            // Verify the timestamp is reasonable (approximately 6 hours from now)
+            let delete_at_str = updated.delete_at.unwrap();
+            let delete_at = DateTime::parse_from_rfc3339(&delete_at_str)
+                .expect("delete_at should be valid RFC3339")
+                .with_timezone(&Utc);
+
+            let duration_from_before = delete_at.signed_duration_since(before_update);
+            let expected_duration = Duration::hours(6);
+            let tolerance = Duration::minutes(5);
+
+            assert!(
+                duration_from_before >= expected_duration - tolerance &&
+                duration_from_before <= expected_duration + tolerance,
+                "delete_at should be approximately 6 hours from now for status: {:?}. Duration: {:?}",
+                status, duration_from_before
+            );
+        }
+
+        // Cleanup
+        env::remove_var("TRANSACTION_EXPIRATION_HOURS");
+    }
+
+    #[tokio::test]
+    async fn test_update_status_does_not_set_delete_at_for_non_final_statuses() {
+        let _lock = match ENV_MUTEX.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+
+        use std::env;
+
+        env::set_var("TRANSACTION_EXPIRATION_HOURS", "4");
+
+        let repo = InMemoryTransactionRepository::new();
+
+        let non_final_statuses = vec![
+            TransactionStatus::Pending,
+            TransactionStatus::Sent,
+            TransactionStatus::Submitted,
+            TransactionStatus::Mined,
+        ];
+
+        for (i, status) in non_final_statuses.iter().enumerate() {
+            let tx_id = format!("test-non-final-{}", i);
+            let tx = create_test_transaction_pending_state(&tx_id);
+
+            repo.create(tx).await.unwrap();
+
+            // Update to non-final status
+            let updated = repo
+                .update_status(tx_id.clone(), status.clone())
+                .await
+                .unwrap();
+
+            // Should NOT have delete_at set
+            assert!(
+                updated.delete_at.is_none(),
+                "delete_at should NOT be set for status: {:?}",
+                status
+            );
+        }
+
+        // Cleanup
+        env::remove_var("TRANSACTION_EXPIRATION_HOURS");
+    }
+
+    #[tokio::test]
+    async fn test_partial_update_sets_delete_at_for_final_statuses() {
+        let _lock = match ENV_MUTEX.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+
+        use chrono::{DateTime, Duration, Utc};
+        use std::env;
+
+        env::set_var("TRANSACTION_EXPIRATION_HOURS", "8");
+
+        let repo = InMemoryTransactionRepository::new();
+        let tx = create_test_transaction_pending_state("test-partial-final");
+
+        repo.create(tx).await.unwrap();
+
+        let before_update = Utc::now();
+
+        // Use partial_update to set status to Confirmed (final status)
+        let update = TransactionUpdateRequest {
+            status: Some(TransactionStatus::Confirmed),
+            status_reason: Some("Transaction completed".to_string()),
+            confirmed_at: Some("2023-01-01T12:05:00Z".to_string()),
+            ..Default::default()
+        };
+
+        let updated = repo
+            .partial_update("test-partial-final".to_string(), update)
+            .await
+            .unwrap();
+
+        // Should have delete_at set
+        assert!(
+            updated.delete_at.is_some(),
+            "delete_at should be set when updating to Confirmed status"
+        );
+
+        // Verify the timestamp is reasonable (approximately 8 hours from now)
+        let delete_at_str = updated.delete_at.unwrap();
+        let delete_at = DateTime::parse_from_rfc3339(&delete_at_str)
+            .expect("delete_at should be valid RFC3339")
+            .with_timezone(&Utc);
+
+        let duration_from_before = delete_at.signed_duration_since(before_update);
+        let expected_duration = Duration::hours(8);
+        let tolerance = Duration::minutes(5);
+
+        assert!(
+            duration_from_before >= expected_duration - tolerance
+                && duration_from_before <= expected_duration + tolerance,
+            "delete_at should be approximately 8 hours from now. Duration: {:?}",
+            duration_from_before
+        );
+
+        // Also verify other fields were updated
+        assert_eq!(updated.status, TransactionStatus::Confirmed);
+        assert_eq!(
+            updated.status_reason,
+            Some("Transaction completed".to_string())
+        );
+        assert_eq!(
+            updated.confirmed_at,
+            Some("2023-01-01T12:05:00Z".to_string())
+        );
+
+        // Cleanup
+        env::remove_var("TRANSACTION_EXPIRATION_HOURS");
+    }
+
+    #[tokio::test]
+    async fn test_update_status_preserves_existing_delete_at() {
+        let _lock = match ENV_MUTEX.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+
+        use std::env;
+
+        env::set_var("TRANSACTION_EXPIRATION_HOURS", "2");
+
+        let repo = InMemoryTransactionRepository::new();
+        let mut tx = create_test_transaction_pending_state("test-preserve-delete-at");
+
+        // Set an existing delete_at value
+        let existing_delete_at = "2025-01-01T12:00:00Z".to_string();
+        tx.delete_at = Some(existing_delete_at.clone());
+
+        repo.create(tx).await.unwrap();
+
+        // Update to final status
+        let updated = repo
+            .update_status(
+                "test-preserve-delete-at".to_string(),
+                TransactionStatus::Confirmed,
+            )
+            .await
+            .unwrap();
+
+        // Should preserve the existing delete_at value
+        assert_eq!(
+            updated.delete_at,
+            Some(existing_delete_at),
+            "Existing delete_at should be preserved when updating to final status"
+        );
+
+        // Cleanup
+        env::remove_var("TRANSACTION_EXPIRATION_HOURS");
+    }
+
+    #[tokio::test]
+    async fn test_partial_update_without_status_change_preserves_delete_at() {
+        let _lock = match ENV_MUTEX.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+
+        use std::env;
+
+        env::set_var("TRANSACTION_EXPIRATION_HOURS", "3");
+
+        let repo = InMemoryTransactionRepository::new();
+        let tx = create_test_transaction_pending_state("test-preserve-no-status");
+
+        repo.create(tx).await.unwrap();
+
+        // First, update to final status to set delete_at
+        let updated1 = repo
+            .update_status(
+                "test-preserve-no-status".to_string(),
+                TransactionStatus::Confirmed,
+            )
+            .await
+            .unwrap();
+
+        assert!(updated1.delete_at.is_some());
+        let original_delete_at = updated1.delete_at.clone();
+
+        // Now update other fields without changing status
+        let update = TransactionUpdateRequest {
+            status: None, // No status change
+            status_reason: Some("Updated reason".to_string()),
+            confirmed_at: Some("2023-01-01T12:10:00Z".to_string()),
+            ..Default::default()
+        };
+
+        let updated2 = repo
+            .partial_update("test-preserve-no-status".to_string(), update)
+            .await
+            .unwrap();
+
+        // delete_at should be preserved
+        assert_eq!(
+            updated2.delete_at, original_delete_at,
+            "delete_at should be preserved when status is not updated"
+        );
+
+        // Other fields should be updated
+        assert_eq!(updated2.status, TransactionStatus::Confirmed); // Unchanged
+        assert_eq!(updated2.status_reason, Some("Updated reason".to_string()));
+        assert_eq!(
+            updated2.confirmed_at,
+            Some("2023-01-01T12:10:00Z".to_string())
+        );
+
+        // Cleanup
+        env::remove_var("TRANSACTION_EXPIRATION_HOURS");
+    }
+
+    #[tokio::test]
+    async fn test_update_status_multiple_updates_idempotent() {
+        let _lock = match ENV_MUTEX.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+
+        use std::env;
+
+        env::set_var("TRANSACTION_EXPIRATION_HOURS", "12");
+
+        let repo = InMemoryTransactionRepository::new();
+        let tx = create_test_transaction_pending_state("test-idempotent");
+
+        repo.create(tx).await.unwrap();
+
+        // First update to final status
+        let updated1 = repo
+            .update_status("test-idempotent".to_string(), TransactionStatus::Confirmed)
+            .await
+            .unwrap();
+
+        assert!(updated1.delete_at.is_some());
+        let first_delete_at = updated1.delete_at.clone();
+
+        // Second update to another final status
+        let updated2 = repo
+            .update_status("test-idempotent".to_string(), TransactionStatus::Failed)
+            .await
+            .unwrap();
+
+        // delete_at should remain the same (idempotent)
+        assert_eq!(
+            updated2.delete_at, first_delete_at,
+            "delete_at should not change on subsequent final status updates"
+        );
+
+        // Status should be updated
+        assert_eq!(updated2.status, TransactionStatus::Failed);
+
+        // Cleanup
+        env::remove_var("TRANSACTION_EXPIRATION_HOURS");
     }
 }

--- a/src/repositories/transaction/transaction_redis.rs
+++ b/src/repositories/transaction/transaction_redis.rs
@@ -895,28 +895,8 @@ impl TransactionRepository for RedisTransactionRepository {
         let mut tx = self.get_by_id(tx_id.clone()).await?;
         let old_tx = tx.clone(); // Keep copy for index updates
 
-        // Apply partial updates
-        if let Some(status) = update.status {
-            tx.status = status;
-        }
-        if let Some(status_reason) = update.status_reason {
-            tx.status_reason = Some(status_reason);
-        }
-        if let Some(sent_at) = update.sent_at {
-            tx.sent_at = Some(sent_at);
-        }
-        if let Some(confirmed_at) = update.confirmed_at {
-            tx.confirmed_at = Some(confirmed_at);
-        }
-        if let Some(network_data) = update.network_data {
-            tx.network_data = network_data;
-        }
-        if let Some(hashes) = update.hashes {
-            tx.hashes = hashes;
-        }
-        if let Some(is_canceled) = update.is_canceled {
-            tx.is_canceled = Some(is_canceled);
-        }
+        // Apply partial updates using the model's business logic
+        tx.apply_partial_update(update);
 
         // Update transaction and indexes atomically
         let key = self.tx_key(&tx.relayer_id, &tx_id);
@@ -975,10 +955,16 @@ mod tests {
     use super::*;
     use crate::models::{evm::Speed, EvmTransactionData, NetworkType};
     use alloy::primitives::U256;
+    use lazy_static::lazy_static;
     use redis::Client;
-    use std::str::FromStr;
+    use std::{str::FromStr, sync::Mutex};
     use tokio;
     use uuid::Uuid;
+
+    // Use a mutex to ensure tests don't run in parallel when modifying env vars
+    lazy_static! {
+        static ref ENV_MUTEX: Mutex<()> = Mutex::new(());
+    }
 
     // Helper function to create test transactions
     fn create_test_transaction(id: &str) -> TransactionRepoModel {
@@ -991,6 +977,7 @@ mod tests {
             sent_at: Some("2025-01-27T15:31:10.777083+00:00".to_string()),
             confirmed_at: Some("2025-01-27T15:31:10.777083+00:00".to_string()),
             valid_until: None,
+            delete_at: None,
             network_type: NetworkType::Evm,
             priced_at: None,
             hashes: vec![],
@@ -1439,6 +1426,7 @@ mod tests {
             is_canceled: None,
             priced_at: None,
             noop_count: None,
+            delete_at: None,
         };
 
         let updated = repo
@@ -1632,5 +1620,290 @@ mod tests {
 
         repo.drop_all_entries().await.unwrap();
         assert!(!repo.has_entries().await.unwrap());
+    }
+
+    // Tests for delete_at field setting on final status updates
+    #[tokio::test]
+    #[ignore = "Requires active Redis instance"]
+    async fn test_update_status_sets_delete_at_for_final_statuses() {
+        let _lock = match ENV_MUTEX.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+
+        use chrono::{DateTime, Duration, Utc};
+        use std::env;
+
+        // Use a unique test environment variable to avoid conflicts
+        env::set_var("TRANSACTION_EXPIRATION_HOURS", "6");
+
+        let repo = setup_test_repo().await;
+
+        let final_statuses = vec![
+            TransactionStatus::Canceled,
+            TransactionStatus::Confirmed,
+            TransactionStatus::Failed,
+            TransactionStatus::Expired,
+        ];
+
+        for (i, status) in final_statuses.iter().enumerate() {
+            let tx_id = format!("test-final-{}-{}", i, Uuid::new_v4());
+            let mut tx = create_test_transaction(&tx_id);
+
+            // Ensure transaction has no delete_at initially and is in pending state
+            tx.delete_at = None;
+            tx.status = TransactionStatus::Pending;
+
+            repo.create(tx).await.unwrap();
+
+            let before_update = Utc::now();
+
+            // Update to final status
+            let updated = repo
+                .update_status(tx_id.clone(), status.clone())
+                .await
+                .unwrap();
+
+            // Should have delete_at set
+            assert!(
+                updated.delete_at.is_some(),
+                "delete_at should be set for status: {:?}",
+                status
+            );
+
+            // Verify the timestamp is reasonable (approximately 6 hours from now)
+            let delete_at_str = updated.delete_at.unwrap();
+            let delete_at = DateTime::parse_from_rfc3339(&delete_at_str)
+                .expect("delete_at should be valid RFC3339")
+                .with_timezone(&Utc);
+
+            let duration_from_before = delete_at.signed_duration_since(before_update);
+            let expected_duration = Duration::hours(6);
+            let tolerance = Duration::minutes(5);
+
+            assert!(
+                duration_from_before >= expected_duration - tolerance &&
+                duration_from_before <= expected_duration + tolerance,
+                "delete_at should be approximately 6 hours from now for status: {:?}. Duration: {:?}",
+                status, duration_from_before
+            );
+        }
+
+        // Cleanup
+        env::remove_var("TRANSACTION_EXPIRATION_HOURS");
+    }
+
+    #[tokio::test]
+    #[ignore = "Requires active Redis instance"]
+    async fn test_update_status_does_not_set_delete_at_for_non_final_statuses() {
+        let _lock = match ENV_MUTEX.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+
+        use std::env;
+
+        env::set_var("TRANSACTION_EXPIRATION_HOURS", "4");
+
+        let repo = setup_test_repo().await;
+
+        let non_final_statuses = vec![
+            TransactionStatus::Pending,
+            TransactionStatus::Sent,
+            TransactionStatus::Submitted,
+            TransactionStatus::Mined,
+        ];
+
+        for (i, status) in non_final_statuses.iter().enumerate() {
+            let tx_id = format!("test-non-final-{}-{}", i, Uuid::new_v4());
+            let mut tx = create_test_transaction(&tx_id);
+            tx.delete_at = None;
+            tx.status = TransactionStatus::Pending;
+
+            repo.create(tx).await.unwrap();
+
+            // Update to non-final status
+            let updated = repo
+                .update_status(tx_id.clone(), status.clone())
+                .await
+                .unwrap();
+
+            // Should NOT have delete_at set
+            assert!(
+                updated.delete_at.is_none(),
+                "delete_at should NOT be set for status: {:?}",
+                status
+            );
+        }
+
+        // Cleanup
+        env::remove_var("TRANSACTION_EXPIRATION_HOURS");
+    }
+
+    #[tokio::test]
+    #[ignore = "Requires active Redis instance"]
+    async fn test_partial_update_sets_delete_at_for_final_statuses() {
+        let _lock = match ENV_MUTEX.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+
+        use chrono::{DateTime, Duration, Utc};
+        use std::env;
+
+        env::set_var("TRANSACTION_EXPIRATION_HOURS", "8");
+
+        let repo = setup_test_repo().await;
+        let tx_id = format!("test-partial-final-{}", Uuid::new_v4());
+        let mut tx = create_test_transaction(&tx_id);
+        tx.delete_at = None;
+        tx.status = TransactionStatus::Pending;
+
+        repo.create(tx).await.unwrap();
+
+        let before_update = Utc::now();
+
+        // Use partial_update to set status to Confirmed (final status)
+        let update = TransactionUpdateRequest {
+            status: Some(TransactionStatus::Confirmed),
+            status_reason: Some("Transaction completed".to_string()),
+            confirmed_at: Some("2023-01-01T12:05:00Z".to_string()),
+            ..Default::default()
+        };
+
+        let updated = repo.partial_update(tx_id.clone(), update).await.unwrap();
+
+        // Should have delete_at set
+        assert!(
+            updated.delete_at.is_some(),
+            "delete_at should be set when updating to Confirmed status"
+        );
+
+        // Verify the timestamp is reasonable (approximately 8 hours from now)
+        let delete_at_str = updated.delete_at.unwrap();
+        let delete_at = DateTime::parse_from_rfc3339(&delete_at_str)
+            .expect("delete_at should be valid RFC3339")
+            .with_timezone(&Utc);
+
+        let duration_from_before = delete_at.signed_duration_since(before_update);
+        let expected_duration = Duration::hours(8);
+        let tolerance = Duration::minutes(5);
+
+        assert!(
+            duration_from_before >= expected_duration - tolerance
+                && duration_from_before <= expected_duration + tolerance,
+            "delete_at should be approximately 8 hours from now. Duration: {:?}",
+            duration_from_before
+        );
+
+        // Also verify other fields were updated
+        assert_eq!(updated.status, TransactionStatus::Confirmed);
+        assert_eq!(
+            updated.status_reason,
+            Some("Transaction completed".to_string())
+        );
+        assert_eq!(
+            updated.confirmed_at,
+            Some("2023-01-01T12:05:00Z".to_string())
+        );
+
+        // Cleanup
+        env::remove_var("TRANSACTION_EXPIRATION_HOURS");
+    }
+
+    #[tokio::test]
+    #[ignore = "Requires active Redis instance"]
+    async fn test_update_status_preserves_existing_delete_at() {
+        let _lock = match ENV_MUTEX.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+
+        use std::env;
+
+        env::set_var("TRANSACTION_EXPIRATION_HOURS", "2");
+
+        let repo = setup_test_repo().await;
+        let tx_id = format!("test-preserve-delete-at-{}", Uuid::new_v4());
+        let mut tx = create_test_transaction(&tx_id);
+
+        // Set an existing delete_at value
+        let existing_delete_at = "2025-01-01T12:00:00Z".to_string();
+        tx.delete_at = Some(existing_delete_at.clone());
+        tx.status = TransactionStatus::Pending;
+
+        repo.create(tx).await.unwrap();
+
+        // Update to final status
+        let updated = repo
+            .update_status(tx_id.clone(), TransactionStatus::Confirmed)
+            .await
+            .unwrap();
+
+        // Should preserve the existing delete_at value
+        assert_eq!(
+            updated.delete_at,
+            Some(existing_delete_at),
+            "Existing delete_at should be preserved when updating to final status"
+        );
+
+        // Cleanup
+        env::remove_var("TRANSACTION_EXPIRATION_HOURS");
+    }
+    #[tokio::test]
+    #[ignore = "Requires active Redis instance"]
+    async fn test_partial_update_without_status_change_preserves_delete_at() {
+        let _lock = match ENV_MUTEX.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+
+        use std::env;
+
+        env::set_var("TRANSACTION_EXPIRATION_HOURS", "3");
+
+        let repo = setup_test_repo().await;
+        let tx_id = format!("test-preserve-no-status-{}", Uuid::new_v4());
+        let mut tx = create_test_transaction(&tx_id);
+        tx.delete_at = None;
+        tx.status = TransactionStatus::Pending;
+
+        repo.create(tx).await.unwrap();
+
+        // First, update to final status to set delete_at
+        let updated1 = repo
+            .update_status(tx_id.clone(), TransactionStatus::Confirmed)
+            .await
+            .unwrap();
+
+        assert!(updated1.delete_at.is_some());
+        let original_delete_at = updated1.delete_at.clone();
+
+        // Now update other fields without changing status
+        let update = TransactionUpdateRequest {
+            status: None, // No status change
+            status_reason: Some("Updated reason".to_string()),
+            confirmed_at: Some("2023-01-01T12:10:00Z".to_string()),
+            ..Default::default()
+        };
+
+        let updated2 = repo.partial_update(tx_id.clone(), update).await.unwrap();
+
+        // delete_at should be preserved
+        assert_eq!(
+            updated2.delete_at, original_delete_at,
+            "delete_at should be preserved when status is not updated"
+        );
+
+        // Other fields should be updated
+        assert_eq!(updated2.status, TransactionStatus::Confirmed); // Unchanged
+        assert_eq!(updated2.status_reason, Some("Updated reason".to_string()));
+        assert_eq!(
+            updated2.confirmed_at,
+            Some("2023-01-01T12:10:00Z".to_string())
+        );
+
+        // Cleanup
+        env::remove_var("TRANSACTION_EXPIRATION_HOURS");
     }
 }

--- a/src/repositories/transaction/transaction_redis.rs
+++ b/src/repositories/transaction/transaction_redis.rs
@@ -957,9 +957,11 @@ mod tests {
     use alloy::primitives::U256;
     use lazy_static::lazy_static;
     use redis::Client;
-    use std::{str::FromStr, sync::Mutex};
+    use std::str::FromStr;
     use tokio;
     use uuid::Uuid;
+
+    use tokio::sync::Mutex;
 
     // Use a mutex to ensure tests don't run in parallel when modifying env vars
     lazy_static! {
@@ -1626,10 +1628,7 @@ mod tests {
     #[tokio::test]
     #[ignore = "Requires active Redis instance"]
     async fn test_update_status_sets_delete_at_for_final_statuses() {
-        let _lock = match ENV_MUTEX.lock() {
-            Ok(guard) => guard,
-            Err(poisoned) => poisoned.into_inner(),
-        };
+        let _lock = ENV_MUTEX.lock().await;
 
         use chrono::{DateTime, Duration, Utc};
         use std::env;
@@ -1639,7 +1638,7 @@ mod tests {
 
         let repo = setup_test_repo().await;
 
-        let final_statuses = vec![
+        let final_statuses = [
             TransactionStatus::Canceled,
             TransactionStatus::Confirmed,
             TransactionStatus::Failed,
@@ -1696,10 +1695,7 @@ mod tests {
     #[tokio::test]
     #[ignore = "Requires active Redis instance"]
     async fn test_update_status_does_not_set_delete_at_for_non_final_statuses() {
-        let _lock = match ENV_MUTEX.lock() {
-            Ok(guard) => guard,
-            Err(poisoned) => poisoned.into_inner(),
-        };
+        let _lock = ENV_MUTEX.lock().await;
 
         use std::env;
 
@@ -1707,7 +1703,7 @@ mod tests {
 
         let repo = setup_test_repo().await;
 
-        let non_final_statuses = vec![
+        let non_final_statuses = [
             TransactionStatus::Pending,
             TransactionStatus::Sent,
             TransactionStatus::Submitted,
@@ -1743,10 +1739,7 @@ mod tests {
     #[tokio::test]
     #[ignore = "Requires active Redis instance"]
     async fn test_partial_update_sets_delete_at_for_final_statuses() {
-        let _lock = match ENV_MUTEX.lock() {
-            Ok(guard) => guard,
-            Err(poisoned) => poisoned.into_inner(),
-        };
+        let _lock = ENV_MUTEX.lock().await;
 
         use chrono::{DateTime, Duration, Utc};
         use std::env;
@@ -1814,10 +1807,7 @@ mod tests {
     #[tokio::test]
     #[ignore = "Requires active Redis instance"]
     async fn test_update_status_preserves_existing_delete_at() {
-        let _lock = match ENV_MUTEX.lock() {
-            Ok(guard) => guard,
-            Err(poisoned) => poisoned.into_inner(),
-        };
+        let _lock = ENV_MUTEX.lock().await;
 
         use std::env;
 
@@ -1853,10 +1843,7 @@ mod tests {
     #[tokio::test]
     #[ignore = "Requires active Redis instance"]
     async fn test_partial_update_without_status_change_preserves_delete_at() {
-        let _lock = match ENV_MUTEX.lock() {
-            Ok(guard) => guard,
-            Err(poisoned) => poisoned.into_inner(),
-        };
+        let _lock = ENV_MUTEX.lock().await;
 
         use std::env;
 

--- a/src/utils/mocks.rs
+++ b/src/utils/mocks.rs
@@ -96,6 +96,7 @@ pub mod mockutils {
             sent_at: None,
             confirmed_at: None,
             valid_until: None,
+            delete_at: None,
             network_data: NetworkTransactionData::Evm(EvmTransactionData::default()),
             priced_at: None,
             hashes: vec![],
@@ -229,6 +230,7 @@ pub mod mockutils {
             storage_encryption_key: Some(SecretString::new(
                 "test_encryption_key_1234567890_test_key_32",
             )),
+            transaction_expiration_hours: 4,
         }
     }
 }

--- a/tests/integration/metrics.rs
+++ b/tests/integration/metrics.rs
@@ -31,6 +31,7 @@ async fn test_authorization_middleware_success() {
         repository_storage_type: RepositoryStorageType::InMemory,
         reset_storage_on_start: false,
         storage_encryption_key: None,
+        transaction_expiration_hours: 4,
     });
 
     let app = test::init_service(
@@ -88,6 +89,7 @@ async fn test_authorization_middleware_failure() {
         repository_storage_type: RepositoryStorageType::InMemory,
         reset_storage_on_start: false,
         storage_encryption_key: None,
+        transaction_expiration_hours: 4,
     });
 
     let app = test::init_service(


### PR DESCRIPTION
# Summary

This PR will:
- extend transaction repository model with `delete_at` field.
- implement logic to set  `delete_at` field value once transaction is in one of final statuses
- introduce new env var for setting transaction deletion time(default to 4 hours after reaching one of final statuses)
- introduce new async job for for iterating over relayer and transactions for cleaning up/removing from storage

## Testing Process

## Checklist

- [ ] Add a reference to related issues in the PR description.
- [ ] Add unit tests if applicable.
