### PR TITLE
chore: update clippy to check only internal code, not deps

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
           - rust
       - id: clippy
         name: clippy
-        entry: cargo clippy --workspace --lib --bins -- -D warnings
+        entry: cargo clippy --workspace --lib --bins -- --no-deps -D warnings
         pass_filenames: false
         language: system
   - repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
# Summary

This PR updates pre commit clippy command to avoid checking external deps

## Testing Process

## Checklist

- [ ] Add a reference to related issues in the PR description.
- [ ] Add unit tests if applicable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated pre-commit linting to run workspace-focused checks, improving consistency across the project.
  * Limits linting to relevant targets and excludes external dependencies to speed up developer workflows.
  * No functional or user-facing changes; build and runtime behavior remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->