### PR TITLE
feat: Add support for Japan Open Chain

### DIFF
--- a/config/networks/other-l1s.json
+++ b/config/networks/other-l1s.json
@@ -256,7 +256,7 @@
       "is_testnet": true,
       "network": "fuse-spark",
       "required_confirmations": 6,
-      "rpc_urls": [" https://rpc.fusespark.io"],
+      "rpc_urls": ["https://rpc.fusespark.io"],
       "symbol": "SPARK",
       "tags": [],
       "type": "evm"
@@ -273,22 +273,22 @@
         "https://rpc-2.japanopenchain.org:8545",
         "https://rpc-3.japanopenchain.org"
       ],
-      "average_blocktime_ms": 10930,
+      "average_blocktime_ms": 5000,
+      "features": ["eip1559"],
       "symbol": "JOC"
     },
     {
+      "from": "japan-open-chain",
       "type": "evm",
       "network": "japan-open-chain-testnet",
       "chain_id": 10081,
       "explorer_urls": ["https://explorer.testnet.japanopenchain.org/"],
       "is_testnet": true,
-      "required_confirmations": 1,
       "rpc_urls": [
         "https://rpc-1.testnet.japanopenchain.org:8545",
         "https://rpc-2.testnet.japanopenchain.org:8545"
       ],
-      "average_blocktime_ms": 16200,
-      "symbol": "JOC"
+      "symbol": "JOCT"
     }
   ]
 }


### PR DESCRIPTION
# Summary
I have added the network configuration for `Japan Open Chain` and tested it by sending transactions in testnet.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added support for Japan Open Chain (mainnet) and Japan Open Chain Testnet: network entries, RPC endpoints, explorer links and token symbols (JOC / JOCT) to enable connecting and viewing transactions.

- Chores
  - Formatting cleanup across existing network entries (array and whitespace normalization) with no behavioral changes.

- Minor
  - Added a cross-reference from the testnet entry to its mainnet counterpart.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->