### PR TITLE
docs: Ensured Ubuntu (Unix) Compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,8 +252,10 @@ Run the following commands to install pre-commit hooks:
 - Install stable libsodium version from [here](https://download.libsodium.org/libsodium/releases/).
 - Follow steps to install libsodium from the [libsodium installation guide](https://doc.libsodium.org/installation).
 
-  > **Note**: To compile On Debian/ Ubuntu, you must install the `build-essential` by running `sudo apt-get install build-essential` if it's missing.
-
+  > Note (Debian/Ubuntu): If you're compiling libsodium from source, install build-essential first.
+  ```bash
+  sudo apt-get update && sudo apt-get install -y build-essential
+  ```
 ### Install Node.js
 
 - Install Node.js from [here](https://nodejs.org/).
@@ -326,8 +328,11 @@ cargo run --example create_key -- \
     --force
 ```
 
-> :warning: On Ubuntu/ Debian, if you encounter OpenSSL errors, install the `libssl-dev` and `pkg-config` packages: `sudo apt-get install libssl-dev pkg-config`
+> :warning: Debian/Ubuntu: If you encounter OpenSSL build errors, install the required packages:
 
+```bash
+sudo apt-get update && sudo apt-get install -y pkg-config libssl-dev
+```
 ### Configure Webhook URL
 
 `/config/config.json` file is partially pre-configured. You need to specify the webhook URL that will receive updates from the relayer service.


### PR DESCRIPTION
# Summary

Updated README with notes and tips on how to build on Debian/ Ubuntu. Addresses issue: [#360](https://github.com/OpenZeppelin/openzeppelin-relayer/issues/360)

## Testing Process

- The repository was cloned to a fresh installation of **Ubuntu v24.04**.
- Installed `build-essential` in order to compile the `libsodium` package.
- Installed the Rust toolchain and Git.
- Cloned the Repository and tried to build.
- Ran into OpenSSL issues but resolved by installing the `libssl-dev pkg-config` packages.
- Did not encounter any Pre-commit issues as well.

## Checklist

- [x] Add a reference to related issues in the PR description.
- [ ] Add unit tests if applicable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded README with OS-specific setup notes for Debian/Ubuntu users.
  * After libsodium installation steps, added guidance to install build-essential if missing to ensure required compilation tools are available.
  * After the key-generation example, added a warning to install libssl-dev and pkg-config to prevent OpenSSL-related build errors during installation or builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->