### PR TITLE
feat: Add background job redis collections prefix support

### DIFF
--- a/src/jobs/queue.rs
+++ b/src/jobs/queue.rs
@@ -6,7 +6,7 @@
 //! - Transaction status checks
 //! - Notifications
 //! - Solana swap requests
-use std::sync::Arc;
+use std::{env, sync::Arc};
 
 use apalis_redis::{Config, ConnectionManager, RedisStorage};
 use color_eyre::{eyre, Result};
@@ -58,19 +58,32 @@ impl Queue {
         };
 
         let shared = Arc::new(conn);
+        // use REDIS_KEY_PREFIX only if set, otherwise do not use it
+        let redis_key_prefix = env::var("REDIS_KEY_PREFIX")
+            .map_or_else(|_| "".to_string(), |value| format!("{value}:queue:"));
         Ok(Self {
-            transaction_request_queue: Self::storage("transaction_request_queue", shared.clone())
-                .await?,
-            transaction_submission_queue: Self::storage(
-                "transaction_submission_queue",
+            transaction_request_queue: Self::storage(
+                &format!("{}transaction_request_queue", redis_key_prefix),
                 shared.clone(),
             )
             .await?,
-            transaction_status_queue: Self::storage("transaction_status_queue", shared.clone())
-                .await?,
-            notification_queue: Self::storage("notification_queue", shared.clone()).await?,
+            transaction_submission_queue: Self::storage(
+                &format!("{}transaction_submission_queue", redis_key_prefix),
+                shared.clone(),
+            )
+            .await?,
+            transaction_status_queue: Self::storage(
+                &format!("{}transaction_status_queue", redis_key_prefix),
+                shared.clone(),
+            )
+            .await?,
+            notification_queue: Self::storage(
+                &format!("{}notification_queue", redis_key_prefix),
+                shared.clone(),
+            )
+            .await?,
             solana_token_swap_request_queue: Self::storage(
-                "solana_token_swap_request_queue",
+                &format!("{}solana_token_swap_request_queue", redis_key_prefix),
                 shared.clone(),
             )
             .await?,

--- a/src/jobs/queue.rs
+++ b/src/jobs/queue.rs
@@ -60,7 +60,10 @@ impl Queue {
         let shared = Arc::new(conn);
         // use REDIS_KEY_PREFIX only if set, otherwise do not use it
         let redis_key_prefix = env::var("REDIS_KEY_PREFIX")
-            .map_or_else(|_| "".to_string(), |value| format!("{value}:queue:"));
+            .ok()
+            .filter(|v| !v.is_empty())
+            .map(|value| format!("{value}:queue:"))
+            .unwrap_or_default();
         Ok(Self {
             transaction_request_queue: Self::storage(
                 &format!("{}transaction_request_queue", redis_key_prefix),


### PR DESCRIPTION
# Summary

Prefix Apalis Redis storage queues with the Redis key prefix if set.

This allows using instance-specific tasks on a shared Redis instance across multiple relayer instances.

## Testing Process

## Checklist

- [ ] Add a reference to related issues in the PR description.
- [ ] Add unit tests if applicable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support for an optional Redis key prefix via the REDIS_KEY_PREFIX environment variable. This enables namespacing of all job queues, helping prevent key collisions across environments or multi-instance deployments. Backward compatible: when unset, behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->