### PR TITLE
feat(polkadot): Add Polkadot testnet and TLS 1.3 compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2103,7 +2103,7 @@ dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -4476,7 +4476,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.0",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -4671,7 +4671,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.0",
+ "hashbrown 0.15.5",
  "serde",
  "serde_core",
 ]
@@ -6333,7 +6333,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.32",
- "socket2 0.6.0",
+ "socket2 0.5.10",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -6372,7 +6372,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.0",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -6646,9 +6646,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.23"
+version = "0.12.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d429f34c8092b2d42c7c93cec323bb4adeb7c67698f70839adec842ec10c7ceb"
+checksum = "9d0946410b9f7b082a427e4ef5c8ff541a88b357bc6c637c40db3a68ac70a36f"
 dependencies = [
  "async-compression",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ tower = "0.5"
 oz-keystore = { version = "0.1.4"}
 hex = { version = "0.4"}
 bytes = { version = "1.9" }
-reqwest = { version = "0.12", features = ["json"] }
+reqwest = { version = "0.12", features = ["json", "rustls-tls"] }
 base64 = { version =  "0.22" }
 hmac = { version = "0.12" }
 sha2 = { version = "0.10" }

--- a/config/networks/polkadot.json
+++ b/config/networks/polkadot.json
@@ -1,0 +1,23 @@
+{
+  "networks": [
+    {
+      "average_blocktime_ms": 6000,
+      "chain_id": 420420422,
+      "explorer_urls": [
+        "https://blockscout-passet-hub.parity-testnet.parity.io/"
+      ],
+      "features": [],
+      "is_testnet": true,
+      "network": "polkadot-hub-testnet",
+      "required_confirmations": 2,
+      "rpc_urls": [
+        "https://testnet-passet-hub-eth-rpc.polkadot.io"
+      ],
+      "symbol": "PAS",
+      "tags": [
+        "polkadot-based"
+      ],
+      "type": "evm"
+    }
+  ]
+}

--- a/src/services/provider/evm/mod.rs
+++ b/src/services/provider/evm/mod.rs
@@ -254,8 +254,10 @@ impl EvmProvider {
             ProviderError::NetworkConfiguration(format!("Invalid URL format: {}", e))
         })?;
 
-        let client = ReqwestClientBuilder::default()
+        // Using use_rustls_tls() forces the use of rustls instead of native-tls to support TLS 1.3
+        let client = ReqwestClientBuilder::new()
             .timeout(Duration::from_secs(self.timeout_seconds))
+            .use_rustls_tls()
             .build()
             .map_err(|e| ProviderError::Other(format!("Failed to build HTTP client: {}", e)))?;
 


### PR DESCRIPTION
# Summary

## Network Support
  - Added Polkadot Hub Testnet network configuration (`config/networks/polkadot.json`)
    - Chain ID: 420420422
    - RPC: https://testnet-passet-hub-eth-rpc.polkadot.io
    - Symbol: PAS
    - Block explorer: https://blockscout-passet-hub.parity-testnet.parity.io/

  ## TLS 1.3 Support
  - Updated `reqwest` dependency to include `rustls-tls` feature
  - Modified HTTP client builder in EVM provider to use rustls backend (`src/services/provider/evm/mod.rs:257`)
  
  ## Technical Context

  The Polkadot RPC endpoint has an unusual TLS configuration - it supports TLS 1.0, 1.1, and 1.3, but **not** TLS 1.2 ([TLS test
  results](https://www.cdn77.com/tls-test/result?domain=https%3A%2F%2Ftestnet-passet-hub-eth-rpc.polkadot.io)).

  The default TLS backend used by `reqwest` (`rust-native-tls`) doesn't support TLS 1.3 ([related issue](https://github.com/sfackler/rust-native-tls/issues/140)), which prevented connections to the Polkadot RPC.

## Testing Process
  - Verified successful connection to Polkadot testnet RPC endpoint
  - Smoke test some EVM RPC functions, which are working fine, but need more validation in some cases. (To address in other PRs)
  - Existing tests continue to pass with rustls backend

## Checklist

- [ ] Add a reference to related issues in the PR description.
- [ ] Add unit tests if applicable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Polkadot Hub testnet network support with full EVM compatibility. Users can now interact with this Polkadot-based testnet through configured RPC endpoints and integrated blockchain explorer for transaction verification.

* **Chores**
  * Updated HTTP client configuration to enhance security with improved encryption protocols for all network communications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->