### PR TITLE
add support for redis tls (rediss://)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1189,7 +1189,7 @@ dependencies = [
  "chrono",
  "futures",
  "log",
- "redis",
+ "redis 0.32.7",
  "serde",
  "thiserror 2.0.17",
  "tokio",
@@ -5709,10 +5709,11 @@ dependencies = [
  "prometheus",
  "proptest",
  "rand 0.9.2",
- "redis",
+ "redis 0.31.0",
  "regex",
  "reqwest",
  "reqwest-middleware",
+ "rustls 0.23.34",
  "secrets",
  "serde",
  "serde_json",
@@ -6524,6 +6525,34 @@ name = "recvmsg"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3edd4d5d42c92f0a659926464d4cce56b562761267ecf0f469d85b7de384175"
+
+[[package]]
+name = "redis"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bc1ea653e0b2e097db3ebb5b7f678be339620b8041f66b30a308c1d45d36a7f"
+dependencies = [
+ "arc-swap",
+ "backon",
+ "bytes",
+ "cfg-if",
+ "combine",
+ "futures-channel",
+ "futures-util",
+ "itoa",
+ "num-bigint 0.4.6",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls 0.23.34",
+ "rustls-native-certs 0.8.2",
+ "ryu",
+ "sha1_smol",
+ "socket2 0.5.10",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tokio-util",
+ "url",
+]
 
 [[package]]
 name = "redis"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,8 @@ color-eyre = "0.6"
 apalis = { version = "0.7", features = ["limit", "retry", "catch-panic", "timeout"] }
 apalis-redis = { version = "0.7" }
 apalis-cron = { version = "0.7" }
-redis = { version = "0.32", features = ["aio", "connection-manager", "tokio-comp"] }
+redis = { version = "0.31", features = ["aio", "connection-manager", "tokio-rustls-comp", "tls-rustls-insecure"] }
+rustls = { version = "0.23", features = ["ring"] }
 tokio = { version = "1.43", features = ["sync", "io-util", "time"] }
 rand = "0.9"
 parking_lot = "0.12"

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,6 +58,7 @@ use openzeppelin_relayer::{
     utils::check_authorization_header,
 };
 use tracing_actix_web::TracingLogger;
+use rustls::crypto::ring;
 
 fn load_config_file(config_file_path: &str) -> Result<Config> {
     config::load_config(config_file_path).wrap_err("Failed to load config file")
@@ -65,6 +66,11 @@ fn load_config_file(config_file_path: &str) -> Result<Config> {
 
 #[actix_web::main]
 async fn main() -> Result<()> {
+    // Install rustls crypto provider (required for TLS connections including Redis TLS)
+    ring::default_provider()
+        .install_default()
+        .expect("Failed to install rustls crypto provider");
+
     dotenv().ok();
 
     // Setup logging first so ErrorLayer is available


### PR DESCRIPTION
# Summary
This PR aims to add support for redis over TLS (rediss)

## Testing Process
Tested locally with rediss (with insecure flag)
Tested docker build process with image running in EKS with Elasticache Redis with TLS and AUTH

## Checklist

- [ ] Add a reference to related issues in the PR description.
- [ ] Add unit tests if applicable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal build configuration for improved compatibility.

---

**Impact:** No visible changes to end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->