### PR TITLE
fix: Fixes solana allowed_tokens policy validation

### DIFF
--- a/docs/modules/ROOT/pages/solana.adoc
+++ b/docs/modules/ROOT/pages/solana.adoc
@@ -124,10 +124,15 @@ For more configuration examples, visit the link:https://github.com/OpenZeppelin/
 
 In addition to standard relayer configuration and policies, Solana relayers support additional options:
 
-- `fee_payment_strategy`: `"user"` or `"relayer"` (who pays transaction fees)
-- `allowed_tokens`: List of SPL tokens supported for swaps and fee payments
+- `fee_payment_strategy`: `"user"` or `"relayer"` (who pays transaction fees). "user" is default value.
+  * `"user"`: Users pay transaction fees in tokens (relayer receives fee payment from user)
+  * `"relayer"`: **Relayer pays for all transaction fees** using SOL from the relayer's account
+- `allowed_tokens`: List of SPL tokens supported for swaps and fee payments. Restrict relayer operations to specific tokens. Optional.
+  * **When not set or empty, all tokens are allowed** for transactions and fee payments
+  * When configured, only tokens in this list can be used for transfers and fee payments
 - `allowed_programs`, `allowed_accounts`, `disallowed_accounts`: Restrict relayer operations to specific programs/accounts
 - `swap_config`: Automated token swap settings (see below)
+
 
 
 You can check all options in xref:index.adoc#3_relayers[User Documentation - Relayers].
@@ -174,6 +179,15 @@ Common endpoints:
 - `signAndSendTransaction`,
 - `getSupportedTokens`
 - `getSupportedFeatures`
+
+[NOTE]
+====
+**Fee Token Parameter Behavior:**
+
+When using `fee_payment_strategy: "relayer"`, the `fee_token` parameter in RPC methods becomes **informational only**. The relayer pays all transaction fees in SOL regardless of the specified fee token. In this mode, you can use either `"So11111111111111111111111111111112"` (WSOL) or `"11111111111111111111111111111111"` (native SOL) as the fee_token value.
+
+When using `fee_payment_strategy: "user"`, the `fee_token` parameter determines which token the user will pay fees in, and must be a supported token from the `allowed_tokens` list (if configured).
+====
 
 Example: Estimate fee for a transaction
 [source,bash]

--- a/src/domain/relayer/solana/rpc/methods/utils.rs
+++ b/src/domain/relayer/solana/rpc/methods/utils.rs
@@ -51,6 +51,7 @@ use crate::{
     services::{JupiterServiceTrait, SolanaProviderTrait, SolanaSignTrait},
 };
 
+#[derive(Debug)]
 pub struct FeeQuote {
     pub fee_in_spl: u64,
     pub fee_in_spl_ui: String,
@@ -77,6 +78,56 @@ where
     JP: JobProducerTrait + Send + Sync,
     TR: TransactionRepository + Repository<TransactionRepoModel, String> + Send + Sync + 'static,
 {
+    /// Fetches token decimals from the blockchain using string mint address
+    async fn fetch_token_decimals_from_chain(
+        &self,
+        token_mint_str: &str,
+    ) -> Result<u8, SolanaRpcError> {
+        let token_mint = Pubkey::from_str(token_mint_str)
+            .map_err(|e| SolanaRpcError::Internal(format!("Invalid mint address: {}", e)))?;
+
+        self.fetch_token_decimals_from_chain_pubkey(&token_mint)
+            .await
+    }
+
+    /// Fetches token decimals from the blockchain using Pubkey
+    async fn fetch_token_decimals_from_chain_pubkey(
+        &self,
+        token_mint: &Pubkey,
+    ) -> Result<u8, SolanaRpcError> {
+        let mint_account = self
+            .provider
+            .get_account_from_pubkey(token_mint)
+            .await
+            .map_err(|e| {
+                SolanaRpcError::Internal(format!("Failed to fetch mint account: {}", e))
+            })?;
+
+        let mint_info = spl_token::state::Mint::unpack(&mint_account.data)
+            .map_err(|e| SolanaRpcError::Internal(format!("Failed to unpack mint data: {}", e)))?;
+
+        Ok(mint_info.decimals)
+    }
+
+    /// Gets token decimals from policy first, then fetches from blockchain if not found (Pubkey version)
+    async fn get_token_decimals_from_policy_or_fetch_pubkey(
+        &self,
+        token_mint: &Pubkey,
+    ) -> Result<u8, SolanaRpcError> {
+        match self
+            .relayer
+            .policies
+            .get_solana_policy()
+            .get_allowed_token_decimals(&token_mint.to_string())
+        {
+            Some(decimals) => Ok(decimals),
+            None => {
+                self.fetch_token_decimals_from_chain_pubkey(token_mint)
+                    .await
+            }
+        }
+    }
+
     /// Signs a transaction with the relayer's keypair and returns both the signed transaction and
     /// signature.
     ///
@@ -288,27 +339,39 @@ where
             });
         }
 
-        // Get token policy
-        let token_entry = self
-            .relayer
-            .policies
-            .get_solana_policy()
-            .get_allowed_token_entry(token)
-            .ok_or_else(|| {
+        let policy = self.relayer.policies.get_solana_policy();
+
+        // Check if allowed tokens are configured
+        let no_allowed_tokens_configured = match &policy.allowed_tokens {
+            None => true,                      // No tokens configured
+            Some(tokens) => tokens.is_empty(), // Tokens configured but empty
+        };
+
+        let (decimals, slippage) = if no_allowed_tokens_configured {
+            // No allowed tokens configured - allow all tokens and fetch decimals from blockchain
+            let decimals = self.fetch_token_decimals_from_chain(token).await?;
+            (decimals, DEFAULT_CONVERSION_SLIPPAGE_PERCENTAGE)
+        } else {
+            // Allowed tokens are configured - check if token is in the list
+            let token_entry = policy.get_allowed_token_entry(token).ok_or_else(|| {
                 SolanaRpcError::UnsupportedFeeToken(format!("Token {} not allowed", token))
             })?;
 
-        // Get token decimals
-        let decimals = token_entry.decimals.ok_or_else(|| {
-            SolanaRpcError::Estimation("Token decimals not configured".to_string())
-        })?;
+            // Get token decimals from policy first, then fetch from blockchain
+            let decimals = match token_entry.decimals {
+                Some(decimals) => decimals,
+                None => self.fetch_token_decimals_from_chain(token).await?,
+            };
 
-        // Get slippage from policy
-        let slippage = token_entry
-            .swap_config
-            .as_ref()
-            .and_then(|config| config.slippage_percentage)
-            .unwrap_or(DEFAULT_CONVERSION_SLIPPAGE_PERCENTAGE);
+            // Get slippage from policy
+            let slippage = token_entry
+                .swap_config
+                .as_ref()
+                .and_then(|config| config.slippage_percentage)
+                .unwrap_or(DEFAULT_CONVERSION_SLIPPAGE_PERCENTAGE);
+
+            (decimals, slippage)
+        };
 
         // Get Jupiter quote
         let quote = self
@@ -469,14 +532,11 @@ where
                 token_mint,
             ));
         }
+
+        // Try to get token decimals from policy first, then fetch from blockchain
         let token_decimals = self
-            .relayer
-            .policies
-            .get_solana_policy()
-            .get_allowed_token_decimals(&token_mint.to_string())
-            .ok_or_else(|| {
-                SolanaRpcError::UnsupportedFeeToken("Token not found in allowed tokens".to_string())
-            })?;
+            .get_token_decimals_from_policy_or_fetch_pubkey(token_mint)
+            .await?;
 
         instructions.push(SolanaTokenProgram::create_transfer_checked_instruction(
             &program_id,
@@ -2730,5 +2790,109 @@ mod tests {
 
         // Assert success
         assert!(result.is_ok(), "Schedule status check should succeed");
+    }
+
+    #[tokio::test]
+    async fn test_get_fee_token_quote_fetches_decimals_from_chain_when_no_allowed_tokens() {
+        let (relayer, signer, mut provider, mut jupiter_service, _, job_producer, network) =
+            setup_test_context();
+
+        let test_token = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"; // USDC mint
+        let total_fee = 5000u64; // 5000 lamports
+
+        // Mock the provider to return mint account data when get_account_from_pubkey is called
+        let mint_data = {
+            let mint_info = spl_token::state::Mint {
+                mint_authority: None.into(),
+                supply: 1_000_000_000_000,
+                decimals: 6, // USDC decimals
+                is_initialized: true,
+                freeze_authority: None.into(),
+            };
+            let mut data = vec![0u8; spl_token::state::Mint::LEN];
+            spl_token::state::Mint::pack(mint_info, &mut data).unwrap();
+            data
+        };
+
+        provider
+            .expect_get_account_from_pubkey()
+            .returning(move |_| {
+                let mint_data_clone = mint_data.clone();
+                Box::pin(async move {
+                    Ok(solana_sdk::account::Account {
+                        lamports: 1000000,
+                        data: mint_data_clone,
+                        owner: spl_token::id(),
+                        executable: false,
+                        rent_epoch: 0,
+                    })
+                })
+            });
+
+        // Mock Jupiter service to return a quote
+        jupiter_service
+            .expect_get_sol_to_token_quote()
+            .returning(|_token, _amount, _slippage| {
+                Box::pin(async move {
+                    Ok(QuoteResponse {
+                        input_mint: WRAPPED_SOL_MINT.to_string(),
+                        output_mint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v".to_string(),
+                        in_amount: 5000,  // Input SOL amount
+                        out_amount: 5000, // Output token amount (1:1 for simplicity)
+                        other_amount_threshold: 4750,
+                        swap_mode: "ExactIn".to_string(),
+                        slippage_bps: 50,
+                        price_impact_pct: 0.1,
+                        route_plan: vec![RoutePlan {
+                            swap_info: SwapInfo {
+                                amm_key: "test-amm".to_string(),
+                                label: "test-swap".to_string(),
+                                input_mint: WRAPPED_SOL_MINT.to_string(),
+                                output_mint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+                                    .to_string(),
+                                in_amount: "5000".to_string(),
+                                out_amount: "5000".to_string(),
+                                fee_amount: "25".to_string(),
+                                fee_mint: WRAPPED_SOL_MINT.to_string(),
+                            },
+                            percent: 100,
+                        }],
+                    })
+                })
+            });
+
+        let rpc = SolanaRpcMethodsImpl::new_mock(
+            relayer,
+            network,
+            Arc::new(provider),
+            Arc::new(signer),
+            Arc::new(jupiter_service),
+            Arc::new(job_producer),
+            Arc::new(MockTransactionRepository::new()),
+        );
+
+        let result = rpc.get_fee_token_quote(test_token, total_fee).await;
+
+        // Assert success
+        assert!(result.is_ok(), "Fee quote should succeed: {:?}", result);
+
+        let quote = result.unwrap();
+
+        assert_eq!(quote.fee_in_spl, 5000, "SPL fee amount should match");
+        assert_eq!(
+            quote.fee_in_lamports, total_fee,
+            "Lamports fee should match"
+        );
+
+        assert_eq!(
+            quote.fee_in_spl_ui, "0.005",
+            "UI amount should use correct decimals from chain"
+        );
+
+        assert!(
+            (quote.conversion_rate - 1000.0).abs() < 0.001,
+            "Conversion rate should be approximately 1000.0, got {}",
+            quote.conversion_rate
+        );
     }
 }


### PR DESCRIPTION
# Summary

This PR will fix solana `allowed_tokens` policy validations and it will improve handling of token decimals in case it is not defined as part of policy.

Note: Bug was reported via Telegram channel by @SkymanOne 

## Testing Process

## Checklist

- [ ] Add a reference to related issues in the PR description.
- [x] Add unit tests if applicable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Optional token allowlist: when unset or empty, all tokens are allowed for transfers and fee payments.
  * More accurate fee quotes via policy-aware slippage and automatic on-chain token decimal detection.
  * More reliable token transfers by resolving token decimals before execution.

* **Documentation**
  * Clarified Solana relayer configuration: fee_payment_strategy modes and default, optional allowed_tokens behavior, and fee_token behavior for both strategies.
  * Added explanatory notes in both Common endpoints and API Reference sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->