### PR TITLE
refactor: Handle RPC error codes on retries

### DIFF
--- a/src/services/provider/mod.rs
+++ b/src/services/provider/mod.rs
@@ -37,6 +37,8 @@ pub enum ProviderError {
     BadGateway,
     #[error("Request error (HTTP {status_code}): {error}")]
     RequestError { error: String, status_code: u16 },
+    #[error("JSON-RPC error (code {code}): {message}")]
+    RpcErrorCode { code: i64, message: String },
     #[error("Other provider error: {0}")]
     Other(String),
 }
@@ -145,10 +147,10 @@ where
                 // Fallback for other transport error types
                 ProviderError::Other(format!("Transport error: {}", transport_err))
             }
-            RpcError::ErrorResp(json_rpc_err) => ProviderError::Other(format!(
-                "JSON-RPC error ({}): {}",
-                json_rpc_err.code, json_rpc_err.message
-            )),
+            RpcError::ErrorResp(json_rpc_err) => ProviderError::RpcErrorCode {
+                code: json_rpc_err.code,
+                message: json_rpc_err.message.to_string(),
+            },
             _ => ProviderError::Other(format!("Other RPC error: {}", err)),
         }
     }
@@ -647,6 +649,17 @@ mod tests {
             }
             _ => panic!("Unexpected error type"),
         }
+    }
+
+    #[test]
+    fn test_provider_error_rpc_error_code_variant() {
+        let error = ProviderError::RpcErrorCode {
+            code: -32000,
+            message: "insufficient funds".to_string(),
+        };
+        let error_string = format!("{}", error);
+        assert!(error_string.contains("-32000"));
+        assert!(error_string.contains("insufficient funds"));
     }
 
     #[test]


### PR DESCRIPTION
# Summary
- Handle of RPC Error codes
- Categorize EIP-1474 RPC Error codes that are retryable and the ones that are not.

## Testing Process

## Checklist

- [ ] Add a reference to related issues in the PR description.
- [ ] Add unit tests if applicable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - More informative error reporting for JSON-RPC failures, showing structured codes and messages to aid troubleshooting.
- Bug Fixes
  - Smarter retry behavior for transient JSON-RPC and network errors (e.g., rate limits, temporary resource issues), reducing unnecessary failures.
  - Avoids retrying on clearly invalid requests, improving responsiveness.
- Tests
  - Added comprehensive test coverage for retriable vs. non-retriable error scenarios to ensure consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->