### PR TITLE
feat: Add optimism-based tag to networks

### DIFF
--- a/config/networks/optimism.json
+++ b/config/networks/optimism.json
@@ -71,7 +71,8 @@
       ],
       "symbol": "ETH",
       "tags": [
-        "rollup"
+        "rollup",
+        "optimism-based"
       ],
       "type": "evm"
     },
@@ -93,7 +94,8 @@
       ],
       "tags": [
         "deprecated",
-        "rollup"
+        "rollup",
+        "optimism-based"
       ]
     },
     {
@@ -117,7 +119,8 @@
       ],
       "symbol": "ETH",
       "tags": [
-        "rollup"
+        "rollup",
+        "optimism-based"
       ],
       "type": "evm"
     },
@@ -142,7 +145,8 @@
       "symbol": "ETH",
       "tags": [
         "deprecated",
-        "rollup"
+        "rollup",
+        "optimism-based"
       ],
       "type": "evm"
     },
@@ -165,7 +169,8 @@
       ],
       "symbol": "ETH",
       "tags": [
-        "rollup"
+        "rollup",
+        "optimism-based"
       ],
       "type": "evm"
     },
@@ -190,7 +195,8 @@
       "symbol": "ETH",
       "tags": [
         "deprecated",
-        "rollup"
+        "rollup",
+        "optimism-based"
       ],
       "type": "evm"
     }


### PR DESCRIPTION
# Summary
This PR ensures that all networks in the Optimism configuration file are properly tagged as "optimism-based". After verification, all networks in config/networks/optimism.json are confirmed to be built on the OP Stack


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added the "optimism-based" tag to Optimism, Base, Unichain, World Chain, and their Sepolia testnets to improve network filtering and discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->