### PR TITLE
fix: Improve docker cargo caching

### DIFF
--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -15,7 +15,8 @@ WORKDIR /usr/app
 COPY . .
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
-    --mount=type=cache,target=/app/target \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/usr/app/target \
     cargo install --root /usr/app --path . --debug --locked
 
 # Setting up build directories

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -11,7 +11,8 @@ WORKDIR /usr/app
 
 COPY . .
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
-    --mount=type=cache,target=/app/target \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/usr/app/target \
     cargo install --root /usr/app --path . --debug --locked
 
 # Setting up build directories


### PR DESCRIPTION
# Summary

The Dockerfiles for both dev and production images currently mount the Cargo target cache at `/app/target`, but cargo install builds in `/usr/app/target`, so the cache never hits and rebuilds are slow. Ive pointed the target cache at `/usr/app/target` to align with the actual build and added a cache mount for /usr/local/cargo/git so git dependencies are reused

## Testing Process

## Checklist

- [ ] Add a reference to related issues in the PR description.
- [ ] Add unit tests if applicable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized Docker build caching for development and production images to better reuse dependencies and build artifacts.
  * Improves caching of source-controlled dependencies and compiled outputs, reducing redundant work during builds.
  * Expected outcomes: faster local iterations, reduced CI/CD build times, and quicker deployments.
  * No changes to application behavior or features; runtime remains unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->