### PR TITLE
fix: Docker cross-platform build architecture mismatch

### DIFF
--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -1,5 +1,5 @@
 # Base image
-FROM --platform=${BUILDPLATFORM} cgr.dev/chainguard/rust:latest-dev@sha256:faf49718aaa95c798ed1dfdf3e4edee2cdbc3790c8994705ca6ef35972128459 AS base
+FROM cgr.dev/chainguard/rust:latest-dev@sha256:faf49718aaa95c798ed1dfdf3e4edee2cdbc3790c8994705ca6ef35972128459 AS base
 
 USER root
 RUN apk update && apk --no-cache add \
@@ -19,7 +19,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     cargo install --root /usr/app --path . --debug --locked
 
 # Setting up build directories
-FROM --platform=${BUILDPLATFORM} cgr.dev/chainguard/wolfi-base
+FROM cgr.dev/chainguard/wolfi-base
 
 WORKDIR /app
 

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -1,5 +1,5 @@
 # Base image
-FROM --platform=${BUILDPLATFORM} cgr.dev/chainguard/rust:latest-dev@sha256:faf49718aaa95c798ed1dfdf3e4edee2cdbc3790c8994705ca6ef35972128459 AS base
+FROM cgr.dev/chainguard/rust:latest-dev@sha256:faf49718aaa95c798ed1dfdf3e4edee2cdbc3790c8994705ca6ef35972128459 AS base
 
 USER root
 RUN apk update && apk --no-cache add \
@@ -15,7 +15,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     cargo install --root /usr/app --path . --debug --locked
 
 # Setting up build directories
-FROM --platform=${BUILDPLATFORM} cgr.dev/chainguard/wolfi-base
+FROM cgr.dev/chainguard/wolfi-base
 
 WORKDIR /app
 COPY --from=base --chown=nonroot:nonroot /usr/app/bin/openzeppelin-relayer /app/openzeppelin-relayer


### PR DESCRIPTION
# Summary
- Fixed Docker build producing ARM64 binaries when building for linux/amd64 platform (from macOS)
- Removed `--platform=${BUILDPLATFORM}` from both Dockerfile.development and Dockerfile.production

## Problem
  When building with `--platform linux/amd64`, the Docker container was correctly `amd64`, but the Rust binary inside was ARM64. This happened because `--platform=${BUILDPLATFORM}` forced the build stage to run natively on the host architecture (ARM64 Mac), causing cargo to compile for ARM64 instead of the target platform.

## Testing Process
Check Docker Image Architecture:
```bash
docker inspect <image> --format='{{.Architecture}}'
```
Before and after should have the same output: `amd64`

Check ELF header:
```bash
docker run --rm --entrypoint /bin/sh <image> -c "head -c 20 /app/openzeppelin-relayer | od -A n -t x1"
```

**Before:** `7f 45 4c 46 02 01 01 00 00 00 00 00 00 00 00 00 03 00 b7 00`
**After:** `7f 45 4c 46 02 01 01 00 00 00 00 00 00 00 00 00 03 00 3e 00`

`e_machine` bytes `b7 00` means Arm 64-bits, and `3e 00` AMD x86-64



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified container build configuration for both development and production, removing architecture-specific targeting to streamline builds.
  * Improves build consistency across local and CI environments with fewer platform-related edge cases.
  * No changes to application features or runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->