### PR TITLE
fix: fix alloy error mapping and improve provider retry logic

### DIFF
--- a/src/services/provider/mod.rs
+++ b/src/services/provider/mod.rs
@@ -39,6 +39,8 @@ pub enum ProviderError {
     RequestError { error: String, status_code: u16 },
     #[error("JSON-RPC error (code {code}): {message}")]
     RpcErrorCode { code: i64, message: String },
+    #[error("Transport error: {0}")]
+    TransportError(String),
     #[error("Other provider error: {0}")]
     Other(String),
 }
@@ -144,8 +146,7 @@ where
                     return categorize_reqwest_error(reqwest_err);
                 }
 
-                // Fallback for other transport error types
-                ProviderError::Other(format!("Transport error: {}", transport_err))
+                ProviderError::TransportError(transport_err.to_string())
             }
             RpcError::ErrorResp(json_rpc_err) => ProviderError::RpcErrorCode {
                 code: json_rpc_err.code,


### PR DESCRIPTION
# Summary

This PR will improve Alloy error mapping by mapping all Alloy transport errors to retriable error type. 
Retriable logic is improved by adding coverage for RequestError.

Closes #539 

## Testing Process

## Checklist

- [x] Add a reference to related issues in the PR description.
- [x] Add unit tests if applicable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced network error handling with improved classification of transient and persistent connection failures.
  * Refined retry logic for HTTP errors to increase reliability during temporary network issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->