### PR TITLE
chore: Regenerate openapi spec with latest plugin changes

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -510,7 +510,8 @@
         "tags": [
           "Plugins"
         ],
-        "summary": "Calls a plugin method.",
+        "summary": "Execute a plugin and receive the sanitized result",
+        "description": "Logs and traces are only returned when the plugin is configured with `emit_logs` / `emit_traces`.\nPlugin-provided errors are normalized into a consistent payload (`code`, `details`) and a derived\nmessage so downstream clients receive a stable shape regardless of how the handler threw.",
         "operationId": "callPlugin",
         "parameters": [
           {
@@ -539,21 +540,54 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiResponse_PluginCallResponse"
+                  "$ref": "#/components/schemas/ApiResponse_Value"
+                },
+                "example": {
+                  "data": "done!",
+                  "error": null,
+                  "metadata": {
+                    "logs": [
+                      {
+                        "level": "info",
+                        "message": "Plugin started..."
+                      }
+                    ],
+                    "traces": [
+                      {
+                        "method": "sendTransaction",
+                        "relayerId": "sepolia-example",
+                        "requestId": "6c1f336f-3030-4f90-bd99-ada190a1235b"
+                      }
+                    ]
+                  },
+                  "success": true
                 }
               }
             }
           },
           "400": {
-            "description": "BadRequest",
+            "description": "BadRequest (plugin-provided)",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiResponse_String"
+                  "$ref": "#/components/schemas/ApiResponse_PluginHandlerError"
                 },
                 "example": {
-                  "data": null,
-                  "message": "Bad Request",
+                  "data": {
+                    "code": "VALIDATION_FAILED",
+                    "details": {
+                      "field": "email"
+                    }
+                  },
+                  "error": "Validation failed",
+                  "metadata": {
+                    "logs": [
+                      {
+                        "level": "error",
+                        "message": "Validation failed for field: email"
+                      }
+                    ]
+                  },
                   "success": false
                 }
               }
@@ -568,7 +602,7 @@
                 },
                 "example": {
                   "data": null,
-                  "message": "Unauthorized",
+                  "error": "Unauthorized",
                   "success": false
                 }
               }
@@ -583,7 +617,7 @@
                 },
                 "example": {
                   "data": null,
-                  "message": "Plugin with ID plugin_id not found",
+                  "error": "Plugin with ID plugin_id not found",
                   "success": false
                 }
               }
@@ -598,7 +632,7 @@
                 },
                 "example": {
                   "data": null,
-                  "message": "Too Many Requests",
+                  "error": "Too Many Requests",
                   "success": false
                 }
               }
@@ -613,7 +647,7 @@
                 },
                 "example": {
                   "data": null,
-                  "message": "Internal Server Error",
+                  "error": "Internal Server Error",
                   "success": false
                 }
               }
@@ -3393,6 +3427,9 @@
           "error": {
             "type": "string"
           },
+          "metadata": {
+            "$ref": "#/components/schemas/PluginMetadata"
+          },
           "pagination": {
             "$ref": "#/components/schemas/PaginationMeta"
           },
@@ -3438,6 +3475,9 @@
           "error": {
             "type": "string"
           },
+          "metadata": {
+            "$ref": "#/components/schemas/PluginMetadata"
+          },
           "pagination": {
             "$ref": "#/components/schemas/PaginationMeta"
           },
@@ -3480,6 +3520,9 @@
           "error": {
             "type": "string"
           },
+          "metadata": {
+            "$ref": "#/components/schemas/PluginMetadata"
+          },
           "pagination": {
             "$ref": "#/components/schemas/PaginationMeta"
           },
@@ -3488,7 +3531,7 @@
           }
         }
       },
-      "ApiResponse_PluginCallResponse": {
+      "ApiResponse_PluginHandlerError": {
         "type": "object",
         "required": [
           "success"
@@ -3496,41 +3539,21 @@
         "properties": {
           "data": {
             "type": "object",
-            "required": [
-              "success",
-              "return_value",
-              "message",
-              "logs",
-              "error",
-              "traces"
-            ],
             "properties": {
-              "error": {
-                "type": "string"
+              "code": {
+                "type": [
+                  "string",
+                  "null"
+                ]
               },
-              "logs": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/LogEntry"
-                }
-              },
-              "message": {
-                "type": "string"
-              },
-              "return_value": {
-                "type": "string"
-              },
-              "success": {
-                "type": "boolean"
-              },
-              "traces": {
-                "type": "array",
-                "items": {}
-              }
+              "details": {}
             }
           },
           "error": {
             "type": "string"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/PluginMetadata"
           },
           "pagination": {
             "$ref": "#/components/schemas/PaginationMeta"
@@ -3599,6 +3622,9 @@
           },
           "error": {
             "type": "string"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/PluginMetadata"
           },
           "pagination": {
             "$ref": "#/components/schemas/PaginationMeta"
@@ -3744,6 +3770,9 @@
           "error": {
             "type": "string"
           },
+          "metadata": {
+            "$ref": "#/components/schemas/PluginMetadata"
+          },
           "pagination": {
             "$ref": "#/components/schemas/PaginationMeta"
           },
@@ -3770,6 +3799,9 @@
           },
           "error": {
             "type": "string"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/PluginMetadata"
           },
           "pagination": {
             "$ref": "#/components/schemas/PaginationMeta"
@@ -3811,6 +3843,9 @@
           "error": {
             "type": "string"
           },
+          "metadata": {
+            "$ref": "#/components/schemas/PluginMetadata"
+          },
           "pagination": {
             "$ref": "#/components/schemas/PaginationMeta"
           },
@@ -3850,6 +3885,9 @@
           "error": {
             "type": "string"
           },
+          "metadata": {
+            "$ref": "#/components/schemas/PluginMetadata"
+          },
           "pagination": {
             "$ref": "#/components/schemas/PaginationMeta"
           },
@@ -3869,6 +3907,9 @@
           },
           "error": {
             "type": "string"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/PluginMetadata"
           },
           "pagination": {
             "$ref": "#/components/schemas/PaginationMeta"
@@ -3899,6 +3940,30 @@
           },
           "error": {
             "type": "string"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/PluginMetadata"
+          },
+          "pagination": {
+            "$ref": "#/components/schemas/PaginationMeta"
+          },
+          "success": {
+            "type": "boolean"
+          }
+        }
+      },
+      "ApiResponse_Value": {
+        "type": "object",
+        "required": [
+          "success"
+        ],
+        "properties": {
+          "data": {},
+          "error": {
+            "type": "string"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/PluginMetadata"
           },
           "pagination": {
             "$ref": "#/components/schemas/PaginationMeta"
@@ -3944,6 +4009,9 @@
           },
           "error": {
             "type": "string"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/PluginMetadata"
           },
           "pagination": {
             "$ref": "#/components/schemas/PaginationMeta"
@@ -4016,6 +4084,9 @@
           "error": {
             "type": "string"
           },
+          "metadata": {
+            "$ref": "#/components/schemas/PluginMetadata"
+          },
           "pagination": {
             "$ref": "#/components/schemas/PaginationMeta"
           },
@@ -4058,6 +4129,9 @@
           "error": {
             "type": "string"
           },
+          "metadata": {
+            "$ref": "#/components/schemas/PluginMetadata"
+          },
           "pagination": {
             "$ref": "#/components/schemas/PaginationMeta"
           },
@@ -4090,6 +4164,9 @@
           },
           "error": {
             "type": "string"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/PluginMetadata"
           },
           "pagination": {
             "$ref": "#/components/schemas/PaginationMeta"
@@ -5503,37 +5580,35 @@
           }
         }
       },
-      "PluginCallResponse": {
+      "PluginHandlerError": {
         "type": "object",
-        "required": [
-          "success",
-          "return_value",
-          "message",
-          "logs",
-          "error",
-          "traces"
-        ],
         "properties": {
-          "error": {
-            "type": "string"
+          "code": {
+            "type": [
+              "string",
+              "null"
+            ]
           },
+          "details": {}
+        }
+      },
+      "PluginMetadata": {
+        "type": "object",
+        "properties": {
           "logs": {
-            "type": "array",
+            "type": [
+              "array",
+              "null"
+            ],
             "items": {
               "$ref": "#/components/schemas/LogEntry"
             }
           },
-          "message": {
-            "type": "string"
-          },
-          "return_value": {
-            "type": "string"
-          },
-          "success": {
-            "type": "boolean"
-          },
           "traces": {
-            "type": "array",
+            "type": [
+              "array",
+              "null"
+            ],
             "items": {}
           }
         }
@@ -7136,7 +7211,8 @@
           "created_at",
           "source_account",
           "fee",
-          "sequence_number"
+          "sequence_number",
+          "relayer_id"
         ],
         "properties": {
           "confirmed_at": {
@@ -7154,6 +7230,9 @@
             "type": "string"
           },
           "id": {
+            "type": "string"
+          },
+          "relayer_id": {
             "type": "string"
           },
           "sent_at": {


### PR DESCRIPTION
# Summary

This PR will regenerate openapi spec to include latest plugin improvements.

## Testing Process

## Checklist

- [ ] Add a reference to related issues in the PR description.
- [ ] Add unit tests if applicable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Standardized API responses: unified success/error shape across endpoints with consistent data, success, error, pagination, and metadata fields.
  * New metadata support on many responses, enabling plugin-provided context (e.g., logs/traces).
  * Stellar transaction responses now include relayer_id.

* **Refactor**
  * Normalized error payloads with code and details replacing message-based errors.
  * Consolidated plugin response types into a single, consistent public structure.

* **Documentation**
  * Updated endpoint descriptions and examples to reflect the new response and error formats, including metadata usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->