### PR TITLE
chore: Force run of docker-scan

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -288,7 +288,7 @@ jobs:
       - changed_files
       - ci
     if: |
-      ${{ github.event.pull_request.draft == false && needs.changed_files.outputs.changed-docker-files == 'true' }}
+      ${{ always() && github.event.pull_request.draft == false && needs.changed_files.outputs.changed-docker-files == 'true' && needs.ci.result == 'success' }}
     steps:
       # Checkout the repository
       - name: Harden the runner (Audit all outbound calls)


### PR DESCRIPTION
# Summary
Force run of docker scan, since there is a known bug of `if` conditions not working when previous steps (`ci` in this case) are skipped.

## Testing Process
We need to test it by merging it.

## Checklist

- [ ] Add a reference to related issues in the PR description.
- [ ] Add unit tests if applicable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI workflow reliability by refining conditions for when the Docker security scan runs.
  * Ensures scans only execute after core checks complete successfully, reducing false positives and unnecessary runs.
  * Clarifies job dependencies within the pipeline for more predictable outcomes and cleaner build reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->