### PR TITLE
feat: Add Stellar account creation script

### DIFF
--- a/examples/launchtube-plugin-example/README.md
+++ b/examples/launchtube-plugin-example/README.md
@@ -109,6 +109,40 @@ LOCK_TTL_SECONDS=30
 LOG_LEVEL=info
 ```
 
+### 2b. Provision LaunchTube Sequence Accounts
+
+After generating the credentials above, you can use the bundled TypeScript
+script to create the required relayers, signers, and Stellar accounts while also
+updating the LaunchTube plugin configuration:
+
+```bash
+cd launchtube
+pnpm install
+pnpm exec tsx ./scripts/create-sequence-accounts.ts \
+  --total 3 \
+  --base-url http://localhost:8080 \
+  --api-key <RELAYER_API_KEY> \
+  --funding-relayer launchtube-fund \
+  --plugin-id launchtube-plugin \
+  --plugin-admin-secret <LAUNCHTUBE_ADMIN_SECRET> \
+  --network testnet
+
+# Rerun with --fix to audit or heal any partially created state
+pnpm exec tsx ./scripts/create-sequence-accounts.ts \
+  --total 3 \
+  --base-url http://localhost:8080 \
+  --api-key <RELAYER_API_KEY> \
+  --funding-relayer launchtube-fund \
+  --plugin-id launchtube-plugin \
+  --plugin-admin-secret <LAUNCHTUBE_ADMIN_SECRET> \
+  --network testnet \
+  --fix
+```
+
+The script waits for each funding transaction to confirm, prints a summary of
+the relayer/signer state, and updates the LaunchTube management API with the
+sequence account list so the plugin is immediately ready for use.
+
 ### 3. Verify Configuration
 
 The LaunchTube plugin and relayer configurations are already set up for testnet. The configurations include:

--- a/examples/launchtube-plugin-example/launchtube/create-stellar-accounts.ts
+++ b/examples/launchtube-plugin-example/launchtube/create-stellar-accounts.ts
@@ -1,0 +1,1029 @@
+import { Buffer } from 'node:buffer';
+/**
+ * LaunchTube Stellar account bootstrap script.
+ *
+ * The script manages LaunchTube relayer slots that follow the naming pattern
+ * `lt-seq-0001`, `lt-seq-0002`, ... up to the target count provided via
+ * `--total`. For each slot it ensures:
+ *   1. A plain signer exists (stored under `<slot>-signer`).
+ *   2. A Stellar relayer exists, pointing at that signer.
+ *   3. The associated Stellar account is funded on-chain with the configured
+ *      starting balance.
+ *
+ * When a signer or relayer is missing, the tool recreates it. Funding
+ * transactions are submitted through the designated funding relayer and the
+ * script waits until the relayer reports the transaction as confirmed. The
+ * only stateful data retained by the script is printed on stdout (public key,
+ * Stellar seed, and signer hex key) so make sure to capture the output if you
+ * plan to persist secrets.
+ *
+ * Usage (example):
+ *   pnpm ts-node create-stellar-accounts.ts \
+ *     --total 200 \
+ *     --base-url http://localhost:8080 \
+ *     --api-key <relayer-api-key> \
+ *     --funding-relayer stellar-funder \
+ *     --plugin-id launchtube \
+ *     --plugin-admin-secret <management-secret> \
+ *     --network testnet \
+ *     [--fix] [--dry-run]
+ *
+ * Required flags:
+ *   --total <number>
+ *       Number of LaunchTube relayer slots to create or validate.
+ *   --base-url <url>
+ *       Base URL of the OpenZeppelin Relayer API (e.g. http://localhost:8080).
+ *   --api-key <token>
+ *       API token with permissions to manage signers and relayers.
+ *   --funding-relayer <relayer-id>
+ *       ID of the Stellar relayer that will fund new accounts.
+ *   --plugin-id <string>
+ *       LaunchTube plugin identifier that should receive the updated sequence
+ *       account list after provisioning.
+ *   --plugin-admin-secret <string>
+ *       Secret required by the LaunchTube management API when calling
+ *       `setSequenceAccounts`.
+ *
+ * Optional flags:
+ *   --network <public|mainnet|testnet|futurenet>
+ *       Network identifier used for relayer creation and account funding
+ *       (default: testnet).
+ *   --horizon <url>
+ *       Override the Horizon endpoint used to fetch ledger metadata and account
+ *       information (defaults are inferred from --network).
+ *   --prefix <string>
+ *       Slot prefix (default: lt-seq-). The script pads the numeric suffix with
+ *       `--padding` digits.
+ *   --padding <number>
+ *       Zero-padding for the numeric suffix (default: 4). For example,
+ *       padding=4 produces `lt-seq-0001`.
+ *   --starting-balance <decimal>
+ *       XLM amount credited to each new account (default: 5). Must use up to 7
+ *       decimal places.
+ *   --timeout <seconds>
+ *       Horizon transaction timeout used when building funding transactions
+ *       (default: 180 seconds).
+ *   --fix
+ *       Validate every slot up to --total. Missing signers or relayers are
+ *       recreated and accounts that are absent on-chain are funded. Existing
+ *       accounts are left untouched.
+ *   --dry-run
+ *       Print the actions that would be executed and exit without mutating any
+ *       state. Use together with --fix to audit the current setup.
+ *
+ * Typical workflow:
+ *   1. Run once without --fix to provision new slots.
+ *   2. If the run is interrupted, rerun with --fix to heal partially created
+ *      slots. The plugin list is always updated at the end of the run using the
+ *      provided plugin credentials.
+ *   3. Repeat with a higher --total as you need additional relayer capacity.
+ */
+import {
+  Configuration,
+  PluginsApi,
+  RelayerNetworkType,
+  RelayersApi,
+  SignerTypeRequest,
+  SignersApi,
+  StellarTransactionRequest,
+} from '@openzeppelin/relayer-sdk';
+import { Account, BASE_FEE, Horizon, Keypair, Networks, Operation, TransactionBuilder } from 'stellar-sdk';
+
+const { Server } = Horizon;
+type HorizonAccount = Awaited<ReturnType<InstanceType<typeof Server>['loadAccount']>>;
+
+interface CliOptions {
+  total: number;
+  prefix: string;
+  padding: number;
+  startingBalance: string;
+  timeoutSeconds: number;
+  dryRun: boolean;
+  fix: boolean;
+  horizonUrl?: string;
+  basePath?: string;
+  accessToken?: string;
+  fundingRelayerId?: string;
+  network: string;
+  pluginId: string;
+  pluginAdminSecret: string;
+}
+
+interface CreatedAccountSummary {
+  name: string;
+  relayerId: string;
+  signerId: string;
+  publicKey: string;
+  secretSeed?: string;
+  secretHex?: string;
+  accountExisted: boolean;
+  funded: boolean;
+}
+
+type ResultCodes = {
+  transaction?: string;
+  operations?: string[];
+};
+
+const NETWORK_CONFIG: Record<string, { passphrase: string; horizon: string }> = {
+  public: { passphrase: Networks.PUBLIC, horizon: 'https://horizon.stellar.org' },
+  mainnet: { passphrase: Networks.PUBLIC, horizon: 'https://horizon.stellar.org' },
+  testnet: { passphrase: Networks.TESTNET, horizon: 'https://horizon-testnet.stellar.org' },
+  futurenet: {
+    passphrase: 'Test SDF Future Network ; October 2022',
+    horizon: 'https://horizon-futurenet.stellar.org',
+  },
+};
+
+const DEFAULT_PREFIX = 'lt-seq-';
+const DEFAULT_PADDING = 4;
+const DEFAULT_STARTING_BALANCE = '5';
+const DEFAULT_TIMEOUT_SECONDS = 180;
+const DEFAULT_NETWORK = 'testnet';
+
+async function fetchBaseReserveStroops(server: InstanceType<typeof Server>): Promise<bigint> {
+  const ledgerPage = await server.ledgers().order('desc').limit(1).call();
+  const latestLedger = ledgerPage?.records?.[0];
+  const baseReserve = latestLedger?.base_reserve_in_stroops;
+  if (!baseReserve) {
+    throw new Error('Horizon ledger response did not include base_reserve_in_stroops.');
+  }
+  return BigInt(baseReserve);
+}
+
+const STROOPS_PER_LUMEN = 10_000_000n;
+
+function lumensToStroops(value: string, label: string): bigint {
+  if (!/^\d+(\.\d+)?$/.test(value)) {
+    throw new Error(`Invalid decimal value for ${label}: ${value}`);
+  }
+  const [wholePart, fractionalPart = ''] = value.split('.');
+  if (fractionalPart.length > 7) {
+    throw new Error(`Invalid decimal value for ${label}: ${value} (maximum 7 decimal places)`);
+  }
+  const whole = BigInt(wholePart || '0');
+  const fractional = BigInt((fractionalPart + '0000000').slice(0, 7));
+  return whole * STROOPS_PER_LUMEN + fractional;
+}
+
+function formatLumens(stroops: bigint): string {
+  const sign = stroops < 0n ? '-' : '';
+  const abs = stroops < 0n ? -stroops : stroops;
+  const whole = abs / STROOPS_PER_LUMEN;
+  const fraction = abs % STROOPS_PER_LUMEN;
+  if (fraction === 0n) {
+    return `${sign}${whole.toString()}`;
+  }
+  const fractionStr = fraction.toString().padStart(7, '0').replace(/0+$/, '');
+  return `${sign}${whole.toString()}.${fractionStr}`;
+}
+
+interface FundingCapacitySummary {
+  balance: bigint;
+  reserve: bigint;
+  available: bigint;
+  totalStarting: bigint;
+  totalFees: bigint;
+  totalRequired: bigint;
+}
+
+function summarizeFundingCapacity(
+  account: HorizonAccount,
+  baseReserveStroops: bigint,
+  startingBalance: string,
+  accountCount: number
+): FundingCapacitySummary {
+  const nativeBalance = account.balances.find((balance: any) => balance.asset_type === 'native');
+  if (!nativeBalance) {
+    throw new Error('Funding account does not hold a native XLM balance.');
+  }
+
+  const balanceStroops = lumensToStroops(nativeBalance.balance, 'funding account balance');
+  const subentryCount = BigInt(account.subentry_count ?? 0);
+  const numSponsoring = BigInt((account as any).num_sponsoring ?? 0);
+  const numSponsored = BigInt((account as any).num_sponsored ?? 0);
+  let reserveMultiplier = 2n + subentryCount + numSponsoring - numSponsored;
+  if (reserveMultiplier < 0n) {
+    reserveMultiplier = 0n;
+  }
+  const reserveStroops = baseReserveStroops * reserveMultiplier;
+
+  const startingBalanceStroops = lumensToStroops(startingBalance, 'starting balance');
+  const accounts = BigInt(accountCount);
+  const totalStarting = startingBalanceStroops * accounts;
+  const totalFees = BigInt(BASE_FEE) * accounts;
+  const totalRequired = totalStarting + totalFees;
+
+  const available = balanceStroops - reserveStroops;
+
+  return {
+    balance: balanceStroops,
+    reserve: reserveStroops,
+    available,
+    totalStarting,
+    totalFees,
+    totalRequired,
+  };
+}
+
+function isNotFoundError(error: unknown): boolean {
+  return isHttpStatus(error, 404);
+}
+
+interface SignerRecord {
+  id: string;
+}
+
+interface RelayerRecord {
+  id: string;
+  address?: string;
+  signer_id: string;
+}
+
+async function fetchSignerRecord(signersApi: SignersApi, signerId: string): Promise<SignerRecord | undefined> {
+  try {
+    const response = await signersApi.getSigner(signerId);
+    const data = response.data?.data;
+    if (!data) {
+      return undefined;
+    }
+    return { id: data.id };
+  } catch (error) {
+    if (isNotFoundError(error)) {
+      return undefined;
+    }
+    throw error;
+  }
+}
+
+async function deleteSignerIfExists(signersApi: SignersApi, signerId: string): Promise<void> {
+  try {
+    await signersApi.deleteSigner(signerId);
+  } catch (error) {
+    if (!isNotFoundError(error)) {
+      throw error;
+    }
+  }
+}
+
+async function fetchRelayerRecord(relayersApi: RelayersApi, relayerId: string): Promise<RelayerRecord | undefined> {
+  try {
+    const response = await relayersApi.getRelayer(relayerId);
+    const data = response.data?.data;
+    if (!data) {
+      return undefined;
+    }
+    return { id: data.id, address: data.address, signer_id: data.signer_id ?? '' };
+  } catch (error) {
+    if (isNotFoundError(error)) {
+      return undefined;
+    }
+    throw error;
+  }
+}
+
+async function waitForTransactionConfirmation(
+  relayersApi: RelayersApi,
+  relayerId: string,
+  transactionId: string,
+  timeoutMs = 120_000,
+  pollIntervalMs = 2_000
+): Promise<void> {
+  const startedAt = Date.now();
+  while (true) {
+    const elapsed = Date.now() - startedAt;
+    if (elapsed > timeoutMs) {
+      throw new Error(`Transaction ${transactionId} for relayer ${relayerId} not confirmed within timeout`);
+    }
+
+    try {
+      const response = await relayersApi.getTransactionById(relayerId, transactionId);
+      const data = response.data?.data;
+      if (data && 'status' in data) {
+        const status = (data as { status?: string }).status ?? 'unknown';
+        const reason = (data as { status_reason?: string | null }).status_reason ?? undefined;
+        if (status === 'submitted' || status === 'pending') {
+          // Keep waiting
+        } else if (status === 'confirmed') {
+          return;
+        } else {
+          throw new Error(
+            `Transaction ${transactionId} for relayer ${relayerId} reported status '${status}'${reason ? ` (${reason})` : ''}`
+          );
+        }
+      }
+    } catch (error) {
+      if (isHttpStatus(error, 404)) {
+        // If the relayer API hasn't indexed the tx yet, keep waiting
+      } else {
+        throw error;
+      }
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+  }
+}
+
+async function accountExists(server: InstanceType<typeof Server>, publicKey: string): Promise<boolean> {
+  try {
+    await server.loadAccount(publicKey);
+    return true;
+  } catch (error) {
+    if (isNotFoundError(error)) {
+      return false;
+    }
+    throw error;
+  }
+}
+
+async function updateLaunchTubePlugin(
+  pluginsApi: PluginsApi,
+  pluginId: string,
+  adminSecret: string,
+  relayerIds: string[],
+): Promise<void> {
+  const payload = {
+    params: {
+      management: {
+        action: 'setSequenceAccounts',
+        adminSecret,
+        relayerIds,
+      },
+    },
+  };
+
+  try {
+    await pluginsApi.callPlugin(pluginId, payload);
+    console.log(`[Plugin] Updated ${pluginId} with ${relayerIds.length} sequence account(s).`);
+  } catch (error) {
+    throw new Error(`Failed to update LaunchTube plugin '${pluginId}': ${extractErrorMessage(error)}`);
+  }
+}
+
+
+function parseArgs(argv: string[]): CliOptions {
+  let prefix = DEFAULT_PREFIX;
+  let padding = DEFAULT_PADDING;
+  let startingBalance = DEFAULT_STARTING_BALANCE;
+  let timeoutSeconds = DEFAULT_TIMEOUT_SECONDS;
+  let dryRun = false;
+  let fix = false;
+  let horizonUrl: string | undefined;
+  let total: number | undefined;
+  let basePath: string | undefined;
+  let accessToken: string | undefined;
+  let fundingRelayerId: string | undefined;
+  let network = DEFAULT_NETWORK;
+  let pluginId: string | undefined;
+  let pluginAdminSecret: string | undefined;
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    switch (arg) {
+      case '--total':
+      case '-n': {
+        const value = argv[++i];
+        if (!value) throw new Error('Missing value for --total');
+        total = parsePositiveInt(value, '--total');
+        break;
+      }
+      case '--prefix': {
+        const value = argv[++i];
+        if (!value) throw new Error('Missing value for --prefix');
+        prefix = value;
+        break;
+      }
+      case '--padding': {
+        const value = argv[++i];
+        if (!value) throw new Error('Missing value for --padding');
+        padding = parsePositiveInt(value, '--padding');
+        break;
+      }
+      case '--starting-balance': {
+        const value = argv[++i];
+        if (!value) throw new Error('Missing value for --starting-balance');
+        validateStartingBalance(value, '--starting-balance');
+        startingBalance = value;
+        break;
+      }
+      case '--timeout': {
+        const value = argv[++i];
+        if (!value) throw new Error('Missing value for --timeout');
+        timeoutSeconds = parsePositiveInt(value, '--timeout');
+        break;
+      }
+      case '--horizon': {
+        const value = argv[++i];
+        if (!value) throw new Error('Missing value for --horizon');
+        horizonUrl = value;
+        break;
+      }
+      case '--network': {
+        const value = argv[++i];
+        if (!value) throw new Error('Missing value for --network');
+        network = value.toLowerCase();
+        break;
+      }
+      case '--base-url': {
+        const value = argv[++i];
+        if (!value) throw new Error('Missing value for --base-url');
+        basePath = value;
+        break;
+      }
+      case '--api-key': {
+        const value = argv[++i];
+        if (!value) throw new Error('Missing value for --api-key');
+        accessToken = value;
+        break;
+      }
+      case '--funding-relayer': {
+        const value = argv[++i];
+        if (!value) throw new Error('Missing value for --funding-relayer');
+        fundingRelayerId = value;
+        break;
+      }
+      case '--dry-run':
+        dryRun = true;
+        break;
+      case '--plugin-id': {
+        const value = argv[++i];
+        if (!value) throw new Error('Missing value for --plugin-id');
+        pluginId = value;
+        break;
+      }
+      case '--plugin-admin-secret': {
+        const value = argv[++i];
+        if (!value) throw new Error('Missing value for --plugin-admin-secret');
+        pluginAdminSecret = value;
+        break;
+      }
+      case '--fix':
+        fix = true;
+        break;
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (total === undefined) {
+    throw new Error('Target account count missing. Provide --total.');
+  }
+  if (!pluginId) {
+    throw new Error('LaunchTube plugin ID missing. Provide --plugin-id.');
+  }
+  if (!pluginAdminSecret) {
+    throw new Error('LaunchTube admin secret missing. Provide --plugin-admin-secret.');
+  }
+
+  return {
+    total,
+    prefix,
+    padding,
+    startingBalance,
+    timeoutSeconds,
+    dryRun,
+    fix,
+    horizonUrl,
+    basePath,
+    accessToken,
+    fundingRelayerId,
+    network,
+    pluginId,
+    pluginAdminSecret,
+  };
+}
+
+function parsePositiveInt(value: string, label: string): number {
+  const parsed = Number.parseInt(value, 10);
+  if (Number.isNaN(parsed) || parsed <= 0) {
+    throw new Error(`Invalid positive integer for ${label}: ${value}`);
+  }
+  return parsed;
+}
+
+function validateStartingBalance(value: string, label: string): void {
+  if (!/^\d+(\.\d+)?$/.test(value)) {
+    throw new Error(`Invalid decimal value for ${label}: ${value}`);
+  }
+  const fractional = value.split('.')[1] ?? '';
+  if (fractional.length > 7) {
+    throw new Error(`Invalid decimal value for ${label}: ${value} (maximum 7 decimal places)`);
+  }
+}
+
+function requireOption(value: string | undefined, message: string): string {
+  if (!value) {
+    throw new Error(message);
+  }
+  return value;
+}
+
+function formatAccountName(prefix: string, index: number, padding: number): string {
+  return `${prefix}${index.toString().padStart(padding, '0')}`;
+}
+
+function parseIndexFromName(name: string, prefix: string): number | undefined {
+  if (!name.startsWith(prefix)) return undefined;
+  const suffix = name.slice(prefix.length);
+  if (!/^\d+$/.test(suffix)) return undefined;
+  return Number.parseInt(suffix, 10);
+}
+
+function getNetworkPassphrase(network: string, override?: string): string {
+  if (override) return override;
+  const normalized = network.toLowerCase();
+  const config = NETWORK_CONFIG[normalized];
+  if (config) {
+    return config.passphrase;
+  }
+  throw new Error(`Unsupported Stellar network '${network}'. Provide STELLAR_NETWORK_PASSPHRASE to override.`);
+}
+
+function defaultHorizonUrl(network: string): string {
+  const normalized = network.toLowerCase();
+  const config = NETWORK_CONFIG[normalized];
+  if (config) {
+    return config.horizon;
+  }
+  throw new Error(`Unknown network '${network}'. Set STELLAR_HORIZON_URL to continue.`);
+}
+
+function isHttpStatus(error: unknown, status: number): boolean {
+  if (!error || typeof error !== 'object') return false;
+  const response = (error as { response?: { status?: number } }).response;
+  return response?.status === status;
+}
+
+function extractResultCodes(error: unknown): ResultCodes | undefined {
+  if (!error || typeof error !== 'object') return undefined;
+  const response = (error as { response?: { data?: any } }).response;
+  if (!response || typeof response.data !== 'object') return undefined;
+
+  const data = response.data as { details?: any; result_codes?: any };
+  const details = data.details ?? {};
+  const source = details.result_codes ?? data.result_codes;
+  if (!source || typeof source !== 'object') return undefined;
+
+  const transaction = typeof source.transaction === 'string' ? source.transaction : undefined;
+  const operations = Array.isArray(source.operations)
+    ? source.operations.filter((code: unknown): code is string => typeof code === 'string')
+    : undefined;
+  return { transaction, operations };
+}
+
+function extractErrorMessage(error: unknown): string {
+  if (!error) return 'Unknown error';
+  if (typeof error === 'string') return error;
+  const messages = new Set<string>();
+
+  if (error instanceof Error && error.message) {
+    messages.add(error.message);
+  }
+
+  if (typeof error === 'object') {
+    const anyError = error as any;
+    const response = anyError.response;
+    if (response) {
+      if (typeof response.statusText === 'string') messages.add(response.statusText);
+      const data = response.data;
+      if (typeof data === 'string') {
+        messages.add(data);
+      } else if (data && typeof data === 'object') {
+        if (typeof data.error === 'string') messages.add(data.error);
+        if (typeof data.message === 'string') messages.add(data.message);
+        if (typeof data.detail === 'string') messages.add(data.detail);
+        if (Array.isArray(data.details)) {
+          for (const detail of data.details) {
+            if (typeof detail === 'string') messages.add(detail);
+            else if (detail && typeof detail === 'object' && typeof detail.message === 'string') {
+              messages.add(detail.message);
+            }
+          }
+        }
+        if (data.details && typeof data.details === 'object') {
+          const nested = data.details;
+          if (typeof nested.message === 'string') messages.add(nested.message);
+          if (typeof nested.error === 'string') messages.add(nested.error);
+        }
+      }
+    }
+  }
+
+  const collected = Array.from(messages).filter(Boolean);
+  return collected.length ? collected.join(' | ') : 'Unknown error';
+}
+
+function isAccountAlreadyExistsError(error: unknown): boolean {
+  const resultCodes = extractResultCodes(error);
+  if (resultCodes?.operations?.some((code) => code === 'op_already_exists')) {
+    return true;
+  }
+  const message = extractErrorMessage(error).toLowerCase();
+  return message.includes('op_already_exists') || message.includes('account already exists');
+}
+
+function isTxBadSeqError(error: unknown): boolean {
+  const resultCodes = extractResultCodes(error);
+  if (resultCodes?.transaction === 'tx_bad_seq') return true;
+  const message = extractErrorMessage(error).toLowerCase();
+  return message.includes('tx_bad_seq');
+}
+
+async function ensureSigner(signersApi: SignersApi, signerId: string, secretKey: string): Promise<string> {
+  try {
+    const response = await signersApi.createSigner({
+      id: signerId,
+      type: SignerTypeRequest.PLAIN,
+      config: { key: secretKey },
+    });
+    const data = response.data?.data;
+    if (!data) {
+      throw new Error('createSigner returned an empty response');
+    }
+    return data.id;
+  } catch (error) {
+    if (isHttpStatus(error, 409)) {
+      const existing = await signersApi.getSigner(signerId);
+      const data = existing.data?.data;
+      if (!data) {
+        throw new Error(`Signer ${signerId} already exists but could not be fetched`);
+      }
+      return data.id;
+    }
+    throw error;
+  }
+}
+
+async function ensureRelayer(
+  relayersApi: RelayersApi,
+  relayerId: string,
+  relayerName: string,
+  network: string,
+  signerId: string
+): Promise<{ id: string; address?: string }> {
+  try {
+    const response = await relayersApi.createRelayer({
+      id: relayerId,
+      name: relayerName,
+      network,
+      network_type: RelayerNetworkType.STELLAR,
+      signer_id: signerId,
+      paused: false,
+    });
+    const data = response.data?.data;
+    if (!data) {
+      throw new Error('createRelayer returned an empty response');
+    }
+    return { id: data.id, address: data.address };
+  } catch (error) {
+    if (isHttpStatus(error, 409)) {
+      const existing = await relayersApi.getRelayer(relayerId);
+      const data = existing.data?.data;
+      if (!data) {
+        throw new Error(`Relayer ${relayerId} already exists but could not be fetched`);
+      }
+      return { id: data.id, address: data.address };
+    }
+    throw error;
+  }
+}
+
+async function collectExistingIndices(relayersApi: RelayersApi, prefix: string, network: string): Promise<Set<number>> {
+  const indices = new Set<number>();
+  const perPage = 100;
+  let page = 1;
+  let processed = 0;
+  let totalItems = Number.POSITIVE_INFINITY;
+
+  while (processed < totalItems) {
+    const response = await relayersApi.listRelayers(page, perPage);
+    const payload = response.data;
+    const data = payload.data ?? [];
+
+    for (const relayer of data) {
+      if (relayer.network_type !== RelayerNetworkType.STELLAR) continue;
+      if (relayer.network.toLowerCase() !== network) continue;
+      const index = parseIndexFromName(relayer.name, prefix);
+      if (index !== undefined) {
+        indices.add(index);
+      }
+    }
+
+    const pagination = payload.pagination;
+    if (pagination) {
+      totalItems = pagination.total_items;
+      processed += data.length;
+      if (processed >= totalItems || data.length === 0) {
+        break;
+      }
+    } else {
+      break;
+    }
+
+    page += 1;
+  }
+
+  return indices;
+}
+
+async function main(): Promise<void> {
+  const options = parseArgs(process.argv.slice(2));
+  const basePath = requireOption(options.basePath, 'Relayer base URL (--base-url) is required.');
+  const accessToken = requireOption(options.accessToken, 'Relayer API key (--api-key) is required.');
+  const fundingRelayerId = requireOption(
+    options.fundingRelayerId,
+    'Funding relayer ID (--funding-relayer) is required.'
+  );
+  const network = options.network;
+  const networkPassphrase = getNetworkPassphrase(network);
+  const horizonUrl = options.horizonUrl ?? defaultHorizonUrl(network);
+
+  const configuration = new Configuration({ basePath, accessToken });
+  const relayersApi = new RelayersApi(configuration);
+  const signersApi = new SignersApi(configuration);
+  const pluginsApi = new PluginsApi(configuration);
+
+  const fundingRelayerResponse = await relayersApi.getRelayer(fundingRelayerId);
+  const fundingRelayer = fundingRelayerResponse.data?.data;
+  if (!fundingRelayer) {
+    throw new Error(`Funding relayer ${fundingRelayerId} not found`);
+  }
+  const fundingAddress = fundingRelayer.address;
+  if (!fundingAddress) {
+    throw new Error(`Funding relayer ${fundingRelayerId} does not expose an address`);
+  }
+
+  console.log(`Funding relayer: ${fundingRelayerId} (${fundingAddress})`);
+  console.log(`Stellar network: ${network}`);
+  console.log(`Horizon URL: ${horizonUrl}`);
+  console.log(`Starting balance: ${options.startingBalance} XLM`);
+  console.log(`Target accounts: ${options.total}`);
+  if (options.dryRun) {
+    console.log('Dry run enabled: no signers, relayers, or transactions will be created.');
+  }
+
+  const existingIndices = await collectExistingIndices(relayersApi, options.prefix, network);
+  console.log(`Found ${existingIndices.size} existing relayers with prefix '${options.prefix}'.`);
+
+  const allIndices = Array.from({ length: options.total }, (_, idx) => idx + 1);
+  const missingIndices = allIndices.filter((index) => !existingIndices.has(index));
+  const indicesToProcess = options.fix ? allIndices : missingIndices;
+
+  if (indicesToProcess.length === 0) {
+    console.log('No missing accounts detected. Nothing to do.');
+    if (!options.fix) {
+      return;
+    }
+  }
+
+  if (options.fix) {
+    console.log(`Fix mode enabled: validating ${indicesToProcess.length} account(s).`);
+  } else {
+    console.log(`Preparing to create ${indicesToProcess.length} new account(s).`);
+  }
+  console.log(`Starting balance per account: ${options.startingBalance} XLM`);
+
+  if (options.dryRun) {
+    console.log('Dry run summary:');
+    for (const index of indicesToProcess) {
+      const name = formatAccountName(options.prefix, index, options.padding);
+      console.log(
+        options.fix
+          ? `- would verify relayer '${name}' and signer '${name}-signer', funding if required.`
+          : `- would create relayer '${name}' and signer '${name}-signer'.`
+      );
+    }
+    return;
+  }
+
+  const server = new Server(horizonUrl);
+  const fundingAccountResponse = await server.loadAccount(fundingAddress);
+  const baseReserveStroops = await fetchBaseReserveStroops(server);
+  const targetCount = indicesToProcess.length;
+  const fundingSummary = summarizeFundingCapacity(
+    fundingAccountResponse,
+    baseReserveStroops,
+    options.startingBalance,
+    targetCount
+  );
+
+  console.log(
+    `[Funding] Native balance: ${formatLumens(fundingSummary.balance)} XLM (reserve: ${formatLumens(
+      fundingSummary.reserve
+    )} XLM).`
+  );
+  console.log(`[Funding] Available for new accounts: ${formatLumens(fundingSummary.available)} XLM`);
+  console.log(
+    `[Funding] Required for ${targetCount} account(s): ${formatLumens(
+      fundingSummary.totalRequired
+    )} XLM (starting balances ${formatLumens(fundingSummary.totalStarting)} + fees ${formatLumens(
+      fundingSummary.totalFees
+    )}).`
+  );
+
+  if (fundingSummary.available < fundingSummary.totalRequired) {
+    const deficit = fundingSummary.totalRequired - fundingSummary.available;
+    throw new Error(
+      `Funding relayer ${fundingRelayerId} needs an additional ${formatLumens(deficit)} XLM to fund ${
+        targetCount
+      } account(s). Top up the account or reduce the account count.`
+    );
+  }
+
+  let currentSequence = fundingAccountResponse.sequenceNumber();
+  console.log(`Funding account sequence: ${currentSequence}`);
+
+  const createdAccounts: CreatedAccountSummary[] = [];
+
+  for (const index of indicesToProcess) {
+    const accountName = formatAccountName(options.prefix, index, options.padding);
+    const signerId = `${accountName}-signer`;
+    const relayerId = accountName;
+
+    const existingSigner = await fetchSignerRecord(signersApi, signerId);
+    const existingRelayer = await fetchRelayerRecord(relayersApi, relayerId);
+
+    const signerExistedBefore = Boolean(existingSigner);
+    const relayerExistedBefore = Boolean(existingRelayer);
+
+    let signerRecord = existingSigner;
+    let relayerRecord = existingRelayer;
+    let keypair: Keypair | undefined;
+    let secretSeed: string | undefined;
+    let secretHex: string | undefined;
+    let signerCreated = false;
+    let relayerCreated = false;
+
+    if (!signerRecord) {
+      keypair = Keypair.random();
+      secretSeed = keypair.secret();
+      secretHex = Buffer.from(keypair.rawSecretKey()).toString('hex');
+      const signerIdentifier = await ensureSigner(signersApi, signerId, secretHex);
+      signerRecord = { id: signerIdentifier };
+      signerCreated = true;
+    }
+
+    if (!relayerRecord) {
+      if (!keypair) {
+        if (signerRecord) {
+          console.log(`[${accountName}] Relayer missing; recreating signer to restore configuration.`);
+          await deleteSignerIfExists(signersApi, signerId);
+          keypair = Keypair.random();
+          secretSeed = keypair.secret();
+          secretHex = Buffer.from(keypair.rawSecretKey()).toString('hex');
+          const signerIdentifier = await ensureSigner(signersApi, signerId, secretHex);
+          signerRecord = { id: signerIdentifier };
+          signerCreated = true;
+        } else {
+          keypair = Keypair.random();
+          secretSeed = keypair.secret();
+          secretHex = Buffer.from(keypair.rawSecretKey()).toString('hex');
+          const signerIdentifier = await ensureSigner(signersApi, signerId, secretHex);
+          signerRecord = { id: signerIdentifier };
+          signerCreated = true;
+        }
+      }
+
+      const relayerInfo = await ensureRelayer(
+        relayersApi,
+        relayerId,
+        accountName,
+        network,
+        signerRecord.id
+      );
+      relayerRecord = { id: relayerInfo.id, address: relayerInfo.address, signer_id: signerRecord.id };
+      relayerCreated = true;
+    }
+
+    if (!signerRecord) {
+      throw new Error(`[${accountName}] Unable to ensure signer state.`);
+    }
+    if (!relayerRecord) {
+      throw new Error(
+        `[${accountName}] Unable to determine account address. Consider deleting the relayer and signer manually before rerunning.`
+      );
+    }
+
+    const publicKey = relayerRecord.address ?? keypair?.publicKey();
+    if (!publicKey) {
+      throw new Error(
+        `[${accountName}] Unable to determine account address. Consider deleting the relayer and signer manually before rerunning.`
+      );
+    }
+
+    const signerIdentifier = signerRecord.id;
+    const relayerIdentifier = relayerRecord.id;
+
+    if (signerCreated || relayerCreated) {
+      console.log(
+        `[${accountName}] Signer ${signerIdentifier} and relayer ${relayerIdentifier} ready. Account address: ${publicKey}`
+      );
+    } else {
+      console.log(`[${accountName}] Validating existing signer ${signerIdentifier} and relayer ${relayerIdentifier}.`);
+    }
+
+    const accountAlreadyExists = await accountExists(server, publicKey);
+
+    let funded = false;
+    if (accountAlreadyExists) {
+      console.log(`[${accountName}] Account already exists on network. Skipping funding.`);
+    } else {
+      let submitted = false;
+      let attempt = 0;
+      while (!submitted && attempt < 2) {
+        attempt += 1;
+        const account = new Account(fundingAddress, currentSequence);
+        const transaction = new TransactionBuilder(account, {
+          fee: BASE_FEE.toString(),
+          networkPassphrase,
+        })
+          .addOperation(
+            Operation.createAccount({
+              destination: publicKey,
+              startingBalance: options.startingBalance,
+            })
+          )
+          .setTimeout(options.timeoutSeconds)
+          .build();
+
+        const transactionXdr = transaction.toXDR();
+        currentSequence = account.sequenceNumber();
+
+        const request: StellarTransactionRequest = {
+          network,
+          transaction_xdr: transactionXdr,
+        };
+
+        try {
+          const response = await relayersApi.sendTransaction(fundingRelayerId, request);
+          const payload = response.data?.data;
+          const status = payload && 'status' in payload ? (payload as { status?: string }).status : undefined;
+          const hash = payload && 'hash' in payload ? (payload as { hash?: string }).hash : undefined;
+          console.log(
+            `[${accountName}] Submitted funding transaction${hash ? ` (hash: ${hash})` : ''}${
+              status ? ` with status ${status}` : ''
+            }.`
+          );
+          if (payload && 'id' in payload) {
+            const id = (payload as { id?: string }).id;
+            if (id) {
+              await waitForTransactionConfirmation(relayersApi, fundingRelayerId, id);
+              console.log(`[${accountName}] Funding transaction ${id} confirmed.`);
+            }
+          }
+          submitted = true;
+          funded = true;
+        } catch (error) {
+          console.error(`[${accountName}] Funding transaction failed: ${extractErrorMessage(error)}`);
+          const refreshed = await server.loadAccount(fundingAddress);
+          currentSequence = refreshed.sequenceNumber();
+
+          if (isAccountAlreadyExistsError(error)) {
+            console.warn(`[${accountName}] Account appears to already exist. Skipping funding.`);
+            submitted = true;
+          } else if (attempt < 2 && isTxBadSeqError(error)) {
+            console.warn(`[${accountName}] Sequence mismatch detected. Retrying with refreshed sequence.`);
+          } else {
+            throw error;
+          }
+        }
+      }
+    }
+
+    createdAccounts.push({
+      name: accountName,
+      relayerId: relayerIdentifier,
+      signerId: signerIdentifier,
+      publicKey,
+      secretSeed,
+      secretHex,
+      accountExisted: accountAlreadyExists,
+      funded,
+    });
+  }
+
+  console.log(options.fix ? '\nAccount audit summary:' : '\nAccount creation summary:');
+  for (const entry of createdAccounts) {
+    const secretInfo = entry.secretSeed && entry.secretHex
+      ? `, secret_seed=${entry.secretSeed}, secret_hex=${entry.secretHex}`
+      : '';
+    const existedLabel = entry.accountExisted ? 'yes' : 'no';
+    const fundedLabel = entry.funded ? 'yes' : 'no';
+    console.log(
+      `- ${entry.name}: relayer=${entry.relayerId}, signer=${entry.signerId}, public=${entry.publicKey}, existed=${existedLabel}, funded=${fundedLabel}${secretInfo}`
+    );
+  }
+
+  const relayerIdsForPlugin = allIndices.map((index) =>
+    formatAccountName(options.prefix, index, options.padding).toLowerCase(),
+  );
+  await updateLaunchTubePlugin(pluginsApi, options.pluginId, options.pluginAdminSecret, relayerIdsForPlugin);
+}
+
+main().catch((error) => {
+  console.error(`\nScript failed: ${extractErrorMessage(error)}`);
+  if (error instanceof Error && error.stack) {
+    console.error(error.stack);
+  }
+  process.exitCode = 1;
+});

--- a/examples/launchtube-plugin-example/launchtube/package.json
+++ b/examples/launchtube-plugin-example/launchtube/package.json
@@ -15,7 +15,8 @@
   "dependencies": {
     "@openzeppelin/relayer-plugin-launchtube": "0.2.0",
     "@openzeppelin/relayer-sdk": "^1.6.0",
-    "@types/node": "^24.0.3"
+    "@types/node": "^24.0.3",
+    "stellar-sdk": "^12.3.0"
   },
   "devDependencies": {
     "@types/jest": "^29.5.12",
@@ -23,6 +24,7 @@
     "husky": "^9.1.7",
     "jest": "^29.7.0",
     "ts-jest": "^29.1.2",
+    "ts-node": "^10.9.2",
     "typescript": "^5.3.3"
   }
 }

--- a/examples/launchtube-plugin-example/launchtube/package.json
+++ b/examples/launchtube-plugin-example/launchtube/package.json
@@ -13,7 +13,7 @@
   "author": "",
   "license": "",
   "dependencies": {
-    "@openzeppelin/relayer-plugin-launchtube": "0.2.0",
+    "@openzeppelin/relayer-plugin-launchtube": "0.3.0",
     "@openzeppelin/relayer-sdk": "^1.6.0",
     "@types/node": "^24.0.3",
     "stellar-sdk": "^12.3.0"

--- a/examples/launchtube-plugin-example/launchtube/pnpm-lock.yaml
+++ b/examples/launchtube-plugin-example/launchtube/pnpm-lock.yaml
@@ -15,6 +15,9 @@ importers:
       '@types/node':
         specifier: ^24.0.3
         version: 24.2.0
+      stellar-sdk:
+        specifier: ^12.3.0
+        version: 12.3.0
     devDependencies:
       '@types/jest':
         specifier: ^29.5.12
@@ -27,10 +30,13 @@ importers:
         version: 9.1.7
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.2.0)
+        version: 29.7.0(@types/node@24.2.0)(ts-node@10.9.2(@types/node@24.2.0)(typescript@5.9.2))
       ts-jest:
         specifier: ^29.1.2
-        version: 29.4.1(@babel/core@7.28.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.2.0))(typescript@5.9.2)
+        version: 29.4.1(@babel/core@7.28.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.2.0)(ts-node@10.9.2(@types/node@24.2.0)(typescript@5.9.2)))(typescript@5.9.2)
+      ts-node:
+        specifier: ^10.9.2
+        version: 10.9.2(@types/node@24.2.0)(typescript@5.9.2)
       typescript:
         specifier: ^5.3.3
         version: 5.9.2
@@ -172,6 +178,9 @@ packages:
     engines: {node: '>=6.9.0'}
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
+  '@cspotcode/source-map-support@0.8.1':
+    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
+    engines: {node: '>=12'}
   '@istanbuljs/load-nyc-config@1.1.0':
     resolution: {integrity: sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==}
     engines: {node: '>=8'}
@@ -239,6 +248,8 @@ packages:
     resolution: {integrity: sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw==}
   '@jridgewell/trace-mapping@0.3.29':
     resolution: {integrity: sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ==}
+  '@jridgewell/trace-mapping@0.3.9':
+    resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
   '@openzeppelin/relayer-plugin-launchtube@0.2.0':
     resolution: {integrity: sha512-nhD5ZHDngjeoqdBArzKR1nzbK1R4Gv49fY+cuF3l+QrZ1IVX6PciBqUFenC5kCaKnyBqvMMJx+XDIBFqY7/bgg==}
     engines: {node: '>=22.18.0', npm: use pnpm, pnpm: '>=9', yarn: use pnpm}
@@ -255,8 +266,18 @@ packages:
     resolution: {integrity: sha512-VVolPL5goVEIsvuGqDc5uiKxV03lzfWdvYg1KikvwheDmTBO68CKDji3bAZ/kppZrx5iTA8z3Ld5yuytcvhvOQ==}
   '@stellar/stellar-base@11.0.1':
     resolution: {integrity: sha512-VQh+1KEtFjegD6spx08+lENt8tQOkQQQZoLtqExjpRXyWlqDhEe+bXMlBTYKDc5MIynHyD42RPEib27UG17trA==}
+  '@stellar/stellar-base@12.1.1':
+    resolution: {integrity: sha512-gOBSOFDepihslcInlqnxKZdIW9dMUO1tpOm3AtJR33K2OvpXG6SaVHCzAmCFArcCqI9zXTEiSoh70T48TmiHJA==}
   '@stellar/stellar-sdk@11.3.0':
     resolution: {integrity: sha512-i+heopibJNRA7iM8rEPz0AXphBPYvy2HDo8rxbDwWpozwCfw8kglP9cLkkhgJe8YicgLrdExz/iQZaLpqLC+6w==}
+  '@tsconfig/node10@1.0.11':
+    resolution: {integrity: sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==}
+  '@tsconfig/node12@1.0.11':
+    resolution: {integrity: sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==}
+  '@tsconfig/node14@1.0.3':
+    resolution: {integrity: sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==}
+  '@tsconfig/node16@1.0.4':
+    resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
   '@types/babel__generator@7.27.0':
@@ -285,6 +306,13 @@ packages:
     resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
   '@types/yargs@17.0.33':
     resolution: {integrity: sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==}
+  acorn-walk@8.3.4:
+    resolution: {integrity: sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==}
+    engines: {node: '>=0.4.0'}
+  acorn@8.15.0:
+    resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
   ansi-escapes@4.3.2:
     resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
     engines: {node: '>=8'}
@@ -300,6 +328,8 @@ packages:
   anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
+  arg@4.1.3:
+    resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
   argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
   asynckit@0.4.0:
@@ -434,6 +464,8 @@ packages:
     resolution: {integrity: sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
+  create-require@1.1.1:
+    resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -467,6 +499,9 @@ packages:
   diff-sequences@29.6.3:
     resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+  diff@4.0.2:
+    resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
+    engines: {node: '>=0.3.1'}
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
@@ -954,6 +989,9 @@ packages:
   stack-utils@2.0.6:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
     engines: {node: '>=10'}
+  stellar-sdk@12.3.0:
+    resolution: {integrity: sha512-3z7umyuBAHN+vm3zLTKqj7P/bErBFnjrwoanBsNyBHaoek9krUgufNupQSMK67B1p0E2NKD1Z6gYPuZiPfJ2qQ==}
+    deprecated: ⚠️ This package has moved to @stellar/stellar-sdk! 🚚
   string-length@4.0.2:
     resolution: {integrity: sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==}
     engines: {node: '>=10'}
@@ -1020,6 +1058,19 @@ packages:
         optional: true
       jest-util:
         optional: true
+  ts-node@10.9.2:
+    resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
+    hasBin: true
+    peerDependencies:
+      '@swc/core': '>=1.2.50'
+      '@swc/wasm': '>=1.2.50'
+      '@types/node': '*'
+      typescript: '>=2.7'
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      '@swc/wasm':
+        optional: true
   tweetnacl@1.0.3:
     resolution: {integrity: sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==}
   type-detect@4.0.8:
@@ -1051,6 +1102,8 @@ packages:
       browserslist: '>= 4.21.0'
   urijs@1.19.11:
     resolution: {integrity: sha512-HXgFDgDommxn5/bIv0cnQZsPhHDA90NPHD6+c/v21U5+Sx5hoP8+dP9IZXBU1gIfvdRfhG8cel9QNPeionfcCQ==}
+  v8-compile-cache-lib@3.0.1:
+    resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
   v8-to-istanbul@9.3.0:
     resolution: {integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==}
     engines: {node: '>=10.12.0'}
@@ -1084,6 +1137,9 @@ packages:
   yargs@17.7.2:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
+  yn@3.1.1:
+    resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}
+    engines: {node: '>=6'}
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
@@ -1250,6 +1306,9 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
   '@bcoe/v8-coverage@0.2.3': {}
+  '@cspotcode/source-map-support@0.8.1':
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.9
   '@istanbuljs/load-nyc-config@1.1.0':
     dependencies:
       camelcase: 5.3.1
@@ -1266,7 +1325,7 @@ snapshots:
       jest-message-util: 29.7.0
       jest-util: 29.7.0
       slash: 3.0.0
-  '@jest/core@29.7.0':
+  '@jest/core@29.7.0(ts-node@10.9.2(@types/node@24.2.0)(typescript@5.9.2))':
     dependencies:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0
@@ -1280,7 +1339,7 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@24.2.0)
+      jest-config: 29.7.0(@types/node@24.2.0)(ts-node@10.9.2(@types/node@24.2.0)(typescript@5.9.2))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -1416,6 +1475,10 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.4
+  '@jridgewell/trace-mapping@0.3.9':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.4
   '@openzeppelin/relayer-plugin-launchtube@0.2.0':
     dependencies:
       '@actions/exec': 1.1.1
@@ -1446,6 +1509,16 @@ snapshots:
       tweetnacl: 1.0.3
     optionalDependencies:
       sodium-native: 4.3.3
+  '@stellar/stellar-base@12.1.1':
+    dependencies:
+      '@stellar/js-xdr': 3.1.2
+      base32.js: 0.1.0
+      bignumber.js: 9.3.1
+      buffer: 6.0.3
+      sha.js: 2.4.12
+      tweetnacl: 1.0.3
+    optionalDependencies:
+      sodium-native: 4.3.3
   '@stellar/stellar-sdk@11.3.0':
     dependencies:
       '@stellar/stellar-base': 11.0.1
@@ -1457,6 +1530,10 @@ snapshots:
       urijs: 1.19.11
     transitivePeerDependencies:
       - debug
+  '@tsconfig/node10@1.0.11': {}
+  '@tsconfig/node12@1.0.11': {}
+  '@tsconfig/node14@1.0.3': {}
+  '@tsconfig/node16@1.0.4': {}
   '@types/babel__core@7.20.5':
     dependencies:
       '@babel/parser': 7.28.0
@@ -1497,6 +1574,10 @@ snapshots:
   '@types/yargs@17.0.33':
     dependencies:
       '@types/yargs-parser': 21.0.3
+  acorn-walk@8.3.4:
+    dependencies:
+      acorn: 8.15.0
+  acorn@8.15.0: {}
   ansi-escapes@4.3.2:
     dependencies:
       type-fest: 0.21.3
@@ -1509,6 +1590,7 @@ snapshots:
     dependencies:
       normalize-path: 3.0.0
       picomatch: 2.3.1
+  arg@4.1.3: {}
   argparse@1.0.10:
     dependencies:
       sprintf-js: 1.0.3
@@ -1667,13 +1749,13 @@ snapshots:
       delayed-stream: 1.0.0
   concat-map@0.0.1: {}
   convert-source-map@2.0.0: {}
-  create-jest@29.7.0(@types/node@24.2.0):
+  create-jest@29.7.0(@types/node@24.2.0)(ts-node@10.9.2(@types/node@24.2.0)(typescript@5.9.2)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@24.2.0)
+      jest-config: 29.7.0(@types/node@24.2.0)(ts-node@10.9.2(@types/node@24.2.0)(typescript@5.9.2))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -1681,6 +1763,7 @@ snapshots:
       - babel-plugin-macros
       - supports-color
       - ts-node
+  create-require@1.1.1: {}
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -1699,6 +1782,7 @@ snapshots:
   delayed-stream@1.0.0: {}
   detect-newline@3.1.0: {}
   diff-sequences@29.6.3: {}
+  diff@4.0.2: {}
   dunder-proto@1.0.1:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -1912,16 +1996,16 @@ snapshots:
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
-  jest-cli@29.7.0(@types/node@24.2.0):
+  jest-cli@29.7.0(@types/node@24.2.0)(ts-node@10.9.2(@types/node@24.2.0)(typescript@5.9.2)):
     dependencies:
-      '@jest/core': 29.7.0
+      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@24.2.0)(typescript@5.9.2))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@24.2.0)
+      create-jest: 29.7.0(@types/node@24.2.0)(ts-node@10.9.2(@types/node@24.2.0)(typescript@5.9.2))
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@24.2.0)
+      jest-config: 29.7.0(@types/node@24.2.0)(ts-node@10.9.2(@types/node@24.2.0)(typescript@5.9.2))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -1930,7 +2014,7 @@ snapshots:
       - babel-plugin-macros
       - supports-color
       - ts-node
-  jest-config@29.7.0(@types/node@24.2.0):
+  jest-config@29.7.0(@types/node@24.2.0)(ts-node@10.9.2(@types/node@24.2.0)(typescript@5.9.2)):
     dependencies:
       '@babel/core': 7.28.0
       '@jest/test-sequencer': 29.7.0
@@ -1956,6 +2040,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 24.2.0
+      ts-node: 10.9.2(@types/node@24.2.0)(typescript@5.9.2)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -2153,12 +2238,12 @@ snapshots:
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
-  jest@29.7.0(@types/node@24.2.0):
+  jest@29.7.0(@types/node@24.2.0)(ts-node@10.9.2(@types/node@24.2.0)(typescript@5.9.2)):
     dependencies:
-      '@jest/core': 29.7.0
+      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@24.2.0)(typescript@5.9.2))
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@24.2.0)
+      jest-cli: 29.7.0(@types/node@24.2.0)(ts-node@10.9.2(@types/node@24.2.0)(typescript@5.9.2))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -2313,6 +2398,17 @@ snapshots:
   stack-utils@2.0.6:
     dependencies:
       escape-string-regexp: 2.0.0
+  stellar-sdk@12.3.0:
+    dependencies:
+      '@stellar/stellar-base': 12.1.1
+      axios: 1.11.0
+      bignumber.js: 9.3.1
+      eventsource: 2.0.2
+      randombytes: 2.1.0
+      toml: 3.0.0
+      urijs: 1.19.11
+    transitivePeerDependencies:
+      - debug
   string-length@4.0.2:
     dependencies:
       char-regex: 1.0.2
@@ -2350,12 +2446,12 @@ snapshots:
     dependencies:
       is-number: 7.0.0
   toml@3.0.0: {}
-  ? ts-jest@29.4.1(@babel/core@7.28.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.2.0))(typescript@5.9.2)
+  ? ts-jest@29.4.1(@babel/core@7.28.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.2.0)(ts-node@10.9.2(@types/node@24.2.0)(typescript@5.9.2)))(typescript@5.9.2)
   : dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       handlebars: 4.7.8
-      jest: 29.7.0(@types/node@24.2.0)
+      jest: 29.7.0(@types/node@24.2.0)(ts-node@10.9.2(@types/node@24.2.0)(typescript@5.9.2))
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
@@ -2369,6 +2465,23 @@ snapshots:
       '@jest/types': 29.6.3
       babel-jest: 29.7.0(@babel/core@7.28.0)
       jest-util: 29.7.0
+  ts-node@10.9.2(@types/node@24.2.0)(typescript@5.9.2):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.11
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 24.2.0
+      acorn: 8.15.0
+      acorn-walk: 8.3.4
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.9.2
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
   tweetnacl@1.0.3: {}
   type-detect@4.0.8: {}
   type-fest@0.21.3: {}
@@ -2388,6 +2501,7 @@ snapshots:
       escalade: 3.2.0
       picocolors: 1.1.1
   urijs@1.19.11: {}
+  v8-compile-cache-lib@3.0.1: {}
   v8-to-istanbul@9.3.0:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.29
@@ -2431,4 +2545,5 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
+  yn@3.1.1: {}
   yocto-queue@0.1.0: {}

--- a/examples/launchtube-plugin-example/launchtube/pnpm-lock.yaml
+++ b/examples/launchtube-plugin-example/launchtube/pnpm-lock.yaml
@@ -7,8 +7,8 @@ importers:
   .:
     dependencies:
       '@openzeppelin/relayer-plugin-launchtube':
-        specifier: 0.2.0
-        version: 0.2.0
+        specifier: 0.3.0
+        version: 0.3.0
       '@openzeppelin/relayer-sdk':
         specifier: ^1.6.0
         version: 1.6.0
@@ -250,8 +250,8 @@ packages:
     resolution: {integrity: sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ==}
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
-  '@openzeppelin/relayer-plugin-launchtube@0.2.0':
-    resolution: {integrity: sha512-nhD5ZHDngjeoqdBArzKR1nzbK1R4Gv49fY+cuF3l+QrZ1IVX6PciBqUFenC5kCaKnyBqvMMJx+XDIBFqY7/bgg==}
+  '@openzeppelin/relayer-plugin-launchtube@0.3.0':
+    resolution: {integrity: sha512-pbl14AB1lBJpGGdi3WWBwtizzNOPSRoH4IJ7eMWGyH/ObjAl0bOCvL6eFLk6sbmnAel/710J0DQD1E/hBC+JZA==}
     engines: {node: '>=22.18.0', npm: use pnpm, pnpm: '>=9', yarn: use pnpm}
   '@openzeppelin/relayer-sdk@1.6.0':
     resolution: {integrity: sha512-UjL4TLz4tvCY1ssE3wf47FU+/2vE/bJ5HoXyufUsidL5bRXwf6ziwWZWUa0YsPiGEQNdVtsuoUR9qqHjxYqlXg==}
@@ -1479,7 +1479,7 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.4
-  '@openzeppelin/relayer-plugin-launchtube@0.2.0':
+  '@openzeppelin/relayer-plugin-launchtube@0.3.0':
     dependencies:
       '@actions/exec': 1.1.1
       '@openzeppelin/relayer-sdk': 1.6.0


### PR DESCRIPTION
# Summary

Add a LaunchTube tooling script (launchtube/scripts/create-sequence-accounts.ts) that bootstraps or repairs the seq relayers, funds the Stellar accounts (waiting for confirmation), and updates the plugin via its management API. Docs now describe how to run it (including --fix mode) as part of the example setup.

## Testing Process

## Checklist

- [ ] Add a reference to related issues in the PR description.
- [ ] Add unit tests if applicable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a CLI tool to bootstrap and manage Stellar relayer accounts for LaunchTube.
  - Supports creating/fixing multiple accounts by prefix, with automatic funding and validation.
  - Includes dry-run mode for planning without changes and summarized output of created/updated accounts.
  - Automatically updates the associated plugin with the finalized set of relayer IDs.

- Chores
  - Added Stellar SDK as a runtime dependency and ts-node for local execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->