### PR TITLE
feat: Add SEI network

### DIFF
--- a/config/networks/sei.json
+++ b/config/networks/sei.json
@@ -17,7 +17,7 @@
       "type": "evm",
       "network": "sei-atlantic-2",
       "chain_id": 1328,
-      "explorer_urls": ["https://seitrace.com"],
+      "explorer_urls": ["https://testnet.seitrace.com/"],
       "is_testnet": true,
       "rpc_urls": ["https://evm-rpc-testnet.sei-apis.com"],
       "tags": []

--- a/config/networks/sei.json
+++ b/config/networks/sei.json
@@ -1,0 +1,26 @@
+{
+  "networks": [
+    {
+      "average_blocktime_ms": 400,
+      "chain_id": 1329,
+      "explorer_urls": ["https://seitrace.com"],
+      "features": ["eip1559"],
+      "is_testnet": false,
+      "network": "sei-mainnet",
+      "required_confirmations": 1,
+      "rpc_urls": ["https://evm-rpc.sei-apis.com"],
+      "symbol": "SEI",
+      "type": "evm"
+    },
+    {
+      "from": "sei-mainnet",
+      "type": "evm",
+      "network": "sei-atlantic-2",
+      "chain_id": 1328,
+      "explorer_urls": ["https://seitrace.com"],
+      "is_testnet": true,
+      "rpc_urls": ["https://evm-rpc-testnet.sei-apis.com"],
+      "tags": []
+    }
+  ]
+}


### PR DESCRIPTION
# Summary
- Add SEI network configuration


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Sei networks: Mainnet and Atlantic-2 Testnet.
  * Networks are now available for selection with preconfigured RPC endpoints and block explorers.
  * EIP-1559 fee market supported on Sei for improved fee handling.
  * Default confirmation set to 1 on Sei Mainnet for faster transaction acknowledgment.
  * Clear distinction between mainnet and testnet environments to simplify development and production use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->