### PR TITLE
chore: Add MSRV checks to update-lock workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -102,7 +102,9 @@ jobs:
       - name: Get cache-hit output
         run: 'echo "Cache hit >>>>>: ${{ steps.init.outputs.cache-hit }}"'
       - name: Install cargo hack
-        uses: taiki-e/install-action@7689010b667477e55299b24c373cdf719c945fdf  # cargo-hack
+        uses: taiki-e/install-action@bf2f998095ccb464eb8b85eeb95a460ccd744ec4  # v2.62.17
+        with:
+          tool: cargo-hack
 
       # Check the minimum supported Rust version
       - name: Default features
@@ -223,10 +225,10 @@ jobs:
       # Get the output of the prepare composite action
       - name: Get cache-hit output
         run: 'echo "Cache hit >>>>>: ${{ steps.init.outputs.cache-hit }}"'
-      - name: Install cargo hack
-        uses: taiki-e/install-action@7689010b667477e55299b24c373cdf719c945fdf  # cargo-hack
-      - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@16edcff251c6bb06f6878981359f84b77b28e7e2  # cargo-llvm-cov
+      - name: Install cargo hack and cargo-llvm-cov
+        uses: taiki-e/install-action@bf2f998095ccb464eb8b85eeb95a460ccd744ec4  # v2.62.17
+        with:
+          tool: cargo-hack,cargo-llvm-cov
       - name: Build
         run: cargo test --no-run --locked
 

--- a/.github/workflows/update-lock.yaml
+++ b/.github/workflows/update-lock.yaml
@@ -41,6 +41,14 @@ jobs:
             echo "Cargo.lock has no changes, skipping commit and push."
             exit 0
           fi
+      - name: Install cargo hack
+        if: steps.lock-file-commit.outputs.changes == 'true'
+        uses: taiki-e/install-action@bf2f998095ccb464eb8b85eeb95a460ccd744ec4  # v2.62.17
+        with:
+          tool: cargo-hack
+      - name: Check MSRV
+        if: steps.lock-file-commit.outputs.changes == 'true'
+        run: cargo hack check --feature-powerset --locked --rust-version --workspace --lib --bins
       - name: Create or update pull request
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e  # v7.0.8
         with:


### PR DESCRIPTION
# Summary
- Added MSRV checks to the nightly Cargo.lock update workflow
- Workflow now fails if dependency updates break MSRV compatibility
- Standardized cargo-hack installation across workflows using taiki-e/install-action@v2.62.17

## Testing Process

## Checklist

- [ ] Add a reference to related issues in the PR description.
- [ ] Add unit tests if applicable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- CI
  - Consolidated tool installation into a single step to streamline workflow; no impact on build/test behavior.
  - Added MSRV compatibility checks that run only when the dependency lockfile changes.

- Chores
  - Minor workflow step naming and grouping adjustments for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->