### PR TITLE
chore: Change optimism tag

### DIFF
--- a/config/networks/optimism.json
+++ b/config/networks/optimism.json
@@ -23,7 +23,7 @@
       "symbol": "ETH",
       "tags": [
         "rollup",
-        "optimism"
+        "optimism-based"
       ],
       "type": "evm"
     },
@@ -50,7 +50,7 @@
       "tags": [
         "deprecated",
         "rollup",
-        "optimism"
+        "optimism-based"
       ],
       "type": "evm"
     },

--- a/docs/modules/ROOT/pages/network_configuration.adoc
+++ b/docs/modules/ROOT/pages/network_configuration.adoc
@@ -170,7 +170,7 @@ Some tags have special meaning and affect relayer behavior:
 |`rollup`
 |Identifies Layer 2 rollup networks (e.g., Arbitrum, Optimism, Base)
 
-|`optimism`
+|`optimism-based`
 |Identifies Optimism-based networks using the OP Stack (e.g., Optimism, Base, World Chain)
 
 |`arbitrum-based`
@@ -323,7 +323,7 @@ Here's an example showing a Stellar network configuration with passphrase:
     "https://optimism.drpc.org"
   ],
   "features": ["eip1559"],
-  "tags": ["rollup", "optimism"],
+  "tags": ["rollup", "optimism-based"],
   "average_blocktime_ms": 2000,
   "is_testnet": false
 }

--- a/src/models/network/evm/network.rs
+++ b/src/models/network/evm/network.rs
@@ -93,7 +93,7 @@ impl TryFrom<NetworkRepoModel> for EvmNetwork {
 
 impl EvmNetwork {
     pub fn is_optimism(&self) -> bool {
-        self.tags.contains(&"optimism".to_string())
+        self.tags.contains(&"optimism-based".to_string())
     }
 
     pub fn is_rollup(&self) -> bool {


### PR DESCRIPTION
# Summary
Change optimism tag from `optimism` to `optimism-based` to align with `arbitrum-based` tag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized the special-network tag from "optimism" to "optimism-based" for OP Stack networks. Detection now relies on "optimism-based". Update any configurations using "optimism" to "optimism-based".
* **Documentation**
  * Updated the network configuration guide and examples to use the "optimism-based" tag and clarified its scope (e.g., Optimism, Base, World Chain).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->