### PR TITLE
feat: Include method tag in solana rpc result

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -6013,8 +6013,7 @@
             "type": [
               "boolean",
               "null"
-            ],
-            "description": "Allow concurrent transactions (essential for channel accounts using different accounts' sequence numbers)"
+            ]
           },
           "max_fee": {
             "type": [
@@ -6754,25 +6753,151 @@
       "SolanaRpcResult": {
         "oneOf": [
           {
-            "$ref": "#/components/schemas/FeeEstimateResult"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/FeeEstimateResult"
+              },
+              {
+                "type": "object",
+                "required": [
+                  "method"
+                ],
+                "properties": {
+                  "method": {
+                    "type": "string",
+                    "enum": [
+                      "feeEstimate"
+                    ]
+                  }
+                }
+              }
+            ]
           },
           {
-            "$ref": "#/components/schemas/TransferTransactionResult"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/TransferTransactionResult"
+              },
+              {
+                "type": "object",
+                "required": [
+                  "method"
+                ],
+                "properties": {
+                  "method": {
+                    "type": "string",
+                    "enum": [
+                      "transferTransaction"
+                    ]
+                  }
+                }
+              }
+            ]
           },
           {
-            "$ref": "#/components/schemas/PrepareTransactionResult"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PrepareTransactionResult"
+              },
+              {
+                "type": "object",
+                "required": [
+                  "method"
+                ],
+                "properties": {
+                  "method": {
+                    "type": "string",
+                    "enum": [
+                      "prepareTransaction"
+                    ]
+                  }
+                }
+              }
+            ]
           },
           {
-            "$ref": "#/components/schemas/SignTransactionResult"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SignTransactionResult"
+              },
+              {
+                "type": "object",
+                "required": [
+                  "method"
+                ],
+                "properties": {
+                  "method": {
+                    "type": "string",
+                    "enum": [
+                      "signTransaction"
+                    ]
+                  }
+                }
+              }
+            ]
           },
           {
-            "$ref": "#/components/schemas/SignAndSendTransactionResult"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SignAndSendTransactionResult"
+              },
+              {
+                "type": "object",
+                "required": [
+                  "method"
+                ],
+                "properties": {
+                  "method": {
+                    "type": "string",
+                    "enum": [
+                      "signAndSendTransaction"
+                    ]
+                  }
+                }
+              }
+            ]
           },
           {
-            "$ref": "#/components/schemas/GetSupportedTokensResult"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/GetSupportedTokensResult"
+              },
+              {
+                "type": "object",
+                "required": [
+                  "method"
+                ],
+                "properties": {
+                  "method": {
+                    "type": "string",
+                    "enum": [
+                      "getSupportedTokens"
+                    ]
+                  }
+                }
+              }
+            ]
           },
           {
-            "$ref": "#/components/schemas/GetFeaturesEnabledResult"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/GetFeaturesEnabledResult"
+              },
+              {
+                "type": "object",
+                "required": [
+                  "method"
+                ],
+                "properties": {
+                  "method": {
+                    "type": "string",
+                    "enum": [
+                      "getFeaturesEnabled"
+                    ]
+                  }
+                }
+              }
+            ]
           }
         ]
       },

--- a/src/models/rpc/solana/mod.rs
+++ b/src/models/rpc/solana/mod.rs
@@ -240,7 +240,7 @@ pub enum SolanaRpcRequest {
 }
 
 #[derive(Debug, Serialize, Deserialize, ToSchema, PartialEq)]
-#[serde(untagged)]
+#[serde(tag = "method", rename_all = "camelCase")]
 pub enum SolanaRpcResult {
     FeeEstimate(FeeEstimateResult),
     TransferTransaction(TransferTransactionResult),


### PR DESCRIPTION
# Summary

This PR extends SolanaRpcResult with a method tag to resolve type collisions in SDK consumers caused by multiple RPC methods sharing the same payload format.

SDK PR: https://github.com/OpenZeppelin/openzeppelin-relayer-sdk/pull/174

## Testing Process

## Checklist

- [ ] Add a reference to related issues in the PR description.
- [ ] Add unit tests if applicable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * RPC responses for Solana, Stellar, and Network now include a required method field to identify the result type, aligning response formats across methods. This may require client updates if parsing untagged responses.

* **Documentation**
  * OpenAPI spec updated to reflect method-discriminated RPC results.
  * Removed the description for the Stellar policy field concurrent_transactions (type unchanged).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->