### PR TITLE
chore: bump rust toolchain to version 1.88 and fix clippy errors

### DIFF
--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -14,7 +14,7 @@ runs:
   using: composite
   steps:
     - name: setup rust tool chain
-      uses: dtolnay/rust-toolchain@1.86.0  # v1.86.0
+      uses: dtolnay/rust-toolchain@1.88.0  # v1.88.0
       with:
         components: ${{ (inputs.components != '') && format('{0}, rustfmt, clippy', inputs.components) || 'rustfmt, clippy' }}
     - name: Install libsodium

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -346,7 +346,7 @@ Note: if your pull request isn't getting enough attention, you can contact us on
 
 ## Coding Standards
 
-- Use **Rust 2021 edition**, version `1.86` or later.
+- Use **Rust 2021 edition**, version `1.88` or later.
 - Follow the [Rust API Guidelines](https://rust-lang.github.io/api-guidelines/).
 - Run pre-commit hooks on your code to ensure code quality.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "openzeppelin-relayer"
 version = "1.1.0"
 edition = "2021"
-rust-version = "1.86"         #MSRV
+rust-version = "1.88"         #MSRV
 
 [profile.release]
 opt-level = 0

--- a/docs/evm.mdx
+++ b/docs/evm.mdx
@@ -53,7 +53,7 @@ In production systems, hosted signers (AWS KMS, Google Cloud KMS, Turnkey, CDP) 
 For a step-by-step setup, see [Quick Start Guide](/relayer/quickstart).
 Key prerequisites:
 
-* Rust 2021, version `1.86` or later
+* Rust 2021, version `1.88` or later
 * Redis
 * Docker (optional)
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -202,7 +202,7 @@ For detailed information about each directory and its contents, see [Project Str
 
 ### Prerequisites
 
-* Rust 2021 edition, version `1.86` or later
+* Rust 2021 edition, version `1.88` or later
 * Docker (optional, for containerized deployment)
 * Node.js, typescript and ts-node (optional, for plugins)
 

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -6,7 +6,7 @@ This guide provides step-by-step instructions for setting up OpenZeppelin Relaye
 
 ## Prerequisites
 
-* Rust 2021, version `1.86` or later.
+* Rust 2021, version `1.88` or later.
 * Redis
 * Docker (optional, for containerized deployment)
 * Node.js, typescript and ts-node (optional, for plugins)

--- a/docs/solana.mdx
+++ b/docs/solana.mdx
@@ -71,7 +71,7 @@ In production systems, hosted signers are recommended for the best security mode
 For a step-by-step setup, see [Quick Start Guide](/relayer/quickstart).
 Key prerequisites:
 
-* Rust 2021, version `1.86` or later
+* Rust 2021, version `1.88` or later
 * Redis
 * Docker (optional)
 

--- a/docs/stellar.mdx
+++ b/docs/stellar.mdx
@@ -63,7 +63,7 @@ For detailed network configuration options, see the [Network Configuration](/rel
 For a step-by-step setup, see [Quick Start Guide](/relayer/quickstart).
 Key prerequisites:
 
-* Rust 2021, version `1.86` or later
+* Rust 2021, version `1.88` or later
 * Redis
 * Docker (optional)
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.86.0"
+channel = "1.88.0"
 profile = "minimal"
 components = [
     "rustc",

--- a/src/api/controllers/plugin.rs
+++ b/src/api/controllers/plugin.rs
@@ -53,7 +53,7 @@ where
         .plugin_repository
         .get_by_id(&plugin_id)
         .await?
-        .ok_or_else(|| ApiError::NotFound(format!("Plugin with id {} not found", plugin_id)))?;
+        .ok_or_else(|| ApiError::NotFound(format!("Plugin with id {plugin_id} not found")))?;
 
     let plugin_runner = PluginRunner;
     let plugin_service = PluginService::new(plugin_runner);

--- a/src/api/controllers/relayer.rs
+++ b/src/api/controllers/relayer.rs
@@ -242,11 +242,11 @@ where
 
     // convert patch to UpdateRelayerRequest to validate
     let update_request: UpdateRelayerRequestRaw = serde_json::from_value(patch.clone())
-        .map_err(|e| ApiError::BadRequest(format!("Invalid update request: {}", e)))?;
+        .map_err(|e| ApiError::BadRequest(format!("Invalid update request: {e}")))?;
 
     if let Some(policies) = update_request.policies {
         deserialize_policy_for_network_type(&policies, relayer.network_type)
-            .map_err(|e| ApiError::BadRequest(format!("Invalid policy: {}", e)))?;
+            .map_err(|e| ApiError::BadRequest(format!("Invalid policy: {e}")))?;
     }
 
     if relayer.system_disabled {
@@ -518,7 +518,7 @@ where
         .transaction_repository
         .find_by_nonce(&relayer_id, nonce)
         .await?
-        .ok_or_else(|| ApiError::NotFound(format!("Transaction with nonce {} not found", nonce)))?;
+        .ok_or_else(|| ApiError::NotFound(format!("Transaction with nonce {nonce} not found")))?;
 
     let transaction_response: TransactionResponse = transaction.into();
 

--- a/src/api/routes/metrics.rs
+++ b/src/api/routes/metrics.rs
@@ -82,7 +82,7 @@ async fn metric_detail(path: web::Path<String>) -> impl Responder {
             let encoder = TextEncoder::new();
             let mut buffer = Vec::new();
             if let Err(e) = encoder.encode(&[mf], &mut buffer) {
-                return HttpResponse::InternalServerError().body(format!("Encoding error: {}", e));
+                return HttpResponse::InternalServerError().body(format!("Encoding error: {e}"));
             }
             return HttpResponse::Ok()
                 .content_type(encoder.format_type())
@@ -112,7 +112,7 @@ async fn scrape_metrics() -> impl Responder {
     update_system_metrics();
     match crate::metrics::gather_metrics() {
         Ok(body) => HttpResponse::Ok().content_type("text/plain;").body(body),
-        Err(e) => HttpResponse::InternalServerError().body(format!("Error: {}", e)),
+        Err(e) => HttpResponse::InternalServerError().body(format!("Error: {e}")),
     }
 }
 

--- a/src/bootstrap/initialize_relayers.rs
+++ b/src/bootstrap/initialize_relayers.rs
@@ -30,7 +30,7 @@ where
     relayer_service
         .initialize_relayer()
         .await
-        .wrap_err_with(|| format!("Failed to initialize relayer: {}", relayer_id))?;
+        .wrap_err_with(|| format!("Failed to initialize relayer: {relayer_id}"))?;
 
     Ok(())
 }

--- a/src/config/config_file/network/collection.rs
+++ b/src/config/config_file/network/collection.rs
@@ -56,16 +56,13 @@ impl<'de> Deserialize<'de> for NetworksFileConfig {
         // First, create an instance with unflattened networks.
         // This will perform initial validations like duplicate name checks.
         let unflattened_config = NetworksFileConfig::new(final_networks).map_err(|e| {
-            de::Error::custom(format!(
-                "Error creating initial NetworksFileConfig: {:?}",
-                e
-            ))
+            de::Error::custom(format!("Error creating initial NetworksFileConfig: {e:?}"))
         })?;
 
         // Now, flatten the configuration. (Resolve inheritance)
         unflattened_config
             .flatten()
-            .map_err(|e| de::Error::custom(format!("Error flattening NetworksFileConfig: {:?}", e)))
+            .map_err(|e| de::Error::custom(format!("Error flattening NetworksFileConfig: {e:?}")))
     }
 }
 
@@ -87,8 +84,7 @@ impl NetworksFileConfig {
             if network_map.insert(key, index).is_some() {
                 // Return an error if we find a duplicate within the same network type
                 return Err(ConfigFileError::DuplicateId(format!(
-                    "{:?} network '{}'",
-                    network_type, name
+                    "{network_type:?} network '{name}'"
                 )));
             }
         }
@@ -227,8 +223,7 @@ impl NetworksFileConfig {
             if current_path_names.contains(&current_name) {
                 let cycle_path_str = current_path_names.join(" -> ");
                 return Err(ConfigFileError::CircularInheritance(format!(
-                    "Circular inheritance detected: {} -> {}",
-                    cycle_path_str, current_name
+                    "Circular inheritance detected: {cycle_path_str} -> {current_name}"
                 )));
             }
 
@@ -238,8 +233,7 @@ impl NetworksFileConfig {
                 self.get_network(network_type, current_name)
                     .ok_or_else(|| {
                         ConfigFileError::InvalidReference(format!(
-                            "{:?} network '{}' not found in configuration",
-                            network_type, current_name
+                            "{network_type:?} network '{current_name}' not found in configuration"
                         ))
                     })?;
 
@@ -248,16 +242,14 @@ impl NetworksFileConfig {
 
                 if source_name == current_name {
                     return Err(ConfigFileError::InvalidReference(format!(
-                        "Network '{}' cannot inherit from itself",
-                        current_name
+                        "Network '{current_name}' cannot inherit from itself"
                     )));
                 }
 
                 let source_network =
                     self.get_network(network_type, source_name).ok_or_else(|| {
                         ConfigFileError::InvalidReference(format!(
-                            "{:?} network '{}' inherits from non-existent network '{}'",
-                            network_type, current_name, source_name
+                            "{network_type:?} network '{current_name}' inherits from non-existent network '{source_name}'"
                         ))
                     })?;
 
@@ -265,8 +257,7 @@ impl NetworksFileConfig {
 
                 if derived_type != source_type {
                     return Err(ConfigFileError::IncompatibleInheritanceType(format!(
-                        "Network '{}' (type {:?}) tries to inherit from '{}' (type {:?})",
-                        current_name, derived_type, source_name, source_type
+                        "Network '{current_name}' (type {derived_type:?}) tries to inherit from '{source_name}' (type {source_type:?})"
                     )));
                 }
                 current_name = source_name;

--- a/src/config/config_file/network/common.rs
+++ b/src/config/config_file/network/common.rs
@@ -56,7 +56,7 @@ impl NetworkConfigCommon {
         if let Some(urls) = &self.rpc_urls {
             for url in urls {
                 reqwest::Url::parse(url).map_err(|_| {
-                    ConfigFileError::InvalidFormat(format!("Invalid RPC URL: {}", url))
+                    ConfigFileError::InvalidFormat(format!("Invalid RPC URL: {url}"))
                 })?;
             }
         }
@@ -64,7 +64,7 @@ impl NetworkConfigCommon {
         if let Some(urls) = &self.explorer_urls {
             for url in urls {
                 reqwest::Url::parse(url).map_err(|_| {
-                    ConfigFileError::InvalidFormat(format!("Invalid Explorer URL: {}", url))
+                    ConfigFileError::InvalidFormat(format!("Invalid Explorer URL: {url}"))
                 })?;
             }
         }

--- a/src/config/config_file/network/file_loading.rs
+++ b/src/config/config_file/network/file_loading.rs
@@ -149,10 +149,10 @@ impl NetworkFileLoader {
     /// - `Err(ConfigFileError)` if the file cannot be read or parsed.
     fn load_network_file(file_path: &Path) -> Result<Vec<NetworkFileConfig>, ConfigFileError> {
         let file_content = fs::read_to_string(file_path)
-            .map_err(|e| ConfigFileError::InvalidFormat(format!("Failed to read file: {}", e)))?;
+            .map_err(|e| ConfigFileError::InvalidFormat(format!("Failed to read file: {e}")))?;
 
         let dir_network_list: DirectoryNetworkList = serde_json::from_str(&file_content)
-            .map_err(|e| ConfigFileError::InvalidFormat(format!("Failed to parse JSON: {}", e)))?;
+            .map_err(|e| ConfigFileError::InvalidFormat(format!("Failed to parse JSON: {e}")))?;
 
         Ok(dir_network_list.networks)
     }
@@ -271,7 +271,7 @@ impl<'de> serde::Deserialize<'de> for NetworksSource {
             Value::Array(arr) => {
                 let networks: Vec<NetworkFileConfig> = serde_json::from_value(Value::Array(arr))
                     .map_err(|e| {
-                        de::Error::custom(format!("Failed to deserialize network array: {}", e))
+                        de::Error::custom(format!("Failed to deserialize network array: {e}"))
                     })?;
                 Ok(NetworksSource::List(networks))
             }

--- a/src/config/config_file/plugin.rs
+++ b/src/config/config_file/plugin.rs
@@ -53,8 +53,7 @@ impl PluginsFileConfig {
 
             if !plugin.path.ends_with(PLUGIN_FILE_TYPE) {
                 return Err(ConfigFileError::InvalidFormat(format!(
-                    "Plugin path must be a {} file (ends with '{}')",
-                    PLUGIN_LANG, PLUGIN_FILE_TYPE
+                    "Plugin path must be a {PLUGIN_LANG} file (ends with '{PLUGIN_FILE_TYPE}')"
                 )));
             }
         }

--- a/src/config/server_config.rs
+++ b/src/config/server_config.rs
@@ -17,7 +17,7 @@ impl FromStr for RepositoryStorageType {
         match s.to_lowercase().as_str() {
             "inmemory" | "in_memory" => Ok(Self::InMemory),
             "redis" => Ok(Self::Redis),
-            _ => Err(format!("Invalid repository storage type: {}", s)),
+            _ => Err(format!("Invalid repository storage type: {s}")),
         }
     }
 }
@@ -153,7 +153,7 @@ impl ServerConfig {
         let config_file_name =
             env::var("CONFIG_FILE_NAME").unwrap_or_else(|_| "config.json".to_string());
 
-        format!("{}{}", conf_dir, config_file_name)
+        format!("{conf_dir}{config_file_name}")
     }
 
     /// Gets the API key from environment variable (panics if not set or too short)
@@ -162,8 +162,7 @@ impl ServerConfig {
 
         if !api_key.has_minimum_length(MINIMUM_SECRET_VALUE_LENGTH) {
             panic!(
-                "Security error: API_KEY must be at least {} characters long",
-                MINIMUM_SECRET_VALUE_LENGTH
+                "Security error: API_KEY must be at least {MINIMUM_SECRET_VALUE_LENGTH} characters long"
             );
         }
 

--- a/src/domain/relayer/evm/evm_relayer.rs
+++ b/src/domain/relayer/evm/evm_relayer.rs
@@ -311,7 +311,7 @@ where
             .provider
             .get_transaction_count(&relayer_model.address)
             .await
-            .map_err(|e| RelayerError::ProviderError(format!("Failed to get nonce: {}", e)))?;
+            .map_err(|e| RelayerError::ProviderError(format!("Failed to get nonce: {e}")))?;
         let nonce_str = nonce_u256.to_string();
 
         let balance_response = self.get_balance().await?;

--- a/src/domain/relayer/evm/validations.rs
+++ b/src/domain/relayer/evm/validations.rs
@@ -33,8 +33,7 @@ impl EvmTransactionValidator {
 
         if balance < min_balance {
             return Err(EvmTransactionValidationError::InsufficientBalance(format!(
-                "Relayer balance ({}) is below minimum required balance ({})",
-                balance, min_balance
+                "Relayer balance ({balance}) is below minimum required balance ({min_balance})"
             )));
         }
 

--- a/src/domain/relayer/solana/dex/jupiter_swap.rs
+++ b/src/domain/relayer/solana/dex/jupiter_swap.rs
@@ -76,7 +76,7 @@ where
                 slippage: params.slippage_percent as f32,
             })
             .await
-            .map_err(|e| RelayerError::DexError(format!("Failed to get Jupiter quote: {}", e)))?;
+            .map_err(|e| RelayerError::DexError(format!("Failed to get Jupiter quote: {e}")))?;
         debug!(quote = ?quote, "received quote");
 
         let swap_tx = self
@@ -105,23 +105,19 @@ where
                     .map(|o| o.dynamic_compute_unit_limit.unwrap_or_default()),
             })
             .await
-            .map_err(|e| {
-                RelayerError::DexError(format!("Failed to get swap transaction: {}", e))
-            })?;
+            .map_err(|e| RelayerError::DexError(format!("Failed to get swap transaction: {e}")))?;
 
         debug!(swap_tx = ?swap_tx, "received swap transaction");
 
         let mut swap_tx = VersionedTransaction::try_from(EncodedSerializedTransaction::new(
             swap_tx.swap_transaction,
         ))
-        .map_err(|e| RelayerError::DexError(format!("Failed to decode swap transaction: {}", e)))?;
+        .map_err(|e| RelayerError::DexError(format!("Failed to decode swap transaction: {e}")))?;
         let signature = self
             .signer
             .sign(&swap_tx.message.serialize())
             .await
-            .map_err(|e| {
-                RelayerError::DexError(format!("Failed to sign Dex transaction: {}", e))
-            })?;
+            .map_err(|e| RelayerError::DexError(format!("Failed to sign Dex transaction: {e}")))?;
 
         swap_tx.signatures[0] = signature;
 
@@ -131,9 +127,9 @@ where
             .await
             .map_err(|e| match e {
                 SolanaProviderError::RpcError(err) => {
-                    RelayerError::ProviderError(format!("Failed to send transaction: {}", err))
+                    RelayerError::ProviderError(format!("Failed to send transaction: {err}"))
                 }
-                _ => RelayerError::ProviderError(format!("Unexpected error: {}", e)),
+                _ => RelayerError::ProviderError(format!("Unexpected error: {e}")),
             })?;
 
         // Wait for transaction confirmation
@@ -142,7 +138,7 @@ where
             .confirm_transaction(&signature)
             .await
             .map_err(|e| {
-                RelayerError::ProviderError(format!("Transaction failed to confirm: {}", e))
+                RelayerError::ProviderError(format!("Transaction failed to confirm: {e}"))
             })?;
 
         debug!(signature = %signature, "transaction confirmed");

--- a/src/domain/relayer/solana/dex/jupiter_ultra.rs
+++ b/src/domain/relayer/solana/dex/jupiter_ultra.rs
@@ -63,7 +63,7 @@ where
             })
             .await
             .map_err(|e| {
-                RelayerError::DexError(format!("Failed to get Jupiter Ultra order: {}", e))
+                RelayerError::DexError(format!("Failed to get Jupiter Ultra order: {e}"))
             })?;
 
         debug!(order = ?order, "received order");
@@ -75,7 +75,7 @@ where
         let mut swap_tx =
             VersionedTransaction::try_from(EncodedSerializedTransaction::new(encoded_transaction))
                 .map_err(|e| {
-                    RelayerError::DexError(format!("Failed to decode swap transaction: {}", e))
+                    RelayerError::DexError(format!("Failed to decode swap transaction: {e}"))
                 })?;
 
         let signature = self
@@ -83,16 +83,14 @@ where
             .sign(&swap_tx.message.serialize())
             .await
             .map_err(|e| {
-                RelayerError::DexError(format!("Failed to sign Dex swap transaction: {}", e))
+                RelayerError::DexError(format!("Failed to sign Dex swap transaction: {e}"))
             })?;
 
         swap_tx.signatures[0] = signature;
 
         info!("Execute order transaction");
-        let serialized_transaction =
-            EncodedSerializedTransaction::try_from(&swap_tx).map_err(|e| {
-                RelayerError::DexError(format!("Failed to serialize transaction: {}", e))
-            })?;
+        let serialized_transaction = EncodedSerializedTransaction::try_from(&swap_tx)
+            .map_err(|e| RelayerError::DexError(format!("Failed to serialize transaction: {e}")))?;
         let response = self
             .jupiter_service
             .execute_ultra_order(UltraExecuteRequest {
@@ -100,7 +98,7 @@ where
                 request_id: order.request_id,
             })
             .await
-            .map_err(|e| RelayerError::DexError(format!("Failed to execute order: {}", e)))?;
+            .map_err(|e| RelayerError::DexError(format!("Failed to execute order: {e}")))?;
         debug!(response = ?response, "order executed successfully");
 
         Ok(SwapResult {

--- a/src/domain/relayer/solana/rpc/methods/prepare_transaction.rs
+++ b/src/domain/relayer/solana/rpc/methods/prepare_transaction.rs
@@ -211,7 +211,7 @@ async fn validate_prepare_transaction<P: SolanaProviderTrait + Send + Sync>(
 ) -> Result<(), SolanaTransactionValidationError> {
     let policy = &relayer.policies.get_solana_policy();
     let relayer_pubkey = Pubkey::from_str(&relayer.address).map_err(|e| {
-        SolanaTransactionValidationError::ValidationError(format!("Invalid relayer address: {}", e))
+        SolanaTransactionValidationError::ValidationError(format!("Invalid relayer address: {e}"))
     })?;
 
     let sync_validations = async {

--- a/src/domain/relayer/solana/rpc/methods/sign_and_send_transaction.rs
+++ b/src/domain/relayer/solana/rpc/methods/sign_and_send_transaction.rs
@@ -124,7 +124,7 @@ where
 
                 // Mark transaction as failed in the database
                 // Most RPC errors at this point are simulation failures or invalid transaction body
-                let failure_reason = format!("Transaction send failed: {}", e);
+                let failure_reason = format!("Transaction send failed: {e}");
                 let update = TransactionUpdateRequest {
                     status: Some(TransactionStatus::Failed),
                     status_reason: Some(failure_reason),
@@ -223,7 +223,7 @@ async fn validate_sign_and_send_transaction<P: SolanaProviderTrait + Send + Sync
 
     let policy = &relayer.policies.get_solana_policy();
     let relayer_pubkey = Pubkey::from_str(&relayer.address).map_err(|e| {
-        SolanaTransactionValidationError::ValidationError(format!("Invalid relayer address: {}", e))
+        SolanaTransactionValidationError::ValidationError(format!("Invalid relayer address: {e}"))
     })?;
 
     // Group all synchronous policy validations together

--- a/src/domain/relayer/solana/rpc/methods/sign_transaction.rs
+++ b/src/domain/relayer/solana/rpc/methods/sign_transaction.rs
@@ -128,7 +128,7 @@ async fn validate_sign_transaction<P: SolanaProviderTrait + Send + Sync>(
 ) -> Result<(), SolanaTransactionValidationError> {
     let policy = &relayer.policies.get_solana_policy();
     let relayer_pubkey = Pubkey::from_str(&relayer.address).map_err(|e| {
-        SolanaTransactionValidationError::ValidationError(format!("Invalid relayer address: {}", e))
+        SolanaTransactionValidationError::ValidationError(format!("Invalid relayer address: {e}"))
     })?;
 
     let sync_validations = async {

--- a/src/domain/relayer/solana/rpc/methods/utils.rs
+++ b/src/domain/relayer/solana/rpc/methods/utils.rs
@@ -89,7 +89,7 @@ where
         token_mint_str: &str,
     ) -> Result<u8, SolanaRpcError> {
         let token_mint = Pubkey::from_str(token_mint_str)
-            .map_err(|e| SolanaRpcError::Internal(format!("Invalid mint address: {}", e)))?;
+            .map_err(|e| SolanaRpcError::Internal(format!("Invalid mint address: {e}")))?;
 
         self.fetch_token_decimals_from_chain_pubkey(&token_mint)
             .await
@@ -104,12 +104,10 @@ where
             .provider
             .get_account_from_pubkey(token_mint)
             .await
-            .map_err(|e| {
-                SolanaRpcError::Internal(format!("Failed to fetch mint account: {}", e))
-            })?;
+            .map_err(|e| SolanaRpcError::Internal(format!("Failed to fetch mint account: {e}")))?;
 
         let mint_info = spl_token_interface::state::Mint::unpack(&mint_account.data)
-            .map_err(|e| SolanaRpcError::Internal(format!("Failed to unpack mint data: {}", e)))?;
+            .map_err(|e| SolanaRpcError::Internal(format!("Failed to unpack mint data: {e}")))?;
 
         Ok(mint_info.decimals)
     }
@@ -258,8 +256,7 @@ where
                         // second is the destination.
                         let source_index = ix.accounts.first().ok_or_else(|| {
                             SolanaRpcError::Internal(format!(
-                                "Missing source account in instruction {}",
-                                ix_index
+                                "Missing source account in instruction {ix_index}"
                             ))
                         })?;
                         let source_pubkey = &tx.message.account_keys[*source_index as usize];
@@ -327,7 +324,7 @@ where
         } else {
             // Allowed tokens are configured - check if token is in the list
             let token_entry = policy.get_allowed_token_entry(token).ok_or_else(|| {
-                SolanaRpcError::UnsupportedFeeToken(format!("Token {} not allowed", token))
+                SolanaRpcError::UnsupportedFeeToken(format!("Token {token} not allowed"))
             })?;
 
             // Get token decimals from policy first, then fetch from blockchain

--- a/src/domain/relayer/solana/solana_relayer.rs
+++ b/src/domain/relayer/solana/solana_relayer.rs
@@ -365,7 +365,7 @@ where
         };
 
         let relayer_pubkey = Pubkey::from_str(&relayer.address)
-            .map_err(|e| RelayerError::ProviderError(format!("Invalid relayer address: {}", e)))?;
+            .map_err(|e| RelayerError::ProviderError(format!("Invalid relayer address: {e}")))?;
 
         let tokens_to_swap = {
             let mut eligible_tokens = Vec::<TokenSwapCandidate>::new();
@@ -373,7 +373,7 @@ where
             if let Some(allowed_tokens) = policy.allowed_tokens.as_ref() {
                 for token in allowed_tokens {
                     let token_mint = Pubkey::from_str(&token.mint).map_err(|e| {
-                        RelayerError::ProviderError(format!("Invalid token mint: {}", e))
+                        RelayerError::ProviderError(format!("Invalid token mint: {e}"))
                     })?;
                     let token_account = SolanaTokenProgram::get_and_unpack_token_account(
                         &*self.provider,
@@ -382,7 +382,7 @@ where
                     )
                     .await
                     .map_err(|e| {
-                        RelayerError::ProviderError(format!("Failed to get token account: {}", e))
+                        RelayerError::ProviderError(format!("Failed to get token account: {e}"))
                     })?;
 
                     let swap_amount = self
@@ -755,7 +755,7 @@ where
                             SolanaRpcError::FeatureFetch(msg) => JsonRpcResponse::error(
                                 -32008,
                                 "FEATURE_FETCH_ERROR",
-                                &format!("Failed to retrieve the list of enabled features: {}", msg),
+                                &format!("Failed to retrieve the list of enabled features: {msg}"),
                             ),
                             SolanaRpcError::InvalidParams(msg) => {
                                 JsonRpcResponse::error(-32602, "INVALID_PARAMS", &msg)
@@ -764,16 +764,14 @@ where
                                 -32000,
                                 "UNSUPPORTED_FEE_TOKEN",
                                 &format!(
-                                    "The provided fee_token is not supported by the relayer: {}",
-                                    msg
+                                    "The provided fee_token is not supported by the relayer: {msg}"
                                 ),
                             ),
                             SolanaRpcError::Estimation(msg) => JsonRpcResponse::error(
                                 -32001,
                                 "ESTIMATION_ERROR",
                                 &format!(
-                                    "Failed to estimate the fee due to internal or network issues: {}",
-                                    msg
+                                    "Failed to estimate the fee due to internal or network issues: {msg}"
                                 ),
                             ),
                             SolanaRpcError::InsufficientFunds(msg) => {
@@ -785,73 +783,71 @@ where
                                     -32002,
                                     "INSUFFICIENT_FUNDS",
                                     &format!(
-                                        "The sender does not have enough funds for the transfer: {}",
-                                        msg
+                                        "The sender does not have enough funds for the transfer: {msg}"
                                     ),
                                 )
                             }
                             SolanaRpcError::TransactionPreparation(msg) => JsonRpcResponse::error(
                                 -32003,
                                 "TRANSACTION_PREPARATION_ERROR",
-                                &format!("Failed to prepare the transfer transaction: {}", msg),
+                                &format!("Failed to prepare the transfer transaction: {msg}"),
                             ),
                             SolanaRpcError::Preparation(msg) => JsonRpcResponse::error(
                                 -32013,
                                 "PREPARATION_ERROR",
-                                &format!("Failed to prepare the transfer transaction: {}", msg),
+                                &format!("Failed to prepare the transfer transaction: {msg}"),
                             ),
                             SolanaRpcError::Signature(msg) => JsonRpcResponse::error(
                                 -32005,
                                 "SIGNATURE_ERROR",
-                                &format!("Failed to sign the transaction: {}", msg),
+                                &format!("Failed to sign the transaction: {msg}"),
                             ),
                             SolanaRpcError::Signing(msg) => JsonRpcResponse::error(
                                 -32005,
                                 "SIGNATURE_ERROR",
-                                &format!("Failed to sign the transaction: {}", msg),
+                                &format!("Failed to sign the transaction: {msg}"),
                             ),
                             SolanaRpcError::TokenFetch(msg) => JsonRpcResponse::error(
                                 -32007,
                                 "TOKEN_FETCH_ERROR",
-                                &format!("Failed to retrieve the list of supported tokens: {}", msg),
+                                &format!("Failed to retrieve the list of supported tokens: {msg}"),
                             ),
                             SolanaRpcError::BadRequest(msg) => JsonRpcResponse::error(
                                 -32007,
                                 "BAD_REQUEST",
-                                &format!("Bad request: {}", msg),
+                                &format!("Bad request: {msg}"),
                             ),
                             SolanaRpcError::Send(msg) => JsonRpcResponse::error(
                                 -32006,
                                 "SEND_ERROR",
                                 &format!(
-                                    "Failed to submit the transaction to the blockchain: {}",
-                                    msg
+                                    "Failed to submit the transaction to the blockchain: {msg}"
                                 ),
                             ),
                             SolanaRpcError::SolanaTransactionValidation(msg) => JsonRpcResponse::error(
                                 -32013,
                                 "PREPARATION_ERROR",
-                                &format!("Failed to prepare the transfer transaction: {}", msg),
+                                &format!("Failed to prepare the transfer transaction: {msg}"),
                             ),
                             SolanaRpcError::Encoding(msg) => JsonRpcResponse::error(
                                 -32601,
                                 "INVALID_PARAMS",
-                                &format!("The transaction parameter is invalid or missing: {}", msg),
+                                &format!("The transaction parameter is invalid or missing: {msg}"),
                             ),
                             SolanaRpcError::TokenAccount(msg) => JsonRpcResponse::error(
                                 -32601,
                                 "PREPARATION_ERROR",
-                                &format!("Invalid Token Account: {}", msg),
+                                &format!("Invalid Token Account: {msg}"),
                             ),
                             SolanaRpcError::Token(msg) => JsonRpcResponse::error(
                                 -32601,
                                 "PREPARATION_ERROR",
-                                &format!("Invalid Token Account: {}", msg),
+                                &format!("Invalid Token Account: {msg}"),
                             ),
                             SolanaRpcError::Provider(msg) => JsonRpcResponse::error(
                                 -32006,
                                 "PREPARATION_ERROR",
-                                &format!("Failed to prepare the transfer transaction: {}", msg),
+                                &format!("Failed to prepare the transfer transaction: {msg}"),
                             ),
                             SolanaRpcError::Internal(_) => {
                                 JsonRpcResponse::error(-32000, "INTERNAL_ERROR", "Internal error")

--- a/src/domain/relayer/solana/token.rs
+++ b/src/domain/relayer/solana/token.rs
@@ -139,8 +139,7 @@ impl SolanaTokenProgram {
     ) -> Result<Instruction, TokenError> {
         if !Self::is_token_program(program_id) {
             return Err(TokenError::InvalidTokenProgram(format!(
-                "Unknown token program: {}",
-                program_id
+                "Unknown token program: {program_id}"
             )));
         }
         if program_id == &spl_token_interface::id() {
@@ -169,8 +168,7 @@ impl SolanaTokenProgram {
             .map_err(|e| TokenError::Instruction(e.to_string()));
         }
         Err(TokenError::InvalidTokenProgram(format!(
-            "Unknown token program: {}",
-            program_id
+            "Unknown token program: {program_id}"
         )))
     }
 
@@ -190,13 +188,12 @@ impl SolanaTokenProgram {
     ) -> Result<TokenAccount, TokenError> {
         if !Self::is_token_program(program_id) {
             return Err(TokenError::InvalidTokenProgram(format!(
-                "Unknown token program: {}",
-                program_id
+                "Unknown token program: {program_id}"
             )));
         }
         if program_id == &spl_token_interface::id() {
             let account = SplTokenAccount::unpack(&account.data)
-                .map_err(|e| TokenError::AccountError(format!("Invalid token account1: {}", e)))?;
+                .map_err(|e| TokenError::AccountError(format!("Invalid token account1: {e}")))?;
 
             return Ok(TokenAccount {
                 mint: account.mint,
@@ -208,7 +205,7 @@ impl SolanaTokenProgram {
             let state_with_extensions = spl_token_2022_interface::extension::StateWithExtensions::<
                 spl_token_2022_interface::state::Account,
             >::unpack(&account.data)
-            .map_err(|e| TokenError::AccountError(format!("Invalid token account2: {}", e)))?;
+            .map_err(|e| TokenError::AccountError(format!("Invalid token account2: {e}")))?;
 
             let base_account = state_with_extensions.base;
 
@@ -220,8 +217,7 @@ impl SolanaTokenProgram {
             });
         }
         Err(TokenError::InvalidTokenProgram(format!(
-            "Unknown token program: {}",
-            program_id
+            "Unknown token program: {program_id}"
         )))
     }
 
@@ -281,8 +277,7 @@ impl SolanaTokenProgram {
     ) -> Result<TokenInstruction, TokenError> {
         if !Self::is_token_program(program_id) {
             return Err(TokenError::InvalidTokenProgram(format!(
-                "Unknown token program: {}",
-                program_id
+                "Unknown token program: {program_id}"
             )));
         }
         if program_id == &spl_token_interface::id() {
@@ -316,8 +311,7 @@ impl SolanaTokenProgram {
             }
         } else {
             Err(TokenError::InvalidTokenProgram(format!(
-                "Unknown token program: {}",
-                program_id
+                "Unknown token program: {program_id}"
             )))
         }
     }
@@ -356,8 +350,7 @@ impl SolanaTokenProgram {
             .await
             .map_err(|e| {
                 TokenError::AccountError(format!(
-                    "Failed to fetch token account for owner {} and mint {}: {}",
-                    owner, mint, e
+                    "Failed to fetch token account for owner {owner} and mint {mint}: {e}"
                 ))
             })?;
 

--- a/src/domain/relayer/stellar/stellar_relayer.rs
+++ b/src/domain/relayer/stellar/stellar_relayer.rs
@@ -274,7 +274,7 @@ where
             .get_account(&self.relayer.address)
             .await
             .map_err(|e| {
-                RelayerError::ProviderError(format!("Failed to fetch account for balance: {}", e))
+                RelayerError::ProviderError(format!("Failed to fetch account for balance: {e}"))
             })?;
 
         Ok(BalanceResponse {
@@ -291,7 +291,7 @@ where
             .get_account(&relayer_model.address)
             .await
             .map_err(|e| {
-                RelayerError::ProviderError(format!("Failed to get account details: {}", e))
+                RelayerError::ProviderError(format!("Failed to get account details: {e}"))
             })?;
 
         let sequence_number_str = account_entry.seq_num.0.to_string();

--- a/src/domain/transaction/evm/evm_transaction.rs
+++ b/src/domain/transaction/evm/evm_transaction.rs
@@ -167,7 +167,7 @@ where
             )
             .await
             .map_err(|e| {
-                TransactionError::UnexpectedError(format!("Failed to schedule status check: {}", e))
+                TransactionError::UnexpectedError(format!("Failed to schedule status check: {e}"))
             })
     }
 
@@ -182,7 +182,7 @@ where
             .produce_submit_transaction_job(job, None)
             .await
             .map_err(|e| {
-                TransactionError::UnexpectedError(format!("Failed to produce submit job: {}", e))
+                TransactionError::UnexpectedError(format!("Failed to produce submit job: {e}"))
             })
     }
 
@@ -197,7 +197,7 @@ where
             .produce_submit_transaction_job(job, None)
             .await
             .map_err(|e| {
-                TransactionError::UnexpectedError(format!("Failed to produce resubmit job: {}", e))
+                TransactionError::UnexpectedError(format!("Failed to produce resubmit job: {e}"))
             })
     }
 
@@ -212,7 +212,7 @@ where
             .produce_submit_transaction_job(job, None)
             .await
             .map_err(|e| {
-                TransactionError::UnexpectedError(format!("Failed to produce resend job: {}", e))
+                TransactionError::UnexpectedError(format!("Failed to produce resend job: {e}"))
             })
     }
 
@@ -229,7 +229,7 @@ where
             .produce_transaction_request_job(job, None)
             .await
             .map_err(|e| {
-                TransactionError::UnexpectedError(format!("Failed to produce request job: {}", e))
+                TransactionError::UnexpectedError(format!("Failed to produce request job: {e}"))
             })
     }
 
@@ -315,11 +315,11 @@ where
             }
             // Provider errors are retryable (RPC down, timeout, etc.)
             EvmTransactionValidationError::ProviderError(msg) => {
-                TransactionError::UnexpectedError(format!("Failed to check balance: {}", msg))
+                TransactionError::UnexpectedError(format!("Failed to check balance: {msg}"))
             }
             // Validation errors are also retryable
             EvmTransactionValidationError::ValidationError(msg) => {
-                TransactionError::UnexpectedError(format!("Balance validation error: {}", msg))
+                TransactionError::UnexpectedError(format!("Balance validation error: {msg}"))
             }
         })
     }
@@ -348,7 +348,7 @@ where
 
         let estimated_gas = self.provider.estimate_gas(evm_data).await.map_err(|e| {
             warn!(error = ?e, tx_data = ?evm_data, "failed to estimate gas");
-            TransactionError::UnexpectedError(format!("Failed to estimate gas: {}", e))
+            TransactionError::UnexpectedError(format!("Failed to estimate gas: {e}"))
         })?;
 
         Ok(estimated_gas * GAS_LIMIT_BUFFER_MULTIPLIER / 100)
@@ -923,10 +923,7 @@ where
             })?;
 
         let network = EvmNetwork::try_from(network_repo_model).map_err(|e| {
-            TransactionError::NetworkConfiguration(format!(
-                "Failed to convert network model: {}",
-                e
-            ))
+            TransactionError::NetworkConfiguration(format!("Failed to convert network model: {e}"))
         })?;
 
         // First, create updated EVM data without price parameters

--- a/src/domain/transaction/evm/replacement.rs
+++ b/src/domain/transaction/evm/replacement.rs
@@ -144,8 +144,7 @@ pub fn validate_explicit_price_bump(
     if let Some(gas_price) = new_evm_data.gas_price {
         if gas_price > gas_price_cap {
             return Err(TransactionError::ValidationError(format!(
-                "Gas price {} exceeds gas price cap {}",
-                gas_price, gas_price_cap
+                "Gas price {gas_price} exceeds gas price cap {gas_price_cap}"
             )));
         }
     }
@@ -153,8 +152,7 @@ pub fn validate_explicit_price_bump(
     if let Some(max_fee) = new_evm_data.max_fee_per_gas {
         if max_fee > gas_price_cap {
             return Err(TransactionError::ValidationError(format!(
-                "Max fee per gas {} exceeds gas price cap {}",
-                max_fee, gas_price_cap
+                "Max fee per gas {max_fee} exceeds gas price cap {gas_price_cap}"
             )));
         }
     }

--- a/src/domain/transaction/evm/status.rs
+++ b/src/domain/transaction/evm/status.rs
@@ -97,8 +97,7 @@ where
 
             let network = EvmNetwork::try_from(network_model).map_err(|e| {
                 TransactionError::UnexpectedError(format!(
-                    "Error converting network model to EvmNetwork: {}",
-                    e
+                    "Error converting network model to EvmNetwork: {e}"
                 ))
             })?;
 
@@ -154,8 +153,7 @@ where
 
         let network = EvmNetwork::try_from(network_model).map_err(|e| {
             TransactionError::UnexpectedError(format!(
-                "Error converting network model to EvmNetwork: {}",
-                e
+                "Error converting network model to EvmNetwork: {e}"
             ))
         })?;
 
@@ -202,8 +200,7 @@ where
 
         let network = EvmNetwork::try_from(network_model).map_err(|e| {
             TransactionError::UnexpectedError(format!(
-                "Error converting network model to EvmNetwork: {}",
-                e
+                "Error converting network model to EvmNetwork: {e}"
             ))
         })?;
 
@@ -221,10 +218,7 @@ where
             let created_at = &tx.created_at;
             let created_time = DateTime::parse_from_rfc3339(created_at)
                 .map_err(|e| {
-                    TransactionError::UnexpectedError(format!(
-                        "Invalid created_at timestamp: {}",
-                        e
-                    ))
+                    TransactionError::UnexpectedError(format!("Invalid created_at timestamp: {e}"))
                 })?
                 .with_timezone(&Utc);
             let age = Utc::now().signed_duration_since(created_time);
@@ -266,8 +260,7 @@ where
 
         let network = EvmNetwork::try_from(network_model).map_err(|e| {
             TransactionError::UnexpectedError(format!(
-                "Error converting network model to EvmNetwork: {}",
-                e
+                "Error converting network model to EvmNetwork: {e}"
             ))
         })?;
 

--- a/src/domain/transaction/evm/utils.rs
+++ b/src/domain/transaction/evm/utils.rs
@@ -186,7 +186,7 @@ pub fn get_age_since_status_change(
     if let Some(sent_at) = &tx.sent_at {
         let sent = DateTime::parse_from_rfc3339(sent_at)
             .map_err(|e| {
-                TransactionError::UnexpectedError(format!("Error parsing sent_at time: {}", e))
+                TransactionError::UnexpectedError(format!("Error parsing sent_at time: {e}"))
             })?
             .with_timezone(&Utc);
         return Ok(Utc::now().signed_duration_since(sent));

--- a/src/domain/transaction/solana/solana_transaction.rs
+++ b/src/domain/transaction/solana/solana_transaction.rs
@@ -148,7 +148,7 @@ where
             );
 
             let payer = Pubkey::from_str(&self.relayer.address).map_err(|e| {
-                TransactionError::ValidationError(format!("Invalid relayer address: {}", e))
+                TransactionError::ValidationError(format!("Invalid relayer address: {e}"))
             })?;
 
             // Fetch fresh blockhash for instructions mode
@@ -217,8 +217,7 @@ where
                     EncodedSerializedTransaction::try_from(&transaction)
                         .map_err(|e| {
                             TransactionError::ValidationError(format!(
-                                "Failed to encode transaction: {}",
-                                e
+                                "Failed to encode transaction: {e}"
                             ))
                         })?
                         .into_inner(),
@@ -429,8 +428,7 @@ where
                     EncodedSerializedTransaction::try_from(&transaction)
                         .map_err(|e| {
                             TransactionError::ValidationError(format!(
-                                "Failed to encode transaction: {}",
-                                e
+                                "Failed to encode transaction: {e}"
                             ))
                         })?
                         .into_inner(),
@@ -608,7 +606,7 @@ where
 
         let policy = self.relayer.policies.get_solana_policy();
         let relayer_pubkey = Pubkey::from_str(&self.relayer.address).map_err(|e| {
-            TransactionError::ValidationError(format!("Invalid relayer address: {}", e))
+            TransactionError::ValidationError(format!("Invalid relayer address: {e}"))
         })?;
 
         // Group all synchronous policy validations together

--- a/src/domain/transaction/solana/status.rs
+++ b/src/domain/transaction/solana/status.rs
@@ -115,7 +115,7 @@ where
         })?;
 
         let signature = Signature::from_str(signature_str).map_err(|e| {
-            TransactionError::ValidationError(format!("Invalid signature format: {}", e))
+            TransactionError::ValidationError(format!("Invalid signature format: {e}"))
         })?;
 
         // Query on-chain status
@@ -234,8 +234,7 @@ where
                 .mark_as_failed(
                     tx,
                     format!(
-                        "Transaction stuck in Pending status for more than {} minutes",
-                        SOLANA_PENDING_TIMEOUT_MINUTES
+                        "Transaction stuck in Pending status for more than {SOLANA_PENDING_TIMEOUT_MINUTES} minutes"
                     ),
                 )
                 .await;
@@ -265,8 +264,7 @@ where
                 .await
                 .map_err(|e| {
                     TransactionError::UnexpectedError(format!(
-                        "Failed to enqueue transaction request job: {}",
-                        e
+                        "Failed to enqueue transaction request job: {e}"
                     ))
                 })?;
         } else {
@@ -518,8 +516,7 @@ where
                     .mark_as_failed(
                         tx,
                         format!(
-                            "Transaction exceeded maximum resubmission attempts ({} > {})",
-                            attempt_count, MAXIMUM_SOLANA_TX_ATTEMPTS
+                            "Transaction exceeded maximum resubmission attempts ({attempt_count} > {MAXIMUM_SOLANA_TX_ATTEMPTS})"
                         ),
                     )
                     .await;
@@ -542,8 +539,7 @@ where
                 .mark_as_failed(
                     tx,
                     format!(
-                        "Transaction stuck in {:?} status for more than {} minutes",
-                        status, timeout_minutes
+                        "Transaction stuck in {status:?} status for more than {timeout_minutes} minutes"
                     ),
                 )
                 .await;
@@ -640,8 +636,7 @@ where
                 .await
                 .map_err(|e| {
                     TransactionError::UnexpectedError(format!(
-                        "Failed to enqueue resubmit job: {}",
-                        e
+                        "Failed to enqueue resubmit job: {e}"
                     ))
                 })?;
 

--- a/src/domain/transaction/solana/utils.rs
+++ b/src/domain/transaction/solana/utils.rs
@@ -90,7 +90,7 @@ pub fn decode_solana_transaction_from_string(
 ) -> Result<SolanaTransaction, TransactionError> {
     let encoded_tx = EncodedSerializedTransaction::new(encoded.to_string());
     SolanaTransaction::try_from(encoded_tx)
-        .map_err(|e| TransactionError::ValidationError(format!("Invalid transaction: {}", e)))
+        .map_err(|e| TransactionError::ValidationError(format!("Invalid transaction: {e}")))
 }
 
 /// Converts instruction specifications to Solana SDK instructions.
@@ -111,10 +111,7 @@ pub fn convert_instruction_specs_to_instructions(
 
     for (idx, spec) in instructions.iter().enumerate() {
         let program_id = Pubkey::from_str(&spec.program_id).map_err(|e| {
-            TransactionError::ValidationError(format!(
-                "Instruction {}: Invalid program_id: {}",
-                idx, e
-            ))
+            TransactionError::ValidationError(format!("Instruction {idx}: Invalid program_id: {e}"))
         })?;
 
         let accounts = spec
@@ -124,8 +121,7 @@ pub fn convert_instruction_specs_to_instructions(
             .map(|(acc_idx, a)| {
                 let pubkey = Pubkey::from_str(&a.pubkey).map_err(|e| {
                     TransactionError::ValidationError(format!(
-                        "Instruction {} account {}: Invalid pubkey: {}",
-                        idx, acc_idx, e
+                        "Instruction {idx} account {acc_idx}: Invalid pubkey: {e}"
                     ))
                 })?;
                 Ok(AccountMeta {
@@ -138,8 +134,7 @@ pub fn convert_instruction_specs_to_instructions(
 
         let data = base64_decode(&spec.data).map_err(|e| {
             TransactionError::ValidationError(format!(
-                "Instruction {}: Invalid base64 data: {}",
-                idx, e
+                "Instruction {idx}: Invalid base64 data: {e}"
             ))
         })?;
 

--- a/src/domain/transaction/solana/validation.rs
+++ b/src/domain/transaction/solana/validation.rs
@@ -129,8 +129,7 @@ impl SolanaTransactionValidator {
         let allowed_token = policy.get_allowed_token_entry(token_mint);
         if allowed_token.is_none() {
             return Err(SolanaTransactionValidationError::PolicyViolation(format!(
-                "Token {} not allowed for transfers",
-                token_mint
+                "Token {token_mint} not allowed for transfers"
             )));
         }
 
@@ -150,8 +149,7 @@ impl SolanaTransactionValidator {
         // Verify fee payer matches relayer address
         if fee_payer != relayer_pubkey {
             return Err(SolanaTransactionValidationError::PolicyViolation(format!(
-                "Fee payer {} does not match relayer address {}",
-                fee_payer, relayer_pubkey
+                "Fee payer {fee_payer} does not match relayer address {relayer_pubkey}"
             )));
         }
 
@@ -187,8 +185,7 @@ impl SolanaTransactionValidator {
 
         if !is_valid {
             return Err(SolanaTransactionValidationError::ExpiredBlockhash(format!(
-                "Blockhash {} is no longer valid",
-                blockhash
+                "Blockhash {blockhash} is no longer valid"
             )));
         }
 
@@ -208,8 +205,7 @@ impl SolanaTransactionValidator {
 
         if num_signatures > max_signatures {
             return Err(SolanaTransactionValidationError::PolicyViolation(format!(
-                "Transaction requires {} signatures, which exceeds maximum allowed {}",
-                num_signatures, max_signatures
+                "Transaction requires {num_signatures} signatures, which exceeds maximum allowed {max_signatures}"
             )));
         }
 
@@ -230,8 +226,7 @@ impl SolanaTransactionValidator {
             {
                 if !allowed_programs.contains(&program_id.to_string()) {
                     return Err(SolanaTransactionValidationError::PolicyViolation(format!(
-                        "Program {} not allowed",
-                        program_id
+                        "Program {program_id} not allowed"
                     )));
                 }
             }
@@ -247,8 +242,7 @@ impl SolanaTransactionValidator {
         if let Some(allowed_accounts) = &policy.allowed_accounts {
             if !allowed_accounts.contains(&account.to_string()) {
                 return Err(SolanaTransactionValidationError::PolicyViolation(format!(
-                    "Account {} not allowed",
-                    account
+                    "Account {account} not allowed"
                 )));
             }
         }
@@ -266,8 +260,7 @@ impl SolanaTransactionValidator {
                 info!(account_key = %account_key, "checking account");
                 if !allowed_accounts.contains(&account_key.to_string()) {
                     return Err(SolanaTransactionValidationError::PolicyViolation(format!(
-                        "Account {} not allowed",
-                        account_key
+                        "Account {account_key} not allowed"
                     )));
                 }
             }
@@ -283,8 +276,7 @@ impl SolanaTransactionValidator {
         if let Some(disallowed_accounts) = &policy.disallowed_accounts {
             if disallowed_accounts.contains(&account.to_string()) {
                 return Err(SolanaTransactionValidationError::PolicyViolation(format!(
-                    "Account {} not allowed",
-                    account
+                    "Account {account} not allowed"
                 )));
             }
         }
@@ -304,8 +296,7 @@ impl SolanaTransactionValidator {
         for account_key in &tx.message.account_keys {
             if disallowed_accounts.contains(&account_key.to_string()) {
                 return Err(SolanaTransactionValidationError::PolicyViolation(format!(
-                    "Account {} is explicitly disallowed",
-                    account_key
+                    "Account {account_key} is explicitly disallowed"
                 )));
             }
         }
@@ -353,8 +344,7 @@ impl SolanaTransactionValidator {
                         // second is the destination.
                         let source_index = ix.accounts.first().ok_or_else(|| {
                             SolanaTransactionValidationError::ValidationError(format!(
-                                "Missing source account in instruction {}",
-                                ix_index
+                                "Missing source account in instruction {ix_index}"
                             ))
                         })?;
                         let source_pubkey = &tx.message.account_keys[*source_index as usize];
@@ -381,8 +371,7 @@ impl SolanaTransactionValidator {
         if let Some(max_amount) = policy.max_allowed_fee_lamports {
             if amount > max_amount {
                 return Err(SolanaTransactionValidationError::PolicyViolation(format!(
-                    "Fee amount {} exceeds max allowed fee amount {}",
-                    amount, max_amount
+                    "Fee amount {amount} exceeds max allowed fee amount {max_amount}"
                 )));
             }
         }
@@ -404,8 +393,7 @@ impl SolanaTransactionValidator {
 
         if balance < required_balance {
             return Err(SolanaTransactionValidationError::InsufficientBalance(format!(
-                "Insufficient relayer balance. Required: {}, Available: {}, Fee: {}, Min balance: {}",
-                required_balance, balance, fee, min_balance
+                "Insufficient relayer balance. Required: {required_balance}, Available: {balance}, Fee: {fee}, Min balance: {min_balance}"
             )));
         }
 
@@ -509,8 +497,7 @@ impl SolanaTransactionValidator {
                             SolanaTokenProgram::unpack_account(&program_id, &source_account)
                                 .map_err(|e| {
                                     SolanaTransactionValidationError::ValidationError(format!(
-                                        "Invalid token account: {}",
-                                        e
+                                        "Invalid token account: {e}"
                                     ))
                                 })?;
 
@@ -601,8 +588,7 @@ impl SolanaTransactionValidator {
             if balance < total_transfer {
                 return Err(SolanaTransactionValidationError::ValidationError(
                     format!(
-                        "Insufficient balance for cumulative transfers: account {} has balance {} but requires {} across all instructions",
-                        account, balance, total_transfer
+                        "Insufficient balance for cumulative transfers: account {account} has balance {balance} but requires {total_transfer} across all instructions"
                     ),
                 ));
             }

--- a/src/domain/transaction/stellar/prepare/common.rs
+++ b/src/domain/transaction/stellar/prepare/common.rs
@@ -36,11 +36,11 @@ pub async fn apply_sequence(
     sequence: i64,
 ) -> Result<String, TransactionError> {
     update_xdr_sequence(envelope, sequence).map_err(|e| {
-        TransactionError::ValidationError(format!("Failed to update sequence: {}", e))
+        TransactionError::ValidationError(format!("Failed to update sequence: {e}"))
     })?;
 
     envelope.to_xdr_base64(Limits::none()).map_err(|e| {
-        TransactionError::ValidationError(format!("Failed to serialize envelope: {}", e))
+        TransactionError::ValidationError(format!("Failed to serialize envelope: {e}"))
     })
 }
 
@@ -108,10 +108,10 @@ where
     let signed_envelope = signed_stellar_data
         .get_envelope_for_submission()
         .map_err(|e| {
-            TransactionError::SignerError(format!("Failed to build signed envelope: {}", e))
+            TransactionError::SignerError(format!("Failed to build signed envelope: {e}"))
         })?;
     let signed_xdr = signed_envelope.to_xdr_base64(Limits::none()).map_err(|e| {
-        TransactionError::SignerError(format!("Failed to serialize signed envelope: {}", e))
+        TransactionError::SignerError(format!("Failed to serialize signed envelope: {e}"))
     })?;
     signed_stellar_data.signed_envelope_xdr = Some(signed_xdr);
 
@@ -136,10 +136,7 @@ where
         .map_err(|e| TransactionError::UnexpectedError(e.to_string()))?;
 
     i64_from_u64(sequence_u64).map_err(|relayer_err| {
-        let msg = format!(
-            "Sequence conversion error for {}: {}",
-            sequence_u64, relayer_err
-        );
+        let msg = format!("Sequence conversion error for {sequence_u64}: {relayer_err}");
         TransactionError::ValidationError(msg)
     })
 }
@@ -196,9 +193,8 @@ pub async fn ensure_minimum_fee(
             "Updating transaction fee from {} to minimum {} stroops",
             current_fee, min_fee
         );
-        update_xdr_fee(envelope, min_fee).map_err(|e| {
-            TransactionError::ValidationError(format!("Failed to update fee: {}", e))
-        })?;
+        update_xdr_fee(envelope, min_fee)
+            .map_err(|e| TransactionError::ValidationError(format!("Failed to update fee: {e}")))?;
     }
 
     Ok(())
@@ -236,8 +232,7 @@ where
                 if (max_fee as u64) < required_fee {
                     return Err(TransactionError::ValidationError(
                         format!(
-                            "max_fee ({}) is insufficient. Required fee: {} (inclusion: {} + resource: {})",
-                            max_fee, required_fee, inclusion_fee, resource_fee
+                            "max_fee ({max_fee}) is insufficient. Required fee: {required_fee} (inclusion: {inclusion_fee} + resource: {resource_fee})"
                         )
                     ));
                 }
@@ -344,10 +339,10 @@ where
     let signed_envelope = final_stellar_data
         .get_envelope_for_submission()
         .map_err(|e| {
-            TransactionError::SignerError(format!("Failed to build signed envelope: {}", e))
+            TransactionError::SignerError(format!("Failed to build signed envelope: {e}"))
         })?;
     let signed_xdr = signed_envelope.to_xdr_base64(Limits::none()).map_err(|e| {
-        TransactionError::SignerError(format!("Failed to serialize signed envelope: {}", e))
+        TransactionError::SignerError(format!("Failed to serialize signed envelope: {e}"))
     })?;
     final_stellar_data.signed_envelope_xdr = Some(signed_xdr);
 

--- a/src/domain/transaction/stellar/prepare/fee_bump.rs
+++ b/src/domain/transaction/stellar/prepare/fee_bump.rs
@@ -43,7 +43,7 @@ where
     let fee_bump_envelope =
         build_fee_bump_envelope(inner_envelope.clone(), relayer_address, required_fee as i64)
             .map_err(|e| {
-                TransactionError::ValidationError(format!("Cannot create fee-bump envelope: {}", e))
+                TransactionError::ValidationError(format!("Cannot create fee-bump envelope: {e}"))
             })?;
 
     // Step 4: Sign the fee-bump transaction
@@ -83,7 +83,7 @@ fn extract_inner_transaction(
 
     // Parse the inner transaction envelope
     let inner_envelope = parse_transaction_xdr(&inner_xdr, true).map_err(|e| {
-        StellarValidationError::InvalidXdr(format!("Invalid inner transaction: {}", e))
+        StellarValidationError::InvalidXdr(format!("Invalid inner transaction: {e}"))
     })?;
 
     Ok((inner_envelope, max_fee))
@@ -112,10 +112,7 @@ where
     let fee_bump_xdr = fee_bump_envelope
         .to_xdr_base64(Limits::none())
         .map_err(|e| {
-            TransactionError::ValidationError(format!(
-                "Failed to serialize fee-bump envelope: {}",
-                e
-            ))
+            TransactionError::ValidationError(format!("Failed to serialize fee-bump envelope: {e}"))
         })?;
 
     // Create signing data for the fee-bump transaction
@@ -142,23 +139,19 @@ where
     // Parse the envelope to attach the signature
     let mut signed_envelope = TransactionEnvelope::from_xdr_base64(&fee_bump_xdr, Limits::none())
         .map_err(|e| {
-        TransactionError::SignerError(format!("Failed to parse fee-bump envelope: {}", e))
+        TransactionError::SignerError(format!("Failed to parse fee-bump envelope: {e}"))
     })?;
 
     // Attach the signature directly to the fee-bump envelope
     attach_signatures_to_envelope(&mut signed_envelope, vec![signature.clone()]).map_err(|e| {
         TransactionError::SignerError(format!(
-            "Failed to attach signature to fee-bump envelope: {}",
-            e
+            "Failed to attach signature to fee-bump envelope: {e}"
         ))
     })?;
 
     // Serialize the signed envelope
     let signed_xdr = signed_envelope.to_xdr_base64(Limits::none()).map_err(|e| {
-        TransactionError::SignerError(format!(
-            "Failed to serialize signed fee-bump envelope: {}",
-            e
-        ))
+        TransactionError::SignerError(format!("Failed to serialize signed fee-bump envelope: {e}"))
     })?;
 
     // Update stellar data

--- a/src/domain/transaction/stellar/prepare/mod.rs
+++ b/src/domain/transaction/stellar/prepare/mod.rs
@@ -163,7 +163,7 @@ where
         tx: TransactionRepoModel,
         error: TransactionError,
     ) -> Result<TransactionRepoModel, TransactionError> {
-        let error_reason = format!("Preparation failed: {}", error);
+        let error_reason = format!("Preparation failed: {error}");
         let tx_id = tx.id.clone(); // Clone the ID before moving tx
         warn!(reason = %error_reason, "transaction preparation failed");
 

--- a/src/domain/transaction/stellar/prepare/operations.rs
+++ b/src/domain/transaction/stellar/prepare/operations.rs
@@ -72,8 +72,7 @@ where
                 .with_simulation_data(sim_resp, op_count)
                 .map_err(|e| {
                     TransactionError::ValidationError(format!(
-                        "Failed to apply simulation data: {}",
-                        e
+                        "Failed to apply simulation data: {e}"
                     ))
                 })?
         }

--- a/src/domain/transaction/stellar/prepare/unsigned_xdr.rs
+++ b/src/domain/transaction/stellar/prepare/unsigned_xdr.rs
@@ -55,7 +55,7 @@ where
 
     // Step 2: Validate source account matches relayer
     let source_account = extract_source_account(&envelope).map_err(|e| {
-        TransactionError::ValidationError(format!("Failed to extract source account: {}", e))
+        TransactionError::ValidationError(format!("Failed to extract source account: {e}"))
     })?;
 
     if source_account != relayer_address {
@@ -84,7 +84,7 @@ where
 
     // Re-serialize the envelope after fee update
     let updated_xdr = envelope.to_xdr_base64(Limits::none()).map_err(|e| {
-        TransactionError::ValidationError(format!("Failed to serialize updated envelope: {}", e))
+        TransactionError::ValidationError(format!("Failed to serialize updated envelope: {e}"))
     })?;
 
     // Update stellar data with new XDR
@@ -100,8 +100,7 @@ where
                 .with_simulation_data(sim_resp, op_count)
                 .map_err(|e| {
                     TransactionError::ValidationError(format!(
-                        "Failed to apply simulation data: {}",
-                        e
+                        "Failed to apply simulation data: {e}"
                     ))
                 })?
         }

--- a/src/domain/transaction/stellar/status.rs
+++ b/src/domain/transaction/stellar/status.rs
@@ -67,7 +67,7 @@ where
                             "validation error detected - marking transaction as failed"
                         );
 
-                        self.mark_as_failed(tx, format!("Validation error: {}", msg))
+                        self.mark_as_failed(tx, format!("Validation error: {msg}"))
                             .await
                     }
                     _ => {
@@ -209,7 +209,7 @@ where
                 tx_result_xdr.result.name()
             )
         } else {
-            format!("{} No detailed XDR result available.", base_reason)
+            format!("{base_reason} No detailed XDR result available.")
         };
 
         warn!(reason = %detailed_reason, "stellar transaction failed");

--- a/src/domain/transaction/stellar/stellar_transaction.rs
+++ b/src/domain/transaction/stellar/stellar_transaction.rs
@@ -228,10 +228,7 @@ where
             .set(&self.relayer().id, relayer_address, next_usable_seq)
             .await
             .map_err(|e| {
-                TransactionError::UnexpectedError(format!(
-                    "Failed to update sequence counter: {}",
-                    e
-                ))
+                TransactionError::UnexpectedError(format!("Failed to update sequence counter: {e}"))
             })?;
 
         info!(sequence = %next_usable_seq, "updated local sequence counter");

--- a/src/domain/transaction/stellar/submit.rs
+++ b/src/domain/transaction/stellar/submit.rs
@@ -103,7 +103,7 @@ where
         tx: TransactionRepoModel,
         error: TransactionError,
     ) -> Result<TransactionRepoModel, TransactionError> {
-        let error_reason = format!("Submission failed: {}", error);
+        let error_reason = format!("Submission failed: {error}");
         let tx_id = tx.id.clone();
         warn!(reason = %error_reason, "transaction submission failed");
 

--- a/src/domain/transaction/stellar/utils.rs
+++ b/src/domain/transaction/stellar/utils.rs
@@ -57,11 +57,11 @@ where
     let account = provider
         .get_account(relayer_address)
         .await
-        .map_err(|e| format!("Failed to fetch account from chain: {}", e))?;
+        .map_err(|e| format!("Failed to fetch account from chain: {e}"))?;
 
     let on_chain_seq = account.seq_num.0; // Extract the i64 value
     let next_usable = next_sequence_u64(on_chain_seq)
-        .map_err(|e| format!("Failed to calculate next sequence: {}", e))?;
+        .map_err(|e| format!("Failed to calculate next sequence: {e}"))?;
 
     info!(
         "Fetched sequence from chain: on-chain={}, next usable={}",

--- a/src/domain/transaction/util.rs
+++ b/src/domain/transaction/util.rs
@@ -143,7 +143,7 @@ pub fn solana_not_supported_transaction<T>() -> Result<T, TransactionError> {
 pub fn get_age_since_created(tx: &TransactionRepoModel) -> Result<Duration, TransactionError> {
     let created = DateTime::parse_from_rfc3339(&tx.created_at)
         .map_err(|e| {
-            TransactionError::UnexpectedError(format!("Invalid created_at timestamp: {}", e))
+            TransactionError::UnexpectedError(format!("Invalid created_at timestamp: {e}"))
         })?
         .with_timezone(&Utc);
     Ok(Utc::now().signed_duration_since(created))

--- a/src/jobs/handlers/transaction_status_handler.rs
+++ b/src/jobs/handlers/transaction_status_handler.rs
@@ -88,7 +88,7 @@ fn handle_status_check_result(result: Result<TransactionRepoModel>) -> Result<()
         }
         Err(e) => {
             // Error occurred, retry
-            Err(Error::Failed(Arc::new(format!("{}", e).into())))
+            Err(Error::Failed(Arc::new(format!("{e}").into())))
         }
     }
 }

--- a/src/jobs/queue.rs
+++ b/src/jobs/queue.rs
@@ -73,42 +73,42 @@ impl Queue {
             .unwrap_or_default();
         Ok(Self {
             transaction_request_queue: Self::storage(
-                &format!("{}transaction_request_queue", redis_key_prefix),
+                &format!("{redis_key_prefix}transaction_request_queue"),
                 shared.clone(),
             )
             .await?,
             transaction_submission_queue: Self::storage(
-                &format!("{}transaction_submission_queue", redis_key_prefix),
+                &format!("{redis_key_prefix}transaction_submission_queue"),
                 shared.clone(),
             )
             .await?,
             transaction_status_queue: Self::storage(
-                &format!("{}transaction_status_queue", redis_key_prefix),
+                &format!("{redis_key_prefix}transaction_status_queue"),
                 shared.clone(),
             )
             .await?,
             transaction_status_queue_evm: Self::storage(
-                &format!("{}transaction_status_queue_evm", redis_key_prefix),
+                &format!("{redis_key_prefix}transaction_status_queue_evm"),
                 shared.clone(),
             )
             .await?,
             transaction_status_queue_stellar: Self::storage(
-                &format!("{}transaction_status_queue_stellar", redis_key_prefix),
+                &format!("{redis_key_prefix}transaction_status_queue_stellar"),
                 shared.clone(),
             )
             .await?,
             notification_queue: Self::storage(
-                &format!("{}notification_queue", redis_key_prefix),
+                &format!("{redis_key_prefix}notification_queue"),
                 shared.clone(),
             )
             .await?,
             solana_token_swap_request_queue: Self::storage(
-                &format!("{}solana_token_swap_request_queue", redis_key_prefix),
+                &format!("{redis_key_prefix}solana_token_swap_request_queue"),
                 shared.clone(),
             )
             .await?,
             relayer_health_check_queue: Self::storage(
-                &format!("{}relayer_health_check_queue", redis_key_prefix),
+                &format!("{redis_key_prefix}relayer_health_check_queue"),
                 shared.clone(),
             )
             .await?,

--- a/src/logging/mod.rs
+++ b/src/logging/mod.rs
@@ -26,9 +26,9 @@ use crate::constants::{
 pub fn compute_rolled_file_path(base_file_path: &str, date_str: &str, index: u32) -> String {
     if base_file_path.ends_with(".log") {
         let trimmed = base_file_path.strip_suffix(".log").unwrap();
-        format!("{}-{}.{}.log", trimmed, date_str, index)
+        format!("{trimmed}-{date_str}.{index}.log")
     } else {
-        format!("{}-{}.{}.log", base_file_path, date_str, index)
+        format!("{base_file_path}-{date_str}.{index}.log")
     }
 }
 
@@ -91,7 +91,7 @@ pub fn setup_logging() {
 
         let now = Utc::now();
         let date_str = now.format("%Y-%m-%d").to_string();
-        let base_file_path = format!("{}{}", log_dir, LOG_FILE_NAME);
+        let base_file_path = format!("{log_dir}{LOG_FILE_NAME}");
 
         if let Some(parent) = Path::new(&base_file_path).parent() {
             create_dir_all(parent).expect("Failed to create log directory");

--- a/src/models/address.rs
+++ b/src/models/address.rs
@@ -15,8 +15,8 @@ impl fmt::Display for Address {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Address::Evm(addr) => write!(f, "0x{}", hex::encode(addr)),
-            Address::Stellar(addr) => write!(f, "{}", addr),
-            Address::Solana(addr) => write!(f, "{}", addr),
+            Address::Stellar(addr) => write!(f, "{addr}"),
+            Address::Solana(addr) => write!(f, "{addr}"),
         }
     }
 }

--- a/src/models/error/transaction.rs
+++ b/src/models/error/transaction.rs
@@ -153,7 +153,7 @@ impl From<StellarProviderError> for TransactionError {
 
 impl From<xdr::Error> for TransactionError {
     fn from(error: xdr::Error) -> Self {
-        TransactionError::ValidationError(format!("XDR error: {}", error))
+        TransactionError::ValidationError(format!("XDR error: {error}"))
     }
 }
 

--- a/src/models/network/repository.rs
+++ b/src/models/network/repository.rs
@@ -70,7 +70,7 @@ impl NetworkRepoModel {
     /// A new NetworkRepoModel instance
     pub fn new_evm(config: EvmNetworkConfig) -> Self {
         let name = config.common.network.clone();
-        let id = format!("evm:{}", name).to_lowercase();
+        let id = format!("evm:{name}").to_lowercase();
         Self {
             id,
             name,
@@ -88,7 +88,7 @@ impl NetworkRepoModel {
     /// A new NetworkRepoModel instance
     pub fn new_solana(config: SolanaNetworkConfig) -> Self {
         let name = config.common.network.clone();
-        let id = format!("solana:{}", name).to_lowercase();
+        let id = format!("solana:{name}").to_lowercase();
         Self {
             id,
             name,
@@ -106,7 +106,7 @@ impl NetworkRepoModel {
     /// A new NetworkRepoModel instance
     pub fn new_stellar(config: StellarNetworkConfig) -> Self {
         let name = config.common.network.clone();
-        let id = format!("stellar:{}", name).to_lowercase();
+        let id = format!("stellar:{name}").to_lowercase();
         Self {
             id,
             name,
@@ -124,7 +124,7 @@ impl NetworkRepoModel {
     /// # Returns
     /// A lowercase string ID in format "network_type:name"
     pub fn create_id(network_type: NetworkType, name: &str) -> String {
-        format!("{:?}:{}", network_type, name).to_lowercase()
+        format!("{network_type:?}:{name}").to_lowercase()
     }
 
     /// Returns the common network configuration.

--- a/src/models/notification/config.rs
+++ b/src/models/notification/config.rs
@@ -53,8 +53,7 @@ impl TryFrom<NotificationConfig> for Notification {
             }
             NotificationValidationError::SigningKeyTooShort(min_len) => {
                 ConfigFileError::InvalidFormat(format!(
-                    "Signing key must be at least {} characters long",
-                    min_len
+                    "Signing key must be at least {min_len} characters long"
                 ))
             }
         })?;
@@ -92,8 +91,7 @@ impl NotificationConfig {
                             Ok(Some(secret))
                         }
                         Err(e) => Err(ConfigFileError::MissingEnvVar(format!(
-                            "Environment variable '{}' not found: {}",
-                            value, e
+                            "Environment variable '{value}' not found: {e}"
                         ))),
                     }
                 }

--- a/src/models/notification/mod.rs
+++ b/src/models/notification/mod.rs
@@ -185,7 +185,7 @@ impl From<NotificationValidationError> for crate::models::ApiError {
           NotificationValidationError::EmptyUrl => "URL cannot be empty".to_string(),
           NotificationValidationError::InvalidUrl => "Invalid URL format".to_string(),
           NotificationValidationError::SigningKeyTooShort(min_len) => {
-              format!("Signing key must be at least {} characters long", min_len)
+              format!("Signing key must be at least {min_len} characters long")
           }
       })
     }

--- a/src/models/plain_or_env_value.rs
+++ b/src/models/plain_or_env_value.rs
@@ -37,8 +37,7 @@ impl PlainOrEnvValue {
             PlainOrEnvValue::Env { value } => {
                 let value = Zeroizing::new(std::env::var(value).map_err(|_| {
                     PlainOrEnvValueError::MissingEnvVar(format!(
-                        "Environment variable {} not found",
-                        value
+                        "Environment variable {value} not found"
                     ))
                 })?);
                 Ok(SecretString::new(&value))
@@ -59,7 +58,7 @@ impl PlainOrEnvValue {
 pub fn validate_plain_or_env_value(plain_or_env: &PlainOrEnvValue) -> Result<(), ValidationError> {
     let value = plain_or_env.get_value().map_err(|e| {
         let mut err = ValidationError::new("plain_or_env_value_error");
-        err.message = Some(format!("plain_or_env_value_error: {}", e).into());
+        err.message = Some(format!("plain_or_env_value_error: {e}").into());
         err
     })?;
 

--- a/src/models/relayer/config.rs
+++ b/src/models/relayer/config.rs
@@ -317,7 +317,7 @@ impl TryFrom<RelayerFileConfig> for Relayer {
             RelayerValidationError::EmptyNetwork => ConfigFileError::MissingField("network".into()),
             RelayerValidationError::InvalidPolicy(msg) => ConfigFileError::InvalidPolicy(msg),
             RelayerValidationError::InvalidRpcUrl(msg) => {
-                ConfigFileError::InvalidFormat(format!("Invalid RPC URL: {}", msg))
+                ConfigFileError::InvalidFormat(format!("Invalid RPC URL: {msg}"))
             }
             RelayerValidationError::InvalidRpcWeight => {
                 ConfigFileError::InvalidFormat("RPC URL weight must be in range 0-100".to_string())
@@ -472,7 +472,7 @@ impl RelayersFileConfig {
                 }
                 RelayerValidationError::InvalidPolicy(msg) => ConfigFileError::InvalidPolicy(msg),
                 RelayerValidationError::InvalidRpcUrl(msg) => {
-                    ConfigFileError::InvalidFormat(format!("Invalid RPC URL: {}", msg))
+                    ConfigFileError::InvalidFormat(format!("Invalid RPC URL: {msg}"))
                 }
                 RelayerValidationError::InvalidRpcWeight => ConfigFileError::InvalidFormat(
                     "RPC URL weight must be in range 0-100".to_string(),

--- a/src/models/relayer/mod.rs
+++ b/src/models/relayer/mod.rs
@@ -98,15 +98,15 @@ pub enum HealthCheckFailure {
 impl Display for HealthCheckFailure {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            HealthCheckFailure::NonceSyncFailed(msg) => write!(f, "Nonce sync failed: {}", msg),
+            HealthCheckFailure::NonceSyncFailed(msg) => write!(f, "Nonce sync failed: {msg}"),
             HealthCheckFailure::RpcValidationFailed(msg) => {
-                write!(f, "RPC validation failed: {}", msg)
+                write!(f, "RPC validation failed: {msg}")
             }
             HealthCheckFailure::BalanceCheckFailed(msg) => {
-                write!(f, "Balance check failed: {}", msg)
+                write!(f, "Balance check failed: {msg}")
             }
             HealthCheckFailure::SequenceSyncFailed(msg) => {
-                write!(f, "Sequence sync failed: {}", msg)
+                write!(f, "Sequence sync failed: {msg}")
             }
         }
     }
@@ -218,10 +218,10 @@ impl DisabledReason {
     /// Get a human-readable description of the disabled reason
     pub fn description(&self) -> String {
         match self {
-            DisabledReason::NonceSyncFailed(e) => format!("Nonce sync failed: {}", e),
-            DisabledReason::RpcValidationFailed(e) => format!("RPC validation failed: {}", e),
-            DisabledReason::BalanceCheckFailed(e) => format!("Balance check failed: {}", e),
-            DisabledReason::SequenceSyncFailed(e) => format!("Sequence sync failed: {}", e),
+            DisabledReason::NonceSyncFailed(e) => format!("Nonce sync failed: {e}"),
+            DisabledReason::RpcValidationFailed(e) => format!("RPC validation failed: {e}"),
+            DisabledReason::BalanceCheckFailed(e) => format!("Balance check failed: {e}"),
+            DisabledReason::SequenceSyncFailed(e) => format!("Sequence sync failed: {e}"),
             DisabledReason::Multiple(reasons) => reasons
                 .iter()
                 .map(|r| r.description())
@@ -658,10 +658,9 @@ impl Relayer {
                     RelayerNetworkPolicy::Solana(_) => "Solana",
                     RelayerNetworkPolicy::Stellar(_) => "Stellar",
                 };
-                let network_type_str = format!("{:?}", network_type);
+                let network_type_str = format!("{network_type:?}");
                 return Err(RelayerValidationError::InvalidPolicy(format!(
-                    "Network type {} does not match policy type {}",
-                    network_type_str, policy_type
+                    "Network type {network_type_str} does not match policy type {policy_type}"
                 )));
             }
             // No policies is fine
@@ -718,7 +717,7 @@ impl Relayer {
         if let Some(keys) = keys {
             let solana_pub_key_regex =
                 Regex::new(r"^[1-9A-HJ-NP-Za-km-z]{32,44}$").map_err(|e| {
-                    RelayerValidationError::InvalidPolicy(format!("Regex compilation error: {}", e))
+                    RelayerValidationError::InvalidPolicy(format!("Regex compilation error: {e}"))
                 })?;
 
             for key in keys {
@@ -753,8 +752,7 @@ impl Relayer {
                 SolanaSwapStrategy::JupiterSwap | SolanaSwapStrategy::JupiterUltra => {
                     if self.network != "mainnet-beta" {
                         return Err(RelayerValidationError::InvalidPolicy(format!(
-                            "{:?} strategy is only supported on mainnet-beta",
-                            strategy
+                            "{strategy:?} strategy is only supported on mainnet-beta"
                         )));
                     }
                 }
@@ -861,7 +859,7 @@ impl Relayer {
     ) -> Result<Self, RelayerValidationError> {
         // 1. Convert current domain object to JSON
         let mut domain_json = serde_json::to_value(self).map_err(|e| {
-            RelayerValidationError::InvalidField(format!("Serialization error: {}", e))
+            RelayerValidationError::InvalidField(format!("Serialization error: {e}"))
         })?;
 
         // 2. Apply JSON Merge Patch
@@ -869,7 +867,7 @@ impl Relayer {
 
         // 3. Convert back to domain object
         let updated: Relayer = serde_json::from_value(domain_json).map_err(|e| {
-            RelayerValidationError::InvalidField(format!("Invalid result after patch: {}", e))
+            RelayerValidationError::InvalidField(format!("Invalid result after patch: {e}"))
         })?;
 
         // 4. Validate the final result
@@ -918,10 +916,10 @@ impl From<RelayerValidationError> for crate::models::ApiError {
             RelayerValidationError::EmptyName => "Name cannot be empty".to_string(),
             RelayerValidationError::EmptyNetwork => "Network cannot be empty".to_string(),
             RelayerValidationError::InvalidPolicy(msg) => {
-                format!("Invalid relayer policy: {}", msg)
+                format!("Invalid relayer policy: {msg}")
             }
             RelayerValidationError::InvalidRpcUrl(url) => {
-                format!("Invalid RPC URL: {}", url)
+                format!("Invalid RPC URL: {url}")
             }
             RelayerValidationError::InvalidRpcWeight => {
                 "RPC URL weight must be in range 0-100".to_string()

--- a/src/models/relayer/request.rs
+++ b/src/models/relayer/request.rs
@@ -142,18 +142,18 @@ pub fn deserialize_policy_for_network_type(
     match network_type {
         RelayerNetworkType::Evm => {
             let evm_policy: RelayerEvmPolicy = serde_json::from_value(policies_value.clone())
-                .map_err(|e| ApiError::BadRequest(format!("Invalid EVM policy: {}", e)))?;
+                .map_err(|e| ApiError::BadRequest(format!("Invalid EVM policy: {e}")))?;
             Ok(RelayerNetworkPolicy::Evm(evm_policy))
         }
         RelayerNetworkType::Solana => {
             let solana_policy: RelayerSolanaPolicy = serde_json::from_value(policies_value.clone())
-                .map_err(|e| ApiError::BadRequest(format!("Invalid Solana policy: {}", e)))?;
+                .map_err(|e| ApiError::BadRequest(format!("Invalid Solana policy: {e}")))?;
             Ok(RelayerNetworkPolicy::Solana(solana_policy))
         }
         RelayerNetworkType::Stellar => {
             let stellar_policy: RelayerStellarPolicy =
                 serde_json::from_value(policies_value.clone())
-                    .map_err(|e| ApiError::BadRequest(format!("Invalid Stellar policy: {}", e)))?;
+                    .map_err(|e| ApiError::BadRequest(format!("Invalid Stellar policy: {e}")))?;
             Ok(RelayerNetworkPolicy::Stellar(stellar_policy))
         }
     }

--- a/src/models/rpc/mod.rs
+++ b/src/models/rpc/mod.rs
@@ -144,7 +144,7 @@ pub fn convert_to_internal_rpc_request(
                     let json = serde_json::json!({"method": method, "params": params});
                     let solana_request: crate::models::SolanaRpcRequest =
                         serde_json::from_value(json).map_err(|e| {
-                            ApiError::BadRequest(format!("Invalid Solana RPC request: {}", e))
+                            ApiError::BadRequest(format!("Invalid Solana RPC request: {e}"))
                         })?;
 
                     Ok(JsonRpcRequest {

--- a/src/models/signer/config.rs
+++ b/src/models/signer/config.rs
@@ -234,7 +234,7 @@ impl TryFrom<LocalSignerFileConfig> for LocalSignerConfig {
         }
 
         let passphrase = config.passphrase.get_value().map_err(|e| {
-            ConfigFileError::InvalidFormat(format!("Failed to get passphrase value: {}", e))
+            ConfigFileError::InvalidFormat(format!("Failed to get passphrase value: {e}"))
         })?;
 
         if passphrase.is_empty() {
@@ -271,7 +271,7 @@ impl TryFrom<TurnkeySignerFileConfig> for TurnkeySignerConfig {
 
     fn try_from(config: TurnkeySignerFileConfig) -> Result<Self, Self::Error> {
         let api_private_key = config.api_private_key.get_value().map_err(|e| {
-            ConfigFileError::InvalidFormat(format!("Failed to get API private key: {}", e))
+            ConfigFileError::InvalidFormat(format!("Failed to get API private key: {e}"))
         })?;
 
         Ok(TurnkeySignerConfig {
@@ -289,11 +289,11 @@ impl TryFrom<CdpSignerFileConfig> for CdpSignerConfig {
 
     fn try_from(config: CdpSignerFileConfig) -> Result<Self, Self::Error> {
         let api_key_secret = config.api_key_secret.get_value().map_err(|e| {
-            ConfigFileError::InvalidFormat(format!("Failed to get API key secret: {}", e))
+            ConfigFileError::InvalidFormat(format!("Failed to get API key secret: {e}"))
         })?;
 
         let wallet_secret = config.wallet_secret.get_value().map_err(|e| {
-            ConfigFileError::InvalidFormat(format!("Failed to get wallet secret: {}", e))
+            ConfigFileError::InvalidFormat(format!("Failed to get wallet secret: {e}"))
         })?;
 
         Ok(CdpSignerConfig {
@@ -312,11 +312,12 @@ impl TryFrom<VaultSignerFileConfig> for VaultSignerConfig {
         let role_id = config
             .role_id
             .get_value()
-            .map_err(|e| ConfigFileError::InvalidFormat(format!("Failed to get role ID: {}", e)))?;
+            .map_err(|e| ConfigFileError::InvalidFormat(format!("Failed to get role ID: {e}")))?;
 
-        let secret_id = config.secret_id.get_value().map_err(|e| {
-            ConfigFileError::InvalidFormat(format!("Failed to get secret ID: {}", e))
-        })?;
+        let secret_id = config
+            .secret_id
+            .get_value()
+            .map_err(|e| ConfigFileError::InvalidFormat(format!("Failed to get secret ID: {e}")))?;
 
         Ok(VaultSignerConfig {
             address: config.address,
@@ -336,11 +337,12 @@ impl TryFrom<VaultTransitSignerFileConfig> for VaultTransitSignerConfig {
         let role_id = config
             .role_id
             .get_value()
-            .map_err(|e| ConfigFileError::InvalidFormat(format!("Failed to get role ID: {}", e)))?;
+            .map_err(|e| ConfigFileError::InvalidFormat(format!("Failed to get role ID: {e}")))?;
 
-        let secret_id = config.secret_id.get_value().map_err(|e| {
-            ConfigFileError::InvalidFormat(format!("Failed to get secret ID: {}", e))
-        })?;
+        let secret_id = config
+            .secret_id
+            .get_value()
+            .map_err(|e| ConfigFileError::InvalidFormat(format!("Failed to get secret ID: {e}")))?;
 
         Ok(VaultTransitSignerConfig {
             key_name: config.key_name,
@@ -363,7 +365,7 @@ impl TryFrom<GoogleCloudKmsSignerFileConfig> for GoogleCloudKmsSignerConfig {
             .private_key
             .get_value()
             .map_err(|e| {
-                ConfigFileError::InvalidFormat(format!("Failed to get private key: {}", e))
+                ConfigFileError::InvalidFormat(format!("Failed to get private key: {e}"))
             })?;
 
         let private_key_id = config
@@ -371,7 +373,7 @@ impl TryFrom<GoogleCloudKmsSignerFileConfig> for GoogleCloudKmsSignerConfig {
             .private_key_id
             .get_value()
             .map_err(|e| {
-                ConfigFileError::InvalidFormat(format!("Failed to get private key ID: {}", e))
+                ConfigFileError::InvalidFormat(format!("Failed to get private key ID: {e}"))
             })?;
 
         let client_email = config
@@ -379,7 +381,7 @@ impl TryFrom<GoogleCloudKmsSignerFileConfig> for GoogleCloudKmsSignerConfig {
             .client_email
             .get_value()
             .map_err(|e| {
-                ConfigFileError::InvalidFormat(format!("Failed to get client email: {}", e))
+                ConfigFileError::InvalidFormat(format!("Failed to get client email: {e}"))
             })?;
 
         let service_account = GoogleCloudKmsSignerServiceAccountConfig {
@@ -459,7 +461,7 @@ impl TryFrom<SignerFileConfig> for Signer {
                 ConfigFileError::InvalidFormat("Invalid signer ID format".into())
             }
             crate::models::signer::SignerValidationError::InvalidConfig(msg) => {
-                ConfigFileError::InvalidFormat(format!("Invalid signer configuration: {}", msg))
+                ConfigFileError::InvalidFormat(format!("Invalid signer configuration: {msg}"))
             }
         })?;
 

--- a/src/models/signer/mod.rs
+++ b/src/models/signer/mod.rs
@@ -457,7 +457,7 @@ fn format_validation_errors(errors: &validator::ValidationErrors) -> String {
     for (struct_field, kind) in errors.errors().iter() {
         if let validator::ValidationErrorsKind::Struct(nested) = kind {
             let nested_msgs = format_validation_errors(nested);
-            messages.push(format!("{}.{}", struct_field, nested_msgs));
+            messages.push(format!("{struct_field}.{nested_msgs}"));
         }
     }
 
@@ -553,7 +553,7 @@ impl From<SignerValidationError> for crate::models::ApiError {
             SignerValidationError::InvalidIdFormat => {
                 "ID must contain only letters, numbers, dashes and underscores and must be at most 36 characters long".to_string()
             }
-            SignerValidationError::InvalidConfig(msg) => format!("Invalid signer configuration: {}", msg),
+            SignerValidationError::InvalidConfig(msg) => format!("Invalid signer configuration: {msg}"),
         })
     }
 }

--- a/src/models/signer/request.rs
+++ b/src/models/signer/request.rs
@@ -214,7 +214,7 @@ impl TryFrom<SignerConfigRequest> for SignerConfig {
                 // Decode hex string to raw bytes for cryptographic key
                 let key_bytes = hex::decode(&local_config.key)
                     .map_err(|e| ApiError::BadRequest(format!(
-                        "Invalid hex key format: {}. Key must be a 64-character hex string (32 bytes).", e
+                        "Invalid hex key format: {e}. Key must be a 64-character hex string (32 bytes)."
                     )))?;
 
                 let raw_key = SecretVec::new(key_bytes.len(), |buffer| {

--- a/src/models/transaction/repository.rs
+++ b/src/models/transaction/repository.rs
@@ -703,7 +703,7 @@ impl StellarTransactionData {
     fn parse_xdr_envelope(&self, xdr: &str) -> Result<TransactionEnvelope, SignerError> {
         use soroban_rs::xdr::{Limits, ReadXdr};
         TransactionEnvelope::from_xdr_base64(xdr, Limits::none())
-            .map_err(|e| SignerError::ConversionError(format!("Invalid XDR: {}", e)))
+            .map_err(|e| SignerError::ConversionError(format!("Invalid XDR: {e}")))
     }
 
     // Helper method to attach signatures to an envelope
@@ -715,13 +715,11 @@ impl StellarTransactionData {
 
         // Serialize and re-parse to get a mutable version
         let envelope_xdr = envelope.to_xdr_base64(Limits::none()).map_err(|e| {
-            SignerError::ConversionError(format!("Failed to serialize envelope: {}", e))
+            SignerError::ConversionError(format!("Failed to serialize envelope: {e}"))
         })?;
 
         let mut envelope = TransactionEnvelope::from_xdr_base64(&envelope_xdr, Limits::none())
-            .map_err(|e| {
-                SignerError::ConversionError(format!("Failed to parse envelope: {}", e))
-            })?;
+            .map_err(|e| SignerError::ConversionError(format!("Failed to parse envelope: {e}")))?;
 
         let sigs = VecM::try_from(self.signatures.clone())
             .map_err(|_| SignerError::ConversionError("too many signatures".into()))?;
@@ -918,7 +916,7 @@ impl EvmTransactionData {
     pub fn to_address(&self) -> Result<Option<AlloyAddress>, SignerError> {
         Ok(match self.to.as_deref().filter(|s| !s.is_empty()) {
             Some(addr_str) => Some(AlloyAddress::from_str(addr_str).map_err(|e| {
-                AddressError::ConversionError(format!("Invalid 'to' address: {}", e))
+                AddressError::ConversionError(format!("Invalid 'to' address: {e}"))
             })?),
             None => None,
         })
@@ -931,7 +929,7 @@ impl EvmTransactionData {
     /// * `Err(SignerError)` if the hex string is invalid
     pub fn data_to_bytes(&self) -> Result<Bytes, SignerError> {
         Bytes::from_str(self.data.as_deref().unwrap_or(""))
-            .map_err(|e| SignerError::SigningError(format!("Invalid transaction data: {}", e)))
+            .map_err(|e| SignerError::SigningError(format!("Invalid transaction data: {e}")))
     }
 }
 

--- a/src/models/transaction/request/evm.rs
+++ b/src/models/transaction/request/evm.rs
@@ -71,8 +71,7 @@ pub fn validate_evm_transaction_request(
         let intrinsic_gas = calculate_intrinsic_gas(request);
         if gas_limit < intrinsic_gas {
             return Err(ApiError::BadRequest(format!(
-                "gas_limit is too low, intrinsic gas is {} and gas_limit is {}",
-                intrinsic_gas, gas_limit
+                "gas_limit is too low, intrinsic gas is {intrinsic_gas} and gas_limit is {gas_limit}"
             )));
         }
     }

--- a/src/models/transaction/request/solana.rs
+++ b/src/models/transaction/request/solana.rs
@@ -91,7 +91,7 @@ impl SolanaTransactionRequest {
     ) -> Result<(), ApiError> {
         // Parse the transaction from encoded bytes
         let tx = Transaction::try_from(transaction.clone())
-            .map_err(|e| ApiError::BadRequest(format!("Failed to decode transaction: {}", e)))?;
+            .map_err(|e| ApiError::BadRequest(format!("Failed to decode transaction: {e}")))?;
 
         // Get the fee payer (first account in account_keys)
         let fee_payer = tx.message.account_keys.first().ok_or_else(|| {
@@ -100,13 +100,12 @@ impl SolanaTransactionRequest {
 
         // Parse relayer address
         let relayer_pubkey = Pubkey::from_str(&relayer.address)
-            .map_err(|e| ApiError::BadRequest(format!("Invalid relayer address: {}", e)))?;
+            .map_err(|e| ApiError::BadRequest(format!("Invalid relayer address: {e}")))?;
 
         // Validate fee payer matches relayer address
         if fee_payer != &relayer_pubkey {
             return Err(ApiError::BadRequest(format!(
-                "Transaction fee payer {} does not match relayer address {}",
-                fee_payer, relayer_pubkey
+                "Transaction fee payer {fee_payer} does not match relayer address {relayer_pubkey}"
             )));
         }
 
@@ -129,7 +128,7 @@ impl SolanaTransactionRequest {
     ) -> Result<(), ApiError> {
         // Parse relayer address once for validation
         let relayer_pubkey = Pubkey::from_str(&relayer.address)
-            .map_err(|e| ApiError::BadRequest(format!("Invalid relayer address: {}", e)))?;
+            .map_err(|e| ApiError::BadRequest(format!("Invalid relayer address: {e}")))?;
         if instructions.is_empty() {
             return Err(ApiError::BadRequest(
                 "Instructions cannot be empty".to_string(),
@@ -151,24 +150,21 @@ impl SolanaTransactionRequest {
             let trimmed_program_id = instruction.program_id.trim();
             if trimmed_program_id.is_empty() {
                 return Err(ApiError::BadRequest(format!(
-                    "Instruction {}: program_id cannot be empty",
-                    idx
+                    "Instruction {idx}: program_id cannot be empty"
                 )));
             }
 
             // Validate program_id is valid pubkey
             let program_pubkey = Pubkey::from_str(trimmed_program_id).map_err(|e| {
                 ApiError::BadRequest(format!(
-                    "Instruction {}: Invalid program_id '{}' - {}",
-                    idx, trimmed_program_id, e
+                    "Instruction {idx}: Invalid program_id '{trimmed_program_id}' - {e}"
                 ))
             })?;
 
             // Reject default/zero pubkey as program_id
             if program_pubkey == Pubkey::default() {
                 return Err(ApiError::BadRequest(format!(
-                    "Instruction {}: program_id cannot be default pubkey",
-                    idx
+                    "Instruction {idx}: program_id cannot be default pubkey"
                 )));
             }
 
@@ -189,25 +185,22 @@ impl SolanaTransactionRequest {
                 let trimmed_pubkey = account.pubkey.trim();
                 if trimmed_pubkey.is_empty() {
                     return Err(ApiError::BadRequest(format!(
-                        "Instruction {} account {}: pubkey cannot be empty",
-                        idx, acc_idx
+                        "Instruction {idx} account {acc_idx}: pubkey cannot be empty"
                     )));
                 }
 
                 let pubkey = Pubkey::from_str(trimmed_pubkey).map_err(|e| {
                     ApiError::BadRequest(format!(
-                        "Instruction {} account {}: Invalid pubkey '{}' - {}",
-                        idx, acc_idx, trimmed_pubkey, e
+                        "Instruction {idx} account {acc_idx}: Invalid pubkey '{trimmed_pubkey}' - {e}"
                     ))
                 })?;
 
                 // Validate that only the relayer can be marked as a signer
                 if account.is_signer && pubkey != relayer_pubkey {
                     return Err(ApiError::BadRequest(format!(
-                        "Instruction {} account {}: Only the relayer address {} can be marked as \
-                         a signer, but '{}' is marked as a signer. The relayer can only provide \
-                         its own signature.",
-                        idx, acc_idx, relayer_pubkey, pubkey
+                        "Instruction {idx} account {acc_idx}: Only the relayer address {relayer_pubkey} can be marked as \
+                         a signer, but '{pubkey}' is marked as a signer. The relayer can only provide \
+                         its own signature."
                     )));
                 }
 
@@ -216,7 +209,7 @@ impl SolanaTransactionRequest {
 
             // Validate data is valid base64 and decode it
             let decoded_data = base64_decode(&instruction.data).map_err(|e| {
-                ApiError::BadRequest(format!("Instruction {}: Invalid base64 data - {}", idx, e))
+                ApiError::BadRequest(format!("Instruction {idx}: Invalid base64 data - {e}"))
             })?;
 
             // Validate decoded data size

--- a/src/models/transaction/stellar/asset.rs
+++ b/src/models/transaction/stellar/asset.rs
@@ -33,7 +33,7 @@ impl TryFrom<AssetSpec> for Asset {
                 buf[..b.len()].copy_from_slice(b);
 
                 let issuer_pk = PublicKey::from_str(&issuer)
-                    .map_err(|e| SignerError::ConversionError(format!("Invalid issuer: {}", e)))?;
+                    .map_err(|e| SignerError::ConversionError(format!("Invalid issuer: {e}")))?;
 
                 let uint256 = Uint256(issuer_pk.0);
                 let pk = XdrPublicKey::PublicKeyTypeEd25519(uint256);
@@ -53,7 +53,7 @@ impl TryFrom<AssetSpec> for Asset {
                 buf[..b.len()].copy_from_slice(b);
 
                 let issuer_pk = PublicKey::from_str(&issuer)
-                    .map_err(|e| SignerError::ConversionError(format!("Invalid issuer: {}", e)))?;
+                    .map_err(|e| SignerError::ConversionError(format!("Invalid issuer: {e}")))?;
 
                 let uint256 = Uint256(issuer_pk.0);
                 let pk = XdrPublicKey::PublicKeyTypeEd25519(uint256);

--- a/src/models/transaction/stellar/conversion.rs
+++ b/src/models/transaction/stellar/conversion.rs
@@ -73,7 +73,7 @@ impl TryFrom<StellarTransactionData> for Transaction {
 
                 let source_account =
                     string_to_muxed_account(&data.source_account).map_err(|e| {
-                        SignerError::ConversionError(format!("Invalid source account: {}", e))
+                        SignerError::ConversionError(format!("Invalid source account: {e}"))
                     })?;
 
                 // Apply transaction extension data from simulation if available

--- a/src/models/transaction/stellar/memo.rs
+++ b/src/models/transaction/stellar/memo.rs
@@ -32,9 +32,8 @@ impl TryFrom<MemoSpec> for Memo {
         Ok(match m {
             MemoSpec::None => Memo::None,
             MemoSpec::Text { value } => {
-                let text = StringM::<28>::try_from(value.as_str()).map_err(|e| {
-                    SignerError::ConversionError(format!("Invalid memo text: {}", e))
-                })?;
+                let text = StringM::<28>::try_from(value.as_str())
+                    .map_err(|e| SignerError::ConversionError(format!("Invalid memo text: {e}")))?;
                 Memo::Text(text)
             }
             MemoSpec::Id { value } => Memo::Id(value),

--- a/src/models/transaction/stellar/operation.rs
+++ b/src/models/transaction/stellar/operation.rs
@@ -75,7 +75,7 @@ fn parse_destination_address(destination: &str) -> Result<XdrMuxedAccount, Signe
     } else {
         // fall-back to plain G... public key
         let pk = PublicKey::from_string(destination)
-            .map_err(|e| SignerError::ConversionError(format!("Invalid destination: {}", e)))?;
+            .map_err(|e| SignerError::ConversionError(format!("Invalid destination: {e}")))?;
         Ok(XdrMuxedAccount::Ed25519(Uint256(pk.0)))
     }
 }
@@ -103,7 +103,7 @@ fn decode_xdr_auth_entries(
         .iter()
         .map(|xdr_str| {
             SorobanAuthorizationEntry::from_xdr_base64(xdr_str, Limits::none())
-                .map_err(|e| SignerError::ConversionError(format!("Invalid auth XDR: {}", e)))
+                .map_err(|e| SignerError::ConversionError(format!("Invalid auth XDR: {e}")))
         })
         .collect()
 }
@@ -153,9 +153,9 @@ fn build_auth_vector(
         None => generate_default_auth_entries(host_function)?,
     };
 
-    auth_entries.try_into().map_err(|e| {
-        SignerError::ConversionError(format!("Failed to convert auth entries: {:?}", e))
-    })
+    auth_entries
+        .try_into()
+        .map_err(|e| SignerError::ConversionError(format!("Failed to convert auth entries: {e:?}")))
 }
 
 /// Converts Payment operation spec to Operation

--- a/src/repositories/api_key/api_key_in_memory.rs
+++ b/src/repositories/api_key/api_key_in_memory.rs
@@ -98,8 +98,7 @@ impl ApiKeyRepositoryTrait for InMemoryApiKeyRepository {
         let api_key = store
             .get(api_key_id)
             .ok_or(RepositoryError::NotFound(format!(
-                "Api key with id {} not found",
-                api_key_id
+                "Api key with id {api_key_id} not found"
             )))?;
         Ok(api_key.permissions.clone())
     }

--- a/src/repositories/api_key/api_key_redis.rs
+++ b/src/repositories/api_key/api_key_redis.rs
@@ -240,8 +240,7 @@ impl ApiKeyRepositoryTrait for RedisApiKeyRepository {
         match api_key {
             Some(api_key) => Ok(api_key.permissions),
             None => Err(RepositoryError::NotFound(format!(
-                "Api key with ID {} not found",
-                api_key_id
+                "Api key with ID {api_key_id} not found"
             ))),
         }
     }
@@ -267,8 +266,7 @@ impl ApiKeyRepositoryTrait for RedisApiKeyRepository {
 
         if existing.is_none() {
             return Err(RepositoryError::NotFound(format!(
-                "Api key with ID {} not found",
-                id
+                "Api key with ID {id} not found"
             )));
         }
 

--- a/src/repositories/network/network_in_memory.rs
+++ b/src/repositories/network/network_in_memory.rs
@@ -85,8 +85,7 @@ impl Repository<NetworkRepoModel, String> for InMemoryNetworkRepository {
         match store.get(&id) {
             Some(network) => Ok(network.clone()),
             None => Err(RepositoryError::NotFound(format!(
-                "Network with ID {} not found",
-                id
+                "Network with ID {id} not found"
             ))),
         }
     }

--- a/src/repositories/network/network_redis.rs
+++ b/src/repositories/network/network_redis.rs
@@ -308,8 +308,7 @@ impl Repository<NetworkRepoModel, String> for RedisNetworkRepository {
             None => {
                 debug!(network_id = %id, "network not found");
                 Err(RepositoryError::NotFound(format!(
-                    "Network with ID {} not found",
-                    id
+                    "Network with ID {id} not found"
                 )))
             }
         }

--- a/src/repositories/notification/notification_in_memory.rs
+++ b/src/repositories/notification/notification_in_memory.rs
@@ -72,8 +72,7 @@ impl Repository<NotificationRepoModel, String> for InMemoryNotificationRepositor
         match store.get(&id) {
             Some(entity) => Ok(entity.clone()),
             None => Err(RepositoryError::NotFound(format!(
-                "Notification with ID '{}' not found",
-                id
+                "Notification with ID '{id}' not found"
             ))),
         }
     }
@@ -89,8 +88,7 @@ impl Repository<NotificationRepoModel, String> for InMemoryNotificationRepositor
         // Check if notification exists
         if !store.contains_key(&id) {
             return Err(RepositoryError::NotFound(format!(
-                "Notification with ID '{}' not found",
-                id
+                "Notification with ID '{id}' not found"
             )));
         }
 
@@ -111,8 +109,7 @@ impl Repository<NotificationRepoModel, String> for InMemoryNotificationRepositor
         match store.remove(&id) {
             Some(_) => Ok(()),
             None => Err(RepositoryError::NotFound(format!(
-                "Notification with ID {} not found",
-                id
+                "Notification with ID {id} not found"
             ))),
         }
     }
@@ -170,7 +167,7 @@ impl TryFrom<NotificationConfig> for NotificationRepoModel {
 
     fn try_from(config: NotificationConfig) -> Result<Self, Self::Error> {
         let signing_key = config.get_signing_key().map_err(|e| {
-            ConversionError::InvalidConfig(format!("Failed to get signing key: {}", e))
+            ConversionError::InvalidConfig(format!("Failed to get signing key: {e}"))
         })?;
 
         Ok(NotificationRepoModel {

--- a/src/repositories/notification/notification_redis.rs
+++ b/src/repositories/notification/notification_redis.rs
@@ -203,8 +203,7 @@ impl Repository<NotificationRepoModel, String> for RedisNotificationRepository {
             None => {
                 debug!("notification not found");
                 Err(RepositoryError::NotFound(format!(
-                    "Notification with ID '{}' not found",
-                    id
+                    "Notification with ID '{id}' not found"
                 )))
             }
         }
@@ -304,8 +303,7 @@ impl Repository<NotificationRepoModel, String> for RedisNotificationRepository {
 
         if existing.is_none() {
             return Err(RepositoryError::NotFound(format!(
-                "Notification with ID '{}' not found",
-                id
+                "Notification with ID '{id}' not found"
             )));
         }
 
@@ -342,8 +340,7 @@ impl Repository<NotificationRepoModel, String> for RedisNotificationRepository {
 
         if existing.is_none() {
             return Err(RepositoryError::NotFound(format!(
-                "Notification with ID '{}' not found",
-                id
+                "Notification with ID '{id}' not found"
             )));
         }
 

--- a/src/repositories/plugin/plugin_redis.rs
+++ b/src/repositories/plugin/plugin_redis.rs
@@ -73,7 +73,7 @@ impl RedisPluginRepository {
         let json: Option<String> = conn
             .get(&key)
             .await
-            .map_err(|e| self.map_redis_error(e, &format!("get_plugin_by_id_{}", id)))?;
+            .map_err(|e| self.map_redis_error(e, &format!("get_plugin_by_id_{id}")))?;
 
         match json {
             Some(json) => {

--- a/src/repositories/redis_base.rs
+++ b/src/repositories/redis_base.rs
@@ -23,10 +23,7 @@ pub trait RedisRepository {
         serde_json::to_string(entity).map_err(|e| {
             let id = id_extractor(entity);
             error!(entity_type = %entity_type, id = %id, error = %e, "serialization failed");
-            RepositoryError::InvalidData(format!(
-                "Failed to serialize {} {}: {}",
-                entity_type, id, e
-            ))
+            RepositoryError::InvalidData(format!("Failed to serialize {entity_type} {id}: {e}"))
         })
     }
 
@@ -59,34 +56,28 @@ pub trait RedisRepository {
 
         match error.kind() {
             redis::ErrorKind::TypeError => RepositoryError::InvalidData(format!(
-                "Redis data type error in operation '{}': {}",
-                context, error
+                "Redis data type error in operation '{context}': {error}"
             )),
             redis::ErrorKind::AuthenticationFailed => {
                 RepositoryError::InvalidData("Redis authentication failed".to_string())
             }
             redis::ErrorKind::NoScriptError => RepositoryError::InvalidData(format!(
-                "Redis script error in operation '{}': {}",
-                context, error
+                "Redis script error in operation '{context}': {error}"
             )),
             redis::ErrorKind::ReadOnly => RepositoryError::InvalidData(format!(
-                "Redis is read-only in operation '{}': {}",
-                context, error
+                "Redis is read-only in operation '{context}': {error}"
             )),
             redis::ErrorKind::ExecAbortError => RepositoryError::InvalidData(format!(
-                "Redis transaction aborted in operation '{}': {}",
-                context, error
+                "Redis transaction aborted in operation '{context}': {error}"
             )),
             redis::ErrorKind::BusyLoadingError => RepositoryError::InvalidData(format!(
-                "Redis is busy in operation '{}': {}",
-                context, error
+                "Redis is busy in operation '{context}': {error}"
             )),
             redis::ErrorKind::ExtensionError => RepositoryError::InvalidData(format!(
-                "Redis extension error in operation '{}': {}",
-                context, error
+                "Redis extension error in operation '{context}': {error}"
             )),
             // Default to Other for connection errors and other issues
-            _ => RepositoryError::Other(format!("Redis operation '{}' failed: {}", context, error)),
+            _ => RepositoryError::Other(format!("Redis operation '{context}' failed: {error}")),
         }
     }
 }

--- a/src/repositories/relayer/relayer_in_memory.rs
+++ b/src/repositories/relayer/relayer_in_memory.rs
@@ -112,8 +112,7 @@ impl RelayerRepository for InMemoryRelayerRepository {
             Ok(relayer.clone())
         } else {
             Err(RepositoryError::NotFound(format!(
-                "Relayer with ID {} not found",
-                id
+                "Relayer with ID {id} not found"
             )))
         }
     }
@@ -124,9 +123,9 @@ impl RelayerRepository for InMemoryRelayerRepository {
         policy: RelayerNetworkPolicy,
     ) -> Result<RelayerRepoModel, RepositoryError> {
         let mut store = Self::acquire_lock(&self.store).await?;
-        let relayer = store.get_mut(&id).ok_or_else(|| {
-            RepositoryError::NotFound(format!("Relayer with ID {} not found", id))
-        })?;
+        let relayer = store
+            .get_mut(&id)
+            .ok_or_else(|| RepositoryError::NotFound(format!("Relayer with ID {id} not found")))?;
         relayer.policies = policy;
         Ok(relayer.clone())
     }
@@ -143,8 +142,7 @@ impl RelayerRepository for InMemoryRelayerRepository {
             Ok(relayer.clone())
         } else {
             Err(RepositoryError::NotFound(format!(
-                "Relayer with ID {} not found",
-                relayer_id
+                "Relayer with ID {relayer_id} not found"
             )))
         }
     }
@@ -160,8 +158,7 @@ impl RelayerRepository for InMemoryRelayerRepository {
             Ok(relayer.clone())
         } else {
             Err(RepositoryError::NotFound(format!(
-                "Relayer with ID {} not found",
-                relayer_id
+                "Relayer with ID {relayer_id} not found"
             )))
         }
     }
@@ -186,8 +183,7 @@ impl Repository<RelayerRepoModel, String> for InMemoryRelayerRepository {
         match store.get(&id) {
             Some(relayer) => Ok(relayer.clone()),
             None => Err(RepositoryError::NotFound(format!(
-                "Relayer with ID {} not found",
-                id
+                "Relayer with ID {id} not found"
             ))),
         }
     }
@@ -206,8 +202,7 @@ impl Repository<RelayerRepoModel, String> for InMemoryRelayerRepository {
             Ok(updated_relayer)
         } else {
             Err(RepositoryError::NotFound(format!(
-                "Relayer with ID {} not found",
-                id
+                "Relayer with ID {id} not found"
             )))
         }
     }
@@ -218,8 +213,7 @@ impl Repository<RelayerRepoModel, String> for InMemoryRelayerRepository {
             Ok(())
         } else {
             Err(RepositoryError::NotFound(format!(
-                "Relayer with ID {} not found",
-                id
+                "Relayer with ID {id} not found"
             )))
         }
     }

--- a/src/repositories/relayer/relayer_redis.rs
+++ b/src/repositories/relayer/relayer_redis.rs
@@ -189,8 +189,7 @@ impl Repository<RelayerRepoModel, String> for RedisRelayerRepository {
             None => {
                 debug!(relayer_id = %id, "relayer not found");
                 Err(RepositoryError::NotFound(format!(
-                    "Relayer with ID {} not found",
-                    id
+                    "Relayer with ID {id} not found"
                 )))
             }
         }
@@ -295,8 +294,7 @@ impl Repository<RelayerRepoModel, String> for RedisRelayerRepository {
 
         if !exists {
             return Err(RepositoryError::NotFound(format!(
-                "Relayer with ID {} not found",
-                id
+                "Relayer with ID {id} not found"
             )));
         }
 
@@ -338,8 +336,7 @@ impl Repository<RelayerRepoModel, String> for RedisRelayerRepository {
 
         if !exists {
             return Err(RepositoryError::NotFound(format!(
-                "Relayer with ID {} not found",
-                id
+                "Relayer with ID {id} not found"
             )));
         }
 

--- a/src/repositories/signer/signer_in_memory.rs
+++ b/src/repositories/signer/signer_in_memory.rs
@@ -70,8 +70,7 @@ impl Repository<SignerRepoModel, String> for InMemorySignerRepository {
         match store.get(&id) {
             Some(signer) => Ok(signer.clone()),
             None => Err(RepositoryError::NotFound(format!(
-                "Signer with ID {} not found",
-                id
+                "Signer with ID {id} not found"
             ))),
         }
     }
@@ -86,8 +85,7 @@ impl Repository<SignerRepoModel, String> for InMemorySignerRepository {
             Self::acquire_lock(&self.store).await?;
         if !store.contains_key(&id) {
             return Err(RepositoryError::NotFound(format!(
-                "Signer with ID {} not found",
-                id
+                "Signer with ID {id} not found"
             )));
         }
         store.insert(id, signer.clone());
@@ -99,8 +97,7 @@ impl Repository<SignerRepoModel, String> for InMemorySignerRepository {
             Self::acquire_lock(&self.store).await?;
         if !store.contains_key(&id) {
             return Err(RepositoryError::NotFound(format!(
-                "Signer with ID {} not found",
-                id
+                "Signer with ID {id} not found"
             )));
         }
         store.remove(&id);

--- a/src/repositories/signer/signer_redis.rs
+++ b/src/repositories/signer/signer_redis.rs
@@ -53,7 +53,7 @@ impl RedisSignerRepository {
         let result: Result<i64, RedisError> = conn.sadd(&key, id).await;
         result.map_err(|e| {
             error!(signer_id = %id, error = %e, "failed to add signer to list");
-            RepositoryError::Other(format!("Failed to add signer to list: {}", e))
+            RepositoryError::Other(format!("Failed to add signer to list: {e}"))
         })?;
 
         debug!(signer_id = %id, "added signer to list");
@@ -67,7 +67,7 @@ impl RedisSignerRepository {
         let result: Result<i64, RedisError> = conn.srem(&key, id).await;
         result.map_err(|e| {
             error!(signer_id = %id, error = %e, "failed to remove signer from list");
-            RepositoryError::Other(format!("Failed to remove signer from list: {}", e))
+            RepositoryError::Other(format!("Failed to remove signer from list: {e}"))
         })?;
 
         debug!(signer_id = %id, "removed signer from list");
@@ -81,7 +81,7 @@ impl RedisSignerRepository {
         let result: Result<Vec<String>, RedisError> = conn.smembers(&key).await;
         result.map_err(|e| {
             error!(error = %e, "failed to get signer IDs");
-            RepositoryError::Other(format!("Failed to get signer IDs: {}", e))
+            RepositoryError::Other(format!("Failed to get signer IDs: {e}"))
         })
     }
 
@@ -182,8 +182,7 @@ impl Repository<SignerRepoModel, String> for RedisSignerRepository {
             Err(e) => {
                 error!(error = %e, "failed to check if signer exists");
                 return Err(RepositoryError::Other(format!(
-                    "Failed to check signer existence: {}",
-                    e
+                    "Failed to check signer existence: {e}"
                 )));
             }
         }
@@ -195,7 +194,7 @@ impl Repository<SignerRepoModel, String> for RedisSignerRepository {
         let result: Result<(), RedisError> = conn.set(&key, &serialized).await;
         result.map_err(|e| {
             error!(signer_id = %signer.id, error = %e, "failed to store signer");
-            RepositoryError::Other(format!("Failed to store signer: {}", e))
+            RepositoryError::Other(format!("Failed to store signer: {e}"))
         })?;
 
         // Add to list
@@ -226,15 +225,13 @@ impl Repository<SignerRepoModel, String> for RedisSignerRepository {
             Ok(None) => {
                 debug!(signer_id = %id, "signer not found");
                 Err(RepositoryError::NotFound(format!(
-                    "Signer with ID {} not found",
-                    id
+                    "Signer with ID {id} not found"
                 )))
             }
             Err(e) => {
                 error!(signer_id = %id, error = %e, "failed to retrieve signer");
                 Err(RepositoryError::Other(format!(
-                    "Failed to retrieve signer: {}",
-                    e
+                    "Failed to retrieve signer: {e}"
                 )))
             }
         }
@@ -265,8 +262,7 @@ impl Repository<SignerRepoModel, String> for RedisSignerRepository {
         match exists {
             Ok(false) => {
                 return Err(RepositoryError::NotFound(format!(
-                    "Signer with ID {} not found",
-                    id
+                    "Signer with ID {id} not found"
                 )));
             }
             Ok(true) => {
@@ -275,8 +271,7 @@ impl Repository<SignerRepoModel, String> for RedisSignerRepository {
             Err(e) => {
                 error!(error = %e, "failed to check if signer exists");
                 return Err(RepositoryError::Other(format!(
-                    "Failed to check signer existence: {}",
-                    e
+                    "Failed to check signer existence: {e}"
                 )));
             }
         }
@@ -288,7 +283,7 @@ impl Repository<SignerRepoModel, String> for RedisSignerRepository {
         let result: Result<(), RedisError> = conn.set(&key, &serialized).await;
         result.map_err(|e| {
             error!(signer_id = %id, error = %e, "failed to update signer");
-            RepositoryError::Other(format!("Failed to update signer: {}", e))
+            RepositoryError::Other(format!("Failed to update signer: {e}"))
         })?;
 
         debug!(signer_id = %id, "updated signer");
@@ -310,8 +305,7 @@ impl Repository<SignerRepoModel, String> for RedisSignerRepository {
         match exists {
             Ok(false) => {
                 return Err(RepositoryError::NotFound(format!(
-                    "Signer with ID {} not found",
-                    id
+                    "Signer with ID {id} not found"
                 )));
             }
             Ok(true) => {
@@ -320,8 +314,7 @@ impl Repository<SignerRepoModel, String> for RedisSignerRepository {
             Err(e) => {
                 error!(error = %e, "failed to check if signer exists");
                 return Err(RepositoryError::Other(format!(
-                    "Failed to check signer existence: {}",
-                    e
+                    "Failed to check signer existence: {e}"
                 )));
             }
         }
@@ -330,7 +323,7 @@ impl Repository<SignerRepoModel, String> for RedisSignerRepository {
         let result: Result<i64, RedisError> = conn.del(&key).await;
         result.map_err(|e| {
             error!(signer_id = %id, error = %e, "failed to delete signer");
-            RepositoryError::Other(format!("Failed to delete signer: {}", e))
+            RepositoryError::Other(format!("Failed to delete signer: {e}"))
         })?;
 
         // Remove from list

--- a/src/repositories/transaction/transaction_in_memory.rs
+++ b/src/repositories/transaction/transaction_in_memory.rs
@@ -69,9 +69,10 @@ impl Repository<TransactionRepoModel, String> for InMemoryTransactionRepository 
 
     async fn get_by_id(&self, id: String) -> Result<TransactionRepoModel, RepositoryError> {
         let store = Self::acquire_lock(&self.store).await?;
-        store.get(&id).cloned().ok_or_else(|| {
-            RepositoryError::NotFound(format!("Transaction with ID {} not found", id))
-        })
+        store
+            .get(&id)
+            .cloned()
+            .ok_or_else(|| RepositoryError::NotFound(format!("Transaction with ID {id} not found")))
     }
 
     #[allow(clippy::map_entry)]
@@ -88,8 +89,7 @@ impl Repository<TransactionRepoModel, String> for InMemoryTransactionRepository 
             Ok(updated_tx)
         } else {
             Err(RepositoryError::NotFound(format!(
-                "Transaction with ID {} not found",
-                id
+                "Transaction with ID {id} not found"
             )))
         }
     }
@@ -100,8 +100,7 @@ impl Repository<TransactionRepoModel, String> for InMemoryTransactionRepository 
             Ok(())
         } else {
             Err(RepositoryError::NotFound(format!(
-                "Transaction with ID {} not found",
-                id
+                "Transaction with ID {id} not found"
             )))
         }
     }
@@ -260,8 +259,7 @@ impl TransactionRepository for InMemoryTransactionRepository {
             Ok(tx.clone())
         } else {
             Err(RepositoryError::NotFound(format!(
-                "Transaction with ID {} not found",
-                tx_id
+                "Transaction with ID {tx_id} not found"
             )))
         }
     }

--- a/src/repositories/transaction/transaction_redis.rs
+++ b/src/repositories/transaction/transaction_redis.rs
@@ -359,8 +359,7 @@ impl Repository<TransactionRepoModel, String> for RedisTransactionRepository {
             None => {
                 debug!(tx_id = %id, "transaction not found (no reverse lookup)");
                 return Err(RepositoryError::NotFound(format!(
-                    "Transaction with ID {} not found",
-                    id
+                    "Transaction with ID {id} not found"
                 )));
             }
         };
@@ -381,8 +380,7 @@ impl Repository<TransactionRepoModel, String> for RedisTransactionRepository {
             None => {
                 debug!(tx_id = %id, "transaction not found");
                 Err(RepositoryError::NotFound(format!(
-                    "Transaction with ID {} not found",
-                    id
+                    "Transaction with ID {id} not found"
                 )))
             }
         }

--- a/src/repositories/transaction_counter/transaction_counter_in_memory.rs
+++ b/src/repositories/transaction_counter/transaction_counter_in_memory.rs
@@ -49,9 +49,7 @@ impl TransactionCounterTrait for InMemoryTransactionCounter {
         let mut entry = self
             .store
             .get_mut(&(relayer_id.to_string(), address.to_string()))
-            .ok_or_else(|| {
-                RepositoryError::NotFound(format!("Counter not found for {}", address))
-            })?;
+            .ok_or_else(|| RepositoryError::NotFound(format!("Counter not found for {address}")))?;
         if *entry > 0 {
             *entry -= 1;
         }

--- a/src/repositories/transaction_counter/transaction_counter_redis.rs
+++ b/src/repositories/transaction_counter/transaction_counter_redis.rs
@@ -148,8 +148,7 @@ impl TransactionCounterTrait for RedisTransactionCounter {
 
         if !exists {
             return Err(RepositoryError::NotFound(format!(
-                "Counter not found for relayer {} and address {}",
-                relayer_id, address
+                "Counter not found for relayer {relayer_id} and address {address}"
             )));
         }
 

--- a/src/services/cdp/mod.rs
+++ b/src/services/cdp/mod.rs
@@ -93,13 +93,13 @@ impl CdpService {
             .source("openzeppelin-relayer".to_string())
             .source_version(env!("CARGO_PKG_VERSION").to_string())
             .build()
-            .map_err(|e| CdpError::ConfigError(format!("Invalid CDP configuration: {}", e)))?;
+            .map_err(|e| CdpError::ConfigError(format!("Invalid CDP configuration: {e}")))?;
 
         let inner = reqwest::Client::builder()
             .connect_timeout(Duration::from_secs(5))
             .timeout(Duration::from_secs(10))
             .build()
-            .map_err(|e| CdpError::ConfigError(format!("Failed to build HTTP client: {}", e)))?;
+            .map_err(|e| CdpError::ConfigError(format!("Failed to build HTTP client: {e}")))?;
         let wallet_client = ClientBuilder::new(inner).with(wallet_auth).build();
         let client = Client::new_with_client(CDP_BASE_URL, wallet_client);
         Ok(Self { config, client })
@@ -128,7 +128,7 @@ impl CdpService {
 
             // Decode hex string to bytes
             let bytes = hex::decode(hex_str)
-                .map_err(|e| CdpError::ConfigError(format!("Invalid hex address: {}", e)))?;
+                .map_err(|e| CdpError::ConfigError(format!("Invalid hex address: {e}")))?;
 
             if bytes.len() != 20 {
                 return Err(CdpError::ConfigError(format!(
@@ -173,7 +173,7 @@ impl CdpServiceTrait for CdpService {
             .body(message_body)
             .send()
             .await
-            .map_err(|e| CdpError::SigningError(format!("Failed to sign message: {}", e)))?;
+            .map_err(|e| CdpError::SigningError(format!("Failed to sign message: {e}")))?;
 
         let result = response.into_inner();
 
@@ -184,7 +184,7 @@ impl CdpServiceTrait for CdpService {
                 .strip_prefix("0x")
                 .unwrap_or(&result.signature),
         )
-        .map_err(|e| CdpError::SigningError(format!("Invalid signature hex: {}", e)))?;
+        .map_err(|e| CdpError::SigningError(format!("Invalid signature hex: {e}")))?;
 
         Ok(signature_bytes)
     }
@@ -201,7 +201,7 @@ impl CdpServiceTrait for CdpService {
         let hex_encoded = hex::encode(message);
 
         let tx_body =
-            types::SignEvmTransactionBody::builder().transaction(format!("0x{}", hex_encoded));
+            types::SignEvmTransactionBody::builder().transaction(format!("0x{hex_encoded}"));
 
         let response = self
             .client
@@ -211,7 +211,7 @@ impl CdpServiceTrait for CdpService {
             .body(tx_body)
             .send()
             .await
-            .map_err(|e| CdpError::SigningError(format!("Failed to sign transaction: {}", e)))?;
+            .map_err(|e| CdpError::SigningError(format!("Failed to sign transaction: {e}")))?;
 
         let result = response.into_inner();
 
@@ -222,7 +222,7 @@ impl CdpServiceTrait for CdpService {
                 .strip_prefix("0x")
                 .unwrap_or(&result.signed_transaction),
         )
-        .map_err(|e| CdpError::SigningError(format!("Invalid signed transaction hex: {}", e)))?;
+        .map_err(|e| CdpError::SigningError(format!("Invalid signed transaction hex: {e}")))?;
 
         Ok(signed_tx_bytes)
     }
@@ -235,7 +235,7 @@ impl CdpServiceTrait for CdpService {
         }
         let address = self.get_account_address();
         let encoded_message = str::from_utf8(message)
-            .map_err(|e| CdpError::SerializationError(format!("Invalid UTF-8 message: {}", e)))?
+            .map_err(|e| CdpError::SerializationError(format!("Invalid UTF-8 message: {e}")))?
             .to_string();
 
         let message_body = types::SignSolanaMessageBody::builder().message(encoded_message);
@@ -248,14 +248,14 @@ impl CdpServiceTrait for CdpService {
             .body(message_body)
             .send()
             .await
-            .map_err(|e| CdpError::SigningError(format!("Failed to sign Solana message: {}", e)))?;
+            .map_err(|e| CdpError::SigningError(format!("Failed to sign Solana message: {e}")))?;
 
         let result = response.into_inner();
 
         // Parse the signature base58 string to bytes
-        let signature_bytes = bs58::decode(result.signature).into_vec().map_err(|e| {
-            CdpError::SigningError(format!("Invalid Solana signature base58: {}", e))
-        })?;
+        let signature_bytes = bs58::decode(result.signature)
+            .into_vec()
+            .map_err(|e| CdpError::SigningError(format!("Invalid Solana signature base58: {e}")))?;
 
         Ok(signature_bytes)
     }
@@ -278,7 +278,7 @@ impl CdpServiceTrait for CdpService {
             .body(message_body)
             .send()
             .await
-            .map_err(|e| CdpError::SigningError(format!("Failed to sign Solana transaction: {}", e)))?;
+            .map_err(|e| CdpError::SigningError(format!("Failed to sign Solana transaction: {e}")))?;
 
         let result = response.into_inner();
 
@@ -286,7 +286,7 @@ impl CdpServiceTrait for CdpService {
         let signature_bytes = general_purpose::STANDARD
             .decode(result.signed_transaction)
             .map_err(|e| {
-                CdpError::SigningError(format!("Invalid Solana signed transaction base64: {}", e))
+                CdpError::SigningError(format!("Invalid Solana signed transaction base64: {e}"))
             })?;
 
         Ok(signature_bytes)

--- a/src/services/gas/evm_gas_price.rs
+++ b/src/services/gas/evm_gas_price.rs
@@ -379,8 +379,7 @@ impl<P: EvmProviderTrait + Send + Sync + 'static> EvmGasPriceServiceTrait
                     .await
                     .map_err(|e| {
                         TransactionError::NetworkConfiguration(format!(
-                            "Failed to fetch fee history data: {}",
-                            e
+                            "Failed to fetch fee history data: {e}"
                         ))
                     })
             }

--- a/src/services/gas/handlers/polygon_zkevm.rs
+++ b/src/services/gas/handlers/polygon_zkevm.rs
@@ -22,12 +22,12 @@ fn build_zkevm_transaction_params(tx: &EvmTransactionData) -> serde_json::Value 
         "to": tx.to.clone(),
         "value": format!("0x{:x}", tx.value),
         "data": tx.data.as_ref().map(|d| {
-            if d.starts_with("0x") { d.clone() } else { format!("0x{}", d) }
+            if d.starts_with("0x") { d.clone() } else { format!("0x{d}") }
         }).unwrap_or("0x".to_string()),
-        "gas": tx.gas_limit.map(|g| format!("0x{:x}", g)),
-        "gasPrice": tx.gas_price.map(|gp| format!("0x{:x}", gp)),
-        "maxFeePerGas": tx.max_fee_per_gas.map(|mfpg| format!("0x{:x}", mfpg)),
-        "maxPriorityFeePerGas": tx.max_priority_fee_per_gas.map(|mpfpg| format!("0x{:x}", mpfpg)),
+        "gas": tx.gas_limit.map(|g| format!("0x{g:x}")),
+        "gasPrice": tx.gas_price.map(|gp| format!("0x{gp:x}")),
+        "maxFeePerGas": tx.max_fee_per_gas.map(|mfpg| format!("0x{mfpg:x}")),
+        "maxPriorityFeePerGas": tx.max_priority_fee_per_gas.map(|mpfpg| format!("0x{mpfpg:x}")),
     })
 }
 
@@ -67,7 +67,7 @@ impl<P: EvmProviderTrait> PolygonZKEvmPriceHandler<P> {
             .ok_or_else(|| ProviderError::Other("Invalid fee response".to_string()))?;
 
         let fee = U256::from_str_radix(fee_hex.trim_start_matches("0x"), 16)
-            .map_err(|e| ProviderError::Other(format!("Failed to parse fee: {}", e)))?;
+            .map_err(|e| ProviderError::Other(format!("Failed to parse fee: {e}")))?;
 
         Ok(fee)
     }
@@ -92,8 +92,7 @@ impl<P: EvmProviderTrait> PolygonZKEvmPriceHandler<P> {
             Ok(fee_estimate) => fee_estimate,
             Err(e) => {
                 return Err(TransactionError::UnexpectedError(format!(
-                    "Failed to estimate zkEVM fee: {}",
-                    e
+                    "Failed to estimate zkEVM fee: {e}"
                 )))
             }
         };

--- a/src/services/google_cloud_kms/mod.rs
+++ b/src/services/google_cloud_kms/mod.rs
@@ -224,13 +224,12 @@ impl GoogleCloudKmsService {
 
         if !status.is_success() {
             return Err(GoogleCloudKmsError::ApiError(format!(
-                "KMS request failed ({}): {}",
-                status, text
+                "KMS request failed ({status}): {text}"
             )));
         }
 
         serde_json::from_str(&text)
-            .map_err(|e| GoogleCloudKmsError::ParseError(format!("{}: {}", e, text)))
+            .map_err(|e| GoogleCloudKmsError::ParseError(format!("{e}: {text}")))
     }
 
     async fn kms_post(&self, url: &str, body: &Value) -> GoogleCloudKmsResult<Value> {
@@ -249,13 +248,12 @@ impl GoogleCloudKmsService {
 
         if !status.is_success() {
             return Err(GoogleCloudKmsError::ApiError(format!(
-                "KMS request failed ({}): {}",
-                status, text
+                "KMS request failed ({status}): {text}"
             )));
         }
 
         serde_json::from_str(&text)
-            .map_err(|e| GoogleCloudKmsError::ParseError(format!("{}: {}", e, text)))
+            .map_err(|e| GoogleCloudKmsError::ParseError(format!("{e}: {text}")))
     }
 
     fn get_key_path(&self) -> String {
@@ -273,7 +271,7 @@ impl GoogleCloudKmsService {
     async fn get_pem(&self) -> GoogleCloudKmsResult<String> {
         let base_url = self.get_base_url();
         let key_path = self.get_key_path();
-        let url = format!("{}/v1/{}/publicKey", base_url, key_path,);
+        let url = format!("{base_url}/v1/{key_path}/publicKey",);
         debug!(url = %url, "kms public key url");
 
         let body = self.kms_get(&url).await?;
@@ -354,7 +352,7 @@ impl GoogleCloudKmsK256 for GoogleCloudKmsService {
     async fn sign_digest(&self, digest: [u8; 32]) -> GoogleCloudKmsResult<Vec<u8>> {
         let base_url = self.get_base_url();
         let key_path = self.get_key_path();
-        let url = format!("{}/v1/{}:asymmetricSign", base_url, key_path);
+        let url = format!("{base_url}/v1/{key_path}:asymmetricSign");
 
         let digest_b64 = base64_encode(&digest);
 
@@ -402,7 +400,7 @@ impl GoogleCloudKmsServiceTrait for GoogleCloudKmsService {
         let base_url = self.get_base_url();
         let key_path = self.get_key_path();
 
-        let url = format!("{}/v1/{}:asymmetricSign", base_url, key_path,);
+        let url = format!("{base_url}/v1/{key_path}:asymmetricSign",);
 
         let body = serde_json::json!({
             "name": key_path,
@@ -424,7 +422,7 @@ impl GoogleCloudKmsServiceTrait for GoogleCloudKmsService {
     async fn sign_evm(&self, message: &[u8]) -> GoogleCloudKmsResult<Vec<u8>> {
         let base_url = self.get_base_url();
         let key_path = self.get_key_path();
-        let url = format!("{}/v1/{}:asymmetricSign", base_url, key_path,);
+        let url = format!("{base_url}/v1/{key_path}:asymmetricSign",);
 
         let hash = Sha256::digest(message);
         let digest = base64_encode(&hash);
@@ -463,7 +461,7 @@ impl GoogleCloudKmsServiceTrait for GoogleCloudKmsService {
         let base_url = self.get_base_url();
         let key_path = self.get_key_path();
 
-        let url = format!("{}/v1/{}:asymmetricSign", base_url, key_path);
+        let url = format!("{base_url}/v1/{key_path}:asymmetricSign",);
         debug!(url = %url, "kms asymmetric sign url for stellar");
 
         // For Ed25519, we can sign the message directly without pre-hashing

--- a/src/services/plugins/socket.rs
+++ b/src/services/plugins/socket.rs
@@ -197,7 +197,7 @@ impl SocketService {
 
         while let Ok(Some(line)) = reader.next_line().await {
             let trace: serde_json::Value = serde_json::from_str(&line)
-                .map_err(|e| PluginError::PluginError(format!("Failed to parse trace: {}", e)))?;
+                .map_err(|e| PluginError::PluginError(format!("Failed to parse trace: {e}")))?;
             traces.push(trace);
 
             let request: Request =

--- a/src/services/provider/mod.rs
+++ b/src/services/provider/mod.rs
@@ -60,13 +60,13 @@ impl From<hex::FromHexError> for ProviderError {
 
 impl From<std::net::AddrParseError> for ProviderError {
     fn from(err: std::net::AddrParseError) -> Self {
-        ProviderError::NetworkConfiguration(format!("Invalid network address: {}", err))
+        ProviderError::NetworkConfiguration(format!("Invalid network address: {err}"))
     }
 }
 
 impl From<ParseIntError> for ProviderError {
     fn from(err: ParseIntError) -> Self {
-        ProviderError::Other(format!("Number parsing error: {}", err))
+        ProviderError::Other(format!("Number parsing error: {err}"))
     }
 }
 
@@ -159,7 +159,7 @@ where
                 code: json_rpc_err.code,
                 message: json_rpc_err.message.to_string(),
             },
-            _ => ProviderError::Other(format!("Other RPC error: {}", err)),
+            _ => ProviderError::Other(format!("Other RPC error: {err}")),
         }
     }
 }
@@ -167,7 +167,7 @@ where
 // Implement From for RpcSelectorError
 impl From<rpc_selector::RpcSelectorError> for ProviderError {
     fn from(err: rpc_selector::RpcSelectorError) -> Self {
-        ProviderError::NetworkConfiguration(format!("RPC selector error: {}", err))
+        ProviderError::NetworkConfiguration(format!("RPC selector error: {err}"))
     }
 }
 
@@ -378,7 +378,7 @@ pub fn is_retriable_error(error: &ProviderError) -> bool {
 
         // Any other errors: check message for network-related issues
         _ => {
-            let err_msg = format!("{}", error);
+            let err_msg = format!("{error}");
             let msg_lower = err_msg.to_lowercase();
             msg_lower.contains("timeout")
                 || msg_lower.contains("connection")

--- a/src/services/provider/retry.rs
+++ b/src/services/provider/retry.rs
@@ -127,16 +127,14 @@ impl RetryConfig {
         // Validate delay consistency: both zero or both non-zero
         if (base_delay_ms == 0) != (max_delay_ms == 0) {
             panic!(
-                "Delay values must be consistent: both zero (no delays) or both non-zero. Got base_delay_ms={}, max_delay_ms={}",
-                base_delay_ms, max_delay_ms
+                "Delay values must be consistent: both zero (no delays) or both non-zero. Got base_delay_ms={base_delay_ms}, max_delay_ms={max_delay_ms}"
             );
         }
 
         // Validate delay ordering when both are non-zero
         if base_delay_ms > 0 && max_delay_ms > 0 && max_delay_ms < base_delay_ms {
             panic!(
-                "max_delay_ms ({}) must be >= base_delay_ms ({}) when both are non-zero",
-                max_delay_ms, base_delay_ms
+                "max_delay_ms ({max_delay_ms}) must be >= base_delay_ms ({base_delay_ms}) when both are non-zero"
             );
         }
 
@@ -339,17 +337,10 @@ where
 
     let error_message = match &last_error {
         Some(e) => format!(
-            "RPC call '{}' failed after {} total attempts across {} providers: {}",
-            operation_name,
-            total_attempts,
-            failover_count,
-            e
+            "RPC call '{operation_name}' failed after {total_attempts} total attempts across {failover_count} providers: {e}"
         ),
         None => format!(
-            "RPC call '{}' failed after {} total attempts across {} providers with no error details",
-            operation_name,
-            total_attempts,
-            failover_count
+            "RPC call '{operation_name}' failed after {total_attempts} total attempts across {failover_count} providers with no error details"
         )
     };
 
@@ -371,7 +362,7 @@ where
     let provider_url = selector
         .get_client(|url| Ok::<_, eyre::Report>(url.to_string()))
         .map_err(|e| {
-            let err_msg = format!("Failed to get provider URL for {}: {}", operation_name, e);
+            let err_msg = format!("Failed to get provider URL for {operation_name}: {e}");
             tracing::warn!(operation_name = %operation_name, error = %e, "failed to get provider url");
             E::from(err_msg)
         })?;

--- a/src/services/provider/solana/mod.rs
+++ b/src/services/provider/solana/mod.rs
@@ -182,7 +182,7 @@ impl SolanaProviderError {
 
             // RPC errors - classify based on error code and message
             ClientErrorKind::RpcError(rpc_err) => {
-                let rpc_err_str = format!("{}", rpc_err);
+                let rpc_err_str = format!("{rpc_err}");
                 Self::from_rpc_response_error(&rpc_err_str, &error)
             }
 
@@ -522,11 +522,11 @@ impl SolanaProvider {
         }
 
         RpcConfig::validate_list(&configs)
-            .map_err(|e| ProviderError::NetworkConfiguration(format!("Invalid URL: {}", e)))?;
+            .map_err(|e| ProviderError::NetworkConfiguration(format!("Invalid URL: {e}")))?;
 
         // Now create the selector with validated configs
         let selector = RpcSelector::new(configs).map_err(|e| {
-            ProviderError::NetworkConfiguration(format!("Failed to create RPC selector: {}", e))
+            ProviderError::NetworkConfiguration(format!("Failed to create RPC selector: {e}"))
         })?;
 
         let retry_config = RetryConfig::from_env();
@@ -562,7 +562,7 @@ impl SolanaProvider {
     /// Initialize a provider for a given URL
     fn initialize_provider(&self, url: &str) -> Result<Arc<RpcClient>, SolanaProviderError> {
         let rpc_url: Url = url.parse().map_err(|e| {
-            SolanaProviderError::NetworkConfiguration(format!("Invalid URL format: {}", e))
+            SolanaProviderError::NetworkConfiguration(format!("Invalid URL format: {e}"))
         })?;
 
         let client = RpcClient::new_with_timeout_and_commitment(
@@ -748,7 +748,7 @@ impl SolanaProviderTrait for SolanaProvider {
     /// Retrieves account data for the given account string.
     async fn get_account_from_str(&self, account: &str) -> Result<Account, SolanaProviderError> {
         let address = Pubkey::from_str(account).map_err(|e| {
-            SolanaProviderError::InvalidAddress(format!("Invalid pubkey {}: {}", account, e))
+            SolanaProviderError::InvalidAddress(format!("Invalid pubkey {account}: {e}"))
         })?;
         self.retry_rpc_call("get_account", |client| async move {
             client
@@ -780,7 +780,7 @@ impl SolanaProviderTrait for SolanaProvider {
     ) -> Result<TokenMetadata, SolanaProviderError> {
         // Parse and validate pubkey once
         let mint_pubkey = Pubkey::from_str(pubkey).map_err(|e| {
-            SolanaProviderError::InvalidAddress(format!("Invalid pubkey {}: {}", pubkey, e))
+            SolanaProviderError::InvalidAddress(format!("Invalid pubkey {pubkey}: {e}"))
         })?;
 
         // Retrieve account using already-parsed pubkey (avoids re-parsing)
@@ -790,8 +790,7 @@ impl SolanaProviderTrait for SolanaProvider {
         let decimals = Mint::unpack(&account.data)
             .map_err(|e| {
                 SolanaProviderError::InvalidTransaction(format!(
-                    "Failed to unpack mint info for {}: {}",
-                    pubkey, e
+                    "Failed to unpack mint info for {pubkey}: {e}"
                 ))
             })?
             .decimals;

--- a/src/services/provider/stellar/mod.rs
+++ b/src/services/provider/stellar/mod.rs
@@ -71,7 +71,7 @@ fn categorize_stellar_error_with_context(
 ) -> ProviderError {
     let add_context = |msg: String| -> String {
         match context {
-            Some(ctx) => format!("{}: {}", ctx, msg),
+            Some(ctx) => format!("{ctx}: {msg}"),
             None => msg,
         }
     };
@@ -81,38 +81,36 @@ fn categorize_stellar_error_with_context(
 
         // === Address/Encoding Errors (Non-retriable, Client-side) ===
         StellarClientError::InvalidAddress(decode_err) => ProviderError::InvalidAddress(
-            add_context(format!("Invalid Stellar address: {}", decode_err)),
+            add_context(format!("Invalid Stellar address: {decode_err}")),
         ),
 
         // === XDR/Serialization Errors (Non-retriable, Client-side) ===
         StellarClientError::Xdr(xdr_err) => {
-            ProviderError::Other(add_context(format!("XDR processing error: {}", xdr_err)))
+            ProviderError::Other(add_context(format!("XDR processing error: {xdr_err}")))
         }
 
         // === JSON Parsing Errors (Non-retriable, may indicate RPC response issue) ===
         StellarClientError::Serde(serde_err) => {
-            ProviderError::Other(add_context(format!("JSON parsing error: {}", serde_err)))
+            ProviderError::Other(add_context(format!("JSON parsing error: {serde_err}")))
         }
 
         // === URL Configuration Errors (Non-retriable, Configuration issue) ===
-        StellarClientError::InvalidRpcUrl(uri_err) => ProviderError::NetworkConfiguration(
-            add_context(format!("Invalid RPC URL: {}", uri_err)),
-        ),
+        StellarClientError::InvalidRpcUrl(uri_err) => {
+            ProviderError::NetworkConfiguration(add_context(format!("Invalid RPC URL: {uri_err}")))
+        }
         StellarClientError::InvalidRpcUrlFromUriParts(uri_err) => {
             ProviderError::NetworkConfiguration(add_context(format!(
-                "Invalid RPC URL parts: {}",
-                uri_err
+                "Invalid RPC URL parts: {uri_err}"
             )))
         }
         StellarClientError::InvalidUrl(url) => {
-            ProviderError::NetworkConfiguration(add_context(format!("Invalid URL: {}", url)))
+            ProviderError::NetworkConfiguration(add_context(format!("Invalid URL: {url}")))
         }
 
         // === Network Passphrase Mismatch (Non-retriable, Configuration issue) ===
         StellarClientError::InvalidNetworkPassphrase { expected, server } => {
             ProviderError::NetworkConfiguration(add_context(format!(
-                "Network passphrase mismatch: expected {:?}, server returned {:?}",
-                expected, server
+                "Network passphrase mismatch: expected {expected:?}, server returned {server:?}"
             )))
         }
 
@@ -141,12 +139,11 @@ fn categorize_stellar_error_with_context(
                     }
 
                     ProviderError::TransportError(add_context(format!(
-                        "Transport error: {}",
-                        transport_err
+                        "Transport error: {transport_err}"
                     )))
                 }
                 // Catch-all for other jsonrpsee errors
-                other => ProviderError::Other(add_context(format!("JSON-RPC error: {}", other))),
+                other => ProviderError::Other(add_context(format!("JSON-RPC error: {other}"))),
             }
         }
         // === Response Parsing/Validation Errors (May indicate RPC node issue) ===
@@ -165,21 +162,21 @@ fn categorize_stellar_error_with_context(
 
         // === Transaction Errors (Non-retriable, Transaction-specific issues) ===
         StellarClientError::TransactionFailed(msg) => {
-            ProviderError::Other(add_context(format!("Transaction failed: {}", msg)))
+            ProviderError::Other(add_context(format!("Transaction failed: {msg}")))
         }
-        StellarClientError::TransactionSubmissionFailed(msg) => ProviderError::Other(add_context(
-            format!("Transaction submission failed: {}", msg),
-        )),
-        StellarClientError::TransactionSimulationFailed(msg) => ProviderError::Other(add_context(
-            format!("Transaction simulation failed: {}", msg),
-        )),
+        StellarClientError::TransactionSubmissionFailed(msg) => {
+            ProviderError::Other(add_context(format!("Transaction submission failed: {msg}")))
+        }
+        StellarClientError::TransactionSimulationFailed(msg) => {
+            ProviderError::Other(add_context(format!("Transaction simulation failed: {msg}")))
+        }
         StellarClientError::UnexpectedTransactionStatus(status) => ProviderError::Other(
-            add_context(format!("Unexpected transaction status: {}", status)),
+            add_context(format!("Unexpected transaction status: {status}")),
         ),
 
         // === Resource Not Found Errors (Non-retriable) ===
         StellarClientError::NotFound(resource, id) => {
-            ProviderError::Other(add_context(format!("{} not found: {}", resource, id)))
+            ProviderError::Other(add_context(format!("{resource} not found: {id}")))
         }
 
         // === Client-side Validation Errors (Non-retriable) ===
@@ -188,24 +185,23 @@ fn categorize_stellar_error_with_context(
         }
         StellarClientError::UnexpectedSimulateTransactionResultSize { length } => {
             ProviderError::Other(add_context(format!(
-                "Unexpected simulate transaction result size: {}",
-                length
+                "Unexpected simulate transaction result size: {length}"
             )))
         }
-        StellarClientError::UnexpectedOperationCount { count } => ProviderError::Other(
-            add_context(format!("Unexpected operation count: {}", count)),
-        ),
+        StellarClientError::UnexpectedOperationCount { count } => {
+            ProviderError::Other(add_context(format!("Unexpected operation count: {count}")))
+        }
         StellarClientError::UnsupportedOperationType => {
             ProviderError::Other(add_context("Unsupported operation type".to_string()))
         }
         StellarClientError::UnexpectedContractCodeDataType(data) => ProviderError::Other(
-            add_context(format!("Unexpected contract code data type: {:?}", data)),
+            add_context(format!("Unexpected contract code data type: {data:?}")),
         ),
         StellarClientError::UnexpectedContractInstance(val) => ProviderError::Other(add_context(
-            format!("Unexpected contract instance: {:?}", val),
+            format!("Unexpected contract instance: {val:?}"),
         )),
         StellarClientError::LargeFee(fee) => {
-            ProviderError::Other(add_context(format!("Fee too large: {}", fee)))
+            ProviderError::Other(add_context(format!("Fee too large: {fee}")))
         }
         StellarClientError::CannotAuthorizeRawTransaction => {
             ProviderError::Other(add_context("Cannot authorize raw transaction".to_string()))
@@ -214,13 +210,13 @@ fn categorize_stellar_error_with_context(
             ProviderError::Other(add_context("Missing operation in transaction".to_string()))
         }
         StellarClientError::MissingSignerForAddress { address } => ProviderError::Other(
-            add_context(format!("Missing signer for address: {}", address)),
+            add_context(format!("Missing signer for address: {address}")),
         ),
 
         // === Deprecated/Other Errors ===
         #[allow(deprecated)]
         StellarClientError::UnexpectedToken(entry) => {
-            ProviderError::Other(add_context(format!("Unexpected token: {:?}", entry)))
+            ProviderError::Other(add_context(format!("Unexpected token: {entry:?}")))
         }
     }
 }
@@ -246,7 +242,7 @@ fn normalize_url_for_log(url: &str) -> String {
         if let Some(at_pos) = s[start..].find('@') {
             let after = &s[start + at_pos + 1..];
             let prefix = &s[..start];
-            s = format!("{}<redacted>@{}", prefix, after);
+            s = format!("{prefix}<redacted>@{after}");
         }
     }
 
@@ -335,7 +331,7 @@ impl StellarProvider {
         }
 
         let selector = RpcSelector::new(rpc_configs).map_err(|e| {
-            ProviderError::NetworkConfiguration(format!("Failed to create RPC selector: {}", e))
+            ProviderError::NetworkConfiguration(format!("Failed to create RPC selector: {e}"))
         })?;
 
         let retry_config = RetryConfig::from_env();
@@ -351,8 +347,7 @@ impl StellarProvider {
     fn initialize_provider(&self, url: &str) -> Result<Client, ProviderError> {
         Client::new(url).map_err(|e| {
             ProviderError::NetworkConfiguration(format!(
-                "Failed to create Stellar RPC client: {} - URL: '{}'",
-                e, url
+                "Failed to create Stellar RPC client: {e} - URL: '{url}'"
             ))
         })
     }
@@ -366,8 +361,7 @@ impl StellarProvider {
             .build()
             .map_err(|e| {
                 ProviderError::NetworkConfiguration(format!(
-                    "Failed to create HTTP client for raw RPC: {} - URL: '{}'",
-                    e, url
+                    "Failed to create HTTP client for raw RPC: {e} - URL: '{url}'"
                 ))
             })
     }
@@ -386,8 +380,7 @@ impl StellarProvider {
             Ok(url) => url,
             Err(e) => {
                 return Err(ProviderError::NetworkConfiguration(format!(
-                    "No RPC URL available for StellarProvider: {}",
-                    e
+                    "No RPC URL available for StellarProvider: {e}"
                 )));
             }
         };
@@ -422,8 +415,7 @@ impl StellarProvider {
             Ok(url) => url,
             Err(e) => {
                 return Err(ProviderError::NetworkConfiguration(format!(
-                    "No RPC URL available for StellarProvider: {}",
-                    e
+                    "No RPC URL available for StellarProvider: {e}"
                 )));
             }
         };
@@ -654,7 +646,7 @@ impl StellarProviderTrait for StellarProvider {
     ) -> Result<serde_json::Value, ProviderError> {
         let id_value = match id {
             Some(id) => serde_json::to_value(id)
-                .map_err(|e| ProviderError::Other(format!("Failed to serialize id: {}", e)))?,
+                .map_err(|e| ProviderError::Other(format!("Failed to serialize id: {e}")))?,
             None => serde_json::json!(generate_unique_rpc_id()),
         };
 
@@ -679,7 +671,7 @@ impl StellarProviderTrait for StellarProvider {
                         .to_string(),
                 });
             }
-            return Err(ProviderError::Other(format!("JSON-RPC error: {}", error)));
+            return Err(ProviderError::Other(format!("JSON-RPC error: {error}")));
         }
 
         // Extract result

--- a/src/services/signer/evm/cdp_signer.rs
+++ b/src/services/signer/evm/cdp_signer.rs
@@ -50,7 +50,7 @@ where
 impl CdpSigner<DefaultCdpService> {
     pub fn new(config: CdpSignerConfig) -> Result<Self, SignerError> {
         let cdp_service = DefaultCdpService::new(config).map_err(|e| {
-            SignerError::Configuration(format!("Failed to create CDP service: {}", e))
+            SignerError::Configuration(format!("Failed to create CDP service: {e}"))
         })?;
         Ok(Self { cdp_service })
     }
@@ -106,8 +106,7 @@ impl<T: CdpServiceTrait> Signer for CdpSigner<T> {
                 alloy::consensus::Signed::<TxEip1559>::eip2718_decode(&mut signed_bytes_slice)
                     .map_err(|e| {
                         SignerError::SigningError(format!(
-                            "Failed to decode signed transaction: {}",
-                            e
+                            "Failed to decode signed transaction: {e}"
                         ))
                     })?;
 
@@ -127,8 +126,7 @@ impl<T: CdpServiceTrait> Signer for CdpSigner<T> {
                 alloy::consensus::Signed::<TxLegacy>::eip2718_decode(&mut signed_bytes_slice)
                     .map_err(|e| {
                         SignerError::SigningError(format!(
-                            "Failed to decode signed transaction: {}",
-                            e
+                            "Failed to decode signed transaction: {e}"
                         ))
                     })?;
 
@@ -166,7 +164,7 @@ impl<T: CdpServiceTrait> DataSignerTrait for CdpSigner<T> {
 
         let v_byte = signature_bytes[64];
         let original_parity = normalize_v(v_byte as u64)
-            .ok_or_else(|| SignerError::SigningError(format!("Invalid v value: {}", v_byte)))?;
+            .ok_or_else(|| SignerError::SigningError(format!("Invalid v value: {v_byte}")))?;
 
         let normalized_sig = if let Some(normalized) = sig.normalize_s() {
             normalized.with_parity(!original_parity)

--- a/src/services/signer/evm/local_signer.rs
+++ b/src/services/signer/evm/local_signer.rs
@@ -60,7 +60,7 @@ impl LocalSigner {
             let key_bytes = config.raw_key.borrow();
 
             AlloyLocalSignerClient::from_bytes(&FixedBytes::from_slice(&key_bytes)).map_err(
-                |e| SignerError::Configuration(format!("Failed to create local signer: {}", e)),
+                |e| SignerError::Configuration(format!("Failed to create local signer: {e}")),
             )?
         };
 
@@ -152,7 +152,7 @@ impl DataSignerTrait for LocalSigner {
             .local_signer_client
             .sign_message(message)
             .await
-            .map_err(|e| SignerError::SigningError(format!("Failed to sign message: {}", e)))?;
+            .map_err(|e| SignerError::SigningError(format!("Failed to sign message: {e}")))?;
 
         validate_and_format_signature(&signature.as_bytes(), "Local")
     }
@@ -167,7 +167,7 @@ impl DataSignerTrait for LocalSigner {
             .sign_hash(&message_hash.into())
             .await
             .map_err(|e| {
-                SignerError::SigningError(format!("Failed to sign EIP-712 message: {}", e))
+                SignerError::SigningError(format!("Failed to sign EIP-712 message: {e}"))
             })?;
 
         validate_and_format_signature(&signature.as_bytes(), "Local")

--- a/src/services/signer/evm/mod.rs
+++ b/src/services/signer/evm/mod.rs
@@ -370,7 +370,7 @@ impl EvmSignerFactory {
             }
             SignerConfig::AwsKms(config) => {
                 let aws_service = AwsKmsService::new(config.clone()).await.map_err(|e| {
-                    SignerFactoryError::CreationFailed(format!("AWS KMS service error: {}", e))
+                    SignerFactoryError::CreationFailed(format!("AWS KMS service error: {e}"))
                 })?;
                 EvmSigner::AwsKms(AwsKmsSigner::new(aws_service))
             }
@@ -379,21 +379,20 @@ impl EvmSignerFactory {
             }
             SignerConfig::Turnkey(config) => {
                 let turnkey_service = TurnkeyService::new(config.clone()).map_err(|e| {
-                    SignerFactoryError::CreationFailed(format!("Turnkey service error: {}", e))
+                    SignerFactoryError::CreationFailed(format!("Turnkey service error: {e}"))
                 })?;
                 EvmSigner::Turnkey(TurnkeySigner::new(turnkey_service))
             }
             SignerConfig::Cdp(config) => {
                 let cdp_signer = CdpSigner::new(config.clone()).map_err(|e| {
-                    SignerFactoryError::CreationFailed(format!("CDP service error: {}", e))
+                    SignerFactoryError::CreationFailed(format!("CDP service error: {e}"))
                 })?;
                 EvmSigner::Cdp(cdp_signer)
             }
             SignerConfig::GoogleCloudKms(config) => {
                 let gcp_service = GoogleCloudKmsService::new(config).map_err(|e| {
                     SignerFactoryError::CreationFailed(format!(
-                        "Google Cloud KMS service error: {}",
-                        e
+                        "Google Cloud KMS service error: {e}"
                     ))
                 })?;
                 EvmSigner::GoogleCloudKms(GoogleCloudKmsSigner::new(gcp_service))

--- a/src/services/signer/evm/turnkey_signer.rs
+++ b/src/services/signer/evm/turnkey_signer.rs
@@ -102,8 +102,7 @@ impl<T: TurnkeyServiceTrait> Signer for TurnkeySigner<T> {
                 alloy::consensus::Signed::<TxEip1559>::eip2718_decode(&mut signed_bytes_slice)
                     .map_err(|e| {
                         SignerError::SigningError(format!(
-                            "Failed to decode signed transaction: {}",
-                            e
+                            "Failed to decode signed transaction: {e}"
                         ))
                     })?;
 
@@ -123,8 +122,7 @@ impl<T: TurnkeyServiceTrait> Signer for TurnkeySigner<T> {
                 alloy::consensus::Signed::<TxLegacy>::eip2718_decode(&mut signed_bytes_slice)
                     .map_err(|e| {
                         SignerError::SigningError(format!(
-                            "Failed to decode signed transaction: {}",
-                            e
+                            "Failed to decode signed transaction: {e}"
                         ))
                     })?;
 
@@ -159,7 +157,7 @@ impl<T: TurnkeyServiceTrait> DataSignerTrait for TurnkeySigner<T> {
 
         let v_byte = signature_bytes[64];
         let original_parity = normalize_v(v_byte as u64)
-            .ok_or_else(|| SignerError::SigningError(format!("Invalid v value: {}", v_byte)))?;
+            .ok_or_else(|| SignerError::SigningError(format!("Invalid v value: {v_byte}")))?;
 
         let normalized_sig = if let Some(normalized) = sig.normalize_s() {
             normalized.with_parity(!original_parity)
@@ -191,7 +189,7 @@ impl<T: TurnkeyServiceTrait> DataSignerTrait for TurnkeySigner<T> {
 
         let v_byte = signature_bytes[64];
         let original_parity = normalize_v(v_byte as u64)
-            .ok_or_else(|| SignerError::SigningError(format!("Invalid v value: {}", v_byte)))?;
+            .ok_or_else(|| SignerError::SigningError(format!("Invalid v value: {v_byte}")))?;
 
         let normalized_sig = if let Some(normalized) = sig.normalize_s() {
             normalized.with_parity(!original_parity)

--- a/src/services/signer/evm/vault_signer.rs
+++ b/src/services/signer/evm/vault_signer.rs
@@ -164,7 +164,7 @@ impl<T: VaultServiceTrait + Clone> VaultSigner<T> {
         }
 
         let decoded_bytes = hex::decode(hex_str)
-            .map_err(|e| SignerError::KeyError(format!("Failed to decode hex: {}", e)))?;
+            .map_err(|e| SignerError::KeyError(format!("Failed to decode hex: {e}")))?;
 
         Ok(SecretVec::new(decoded_bytes.len(), |buffer| {
             buffer.copy_from_slice(&decoded_bytes);

--- a/src/services/signer/solana/cdp_signer.rs
+++ b/src/services/signer/solana/cdp_signer.rs
@@ -43,7 +43,7 @@ where
 impl CdpSigner<DefaultCdpService> {
     pub fn new(config: CdpSignerConfig) -> Result<Self, SignerError> {
         let cdp_service = DefaultCdpService::new(config).map_err(|e| {
-            SignerError::Configuration(format!("Failed to create CDP service: {}", e))
+            SignerError::Configuration(format!("Failed to create CDP service: {e}"))
         })?;
 
         Ok(Self { cdp_service })
@@ -80,7 +80,7 @@ impl<T: CdpServiceTrait> SolanaSignTrait for CdpSigner<T> {
         // Deserialize the message from bincode
         let solana_message: solana_sdk::message::Message =
             bincode::deserialize(message).map_err(|e| {
-                SignerError::SigningError(format!("Failed to deserialize message: {}", e))
+                SignerError::SigningError(format!("Failed to deserialize message: {e}"))
             })?;
 
         // Create an unsigned transaction from the message
@@ -88,9 +88,7 @@ impl<T: CdpServiceTrait> SolanaSignTrait for CdpSigner<T> {
 
         // Convert to EncodedSerializedTransaction (base64)
         let encoded_tx = crate::models::EncodedSerializedTransaction::try_from(&transaction)
-            .map_err(|e| {
-                SignerError::SigningError(format!("Failed to encode transaction: {}", e))
-            })?;
+            .map_err(|e| SignerError::SigningError(format!("Failed to encode transaction: {e}")))?;
 
         // Use the CDP transaction signing API instead of message signing
         let signed_tx_bytes = self
@@ -105,7 +103,7 @@ impl<T: CdpServiceTrait> SolanaSignTrait for CdpSigner<T> {
 
         let signed_tx_data = crate::models::EncodedSerializedTransaction::new(signed_tx_encoded);
         let signed_transaction: Transaction = signed_tx_data.try_into().map_err(|e| {
-            SignerError::SigningError(format!("Failed to decode signed transaction: {}", e))
+            SignerError::SigningError(format!("Failed to decode signed transaction: {e}"))
         })?;
 
         // Get the CDP signer's address to find the correct signature index
@@ -117,7 +115,7 @@ impl<T: CdpServiceTrait> SolanaSignTrait for CdpSigner<T> {
 
         let cdp_pubkey = match cdp_address {
             crate::models::Address::Solana(addr) => Pubkey::from_str(&addr)
-                .map_err(|e| SignerError::SigningError(format!("Invalid CDP pubkey: {}", e)))?,
+                .map_err(|e| SignerError::SigningError(format!("Invalid CDP pubkey: {e}")))?,
             _ => {
                 return Err(SignerError::SigningError(
                     "CDP address is not a Solana address".to_string(),

--- a/src/services/signer/solana/google_cloud_kms_signer.rs
+++ b/src/services/signer/solana/google_cloud_kms_signer.rs
@@ -88,7 +88,7 @@ impl<T: GoogleCloudKmsServiceTrait> SolanaSignTrait for GoogleCloudKmsSigner<T> 
             .map_err(|e| SignerError::SigningError(e.to_string()))?;
 
         Ok(Signature::try_from(sig_bytes.as_slice()).map_err(|e| {
-            SignerError::SigningError(format!("Failed to create signature from bytes: {}", e))
+            SignerError::SigningError(format!("Failed to create signature from bytes: {e}"))
         })?)
     }
 }

--- a/src/services/signer/solana/local_signer.rs
+++ b/src/services/signer/solana/local_signer.rs
@@ -48,7 +48,7 @@ impl LocalSigner {
             let key_bytes = config.raw_key.borrow();
 
             Keypair::from_seed(&key_bytes).map_err(|e| {
-                SignerError::Configuration(format!("Failed to create local signer: {}", e))
+                SignerError::Configuration(format!("Failed to create local signer: {e}"))
             })?
         };
 

--- a/src/services/signer/solana/mod.rs
+++ b/src/services/signer/solana/mod.rs
@@ -81,7 +81,7 @@ impl Signer for SolanaSigner {
     ) -> Result<SignTransactionResponse, SignerError> {
         // Extract Solana transaction data
         let solana_data = transaction.get_solana_transaction_data().map_err(|e| {
-            SignerError::SigningError(format!("Invalid transaction type for Solana signer: {}", e))
+            SignerError::SigningError(format!("Invalid transaction type for Solana signer: {e}"))
         })?;
 
         // Get the pre-built transaction string
@@ -93,9 +93,8 @@ impl Signer for SolanaSigner {
 
         // Decode transaction from base64
         let encoded_tx = EncodedSerializedTransaction::new(transaction_str);
-        let sdk_transaction = SolanaTransaction::try_from(encoded_tx).map_err(|e| {
-            SignerError::SigningError(format!("Failed to decode transaction: {}", e))
-        })?;
+        let sdk_transaction = SolanaTransaction::try_from(encoded_tx)
+            .map_err(|e| SignerError::SigningError(format!("Failed to decode transaction: {e}")))?;
 
         // Sign using the SDK transaction signing helper function
         let (signed_tx, signature) = sign_sdk_transaction(self, sdk_transaction).await?;
@@ -103,7 +102,7 @@ impl Signer for SolanaSigner {
         // Encode back to base64
         let encoded_signed_tx =
             EncodedSerializedTransaction::try_from(&signed_tx).map_err(|e| {
-                SignerError::SigningError(format!("Failed to encode signed transaction: {}", e))
+                SignerError::SigningError(format!("Failed to encode signed transaction: {e}"))
             })?;
 
         // Return Solana-specific response
@@ -167,7 +166,7 @@ pub async fn sign_sdk_transaction<T: SolanaSignTrait + ?Sized>(
     // Get signer's public key
     let signer_address = signer.pubkey().await?;
     let signer_pubkey = Pubkey::from_str(&signer_address.to_string())
-        .map_err(|e| SignerError::KeyError(format!("Invalid signer address: {}", e)))?;
+        .map_err(|e| SignerError::KeyError(format!("Invalid signer address: {e}")))?;
 
     // Find the position of the signer's public key in account_keys
     let signer_index = transaction
@@ -278,7 +277,7 @@ impl SolanaSignerFactory {
             }
             SignerConfig::Cdp(config) => {
                 let cdp_signer = CdpSigner::new(config.clone()).map_err(|e| {
-                    SignerFactoryError::CreationFailed(format!("CDP service error: {}", e))
+                    SignerFactoryError::CreationFailed(format!("CDP service error: {e}"))
                 })?;
                 return Ok(SolanaSigner::Cdp(cdp_signer));
             }
@@ -286,8 +285,7 @@ impl SolanaSignerFactory {
                 let turnkey_service =
                     TurnkeyService::new(turnkey_signer_config.clone()).map_err(|e| {
                         SignerFactoryError::InvalidConfig(format!(
-                            "Failed to create Turnkey service: {}",
-                            e
+                            "Failed to create Turnkey service: {e}"
                         ))
                     })?;
 
@@ -297,8 +295,7 @@ impl SolanaSignerFactory {
                 let google_cloud_kms_service =
                     GoogleCloudKmsService::new(google_cloud_kms_signer_config).map_err(|e| {
                         SignerFactoryError::InvalidConfig(format!(
-                            "Failed to create Google Cloud KMS service: {}",
-                            e
+                            "Failed to create Google Cloud KMS service: {e}"
                         ))
                     })?;
                 return Ok(SolanaSigner::GoogleCloudKms(GoogleCloudKmsSigner::new(

--- a/src/services/signer/solana/turnkey_signer.rs
+++ b/src/services/signer/solana/turnkey_signer.rs
@@ -72,7 +72,7 @@ impl<T: TurnkeyServiceTrait> SolanaSignTrait for TurnkeySigner<T> {
         let sig_bytes = self.turnkey_service.sign_solana(message).await?;
 
         Ok(Signature::try_from(sig_bytes.as_slice()).map_err(|e| {
-            SignerError::SigningError(format!("Failed to create signature from bytes: {}", e))
+            SignerError::SigningError(format!("Failed to create signature from bytes: {e}"))
         })?)
     }
 }

--- a/src/services/signer/solana/vault_signer.rs
+++ b/src/services/signer/solana/vault_signer.rs
@@ -181,7 +181,7 @@ impl<T: VaultServiceTrait + Clone> VaultSigner<T> {
         }
 
         let decoded_bytes = hex::decode(hex_str)
-            .map_err(|e| SignerError::KeyError(format!("Failed to decode hex: {}", e)))?;
+            .map_err(|e| SignerError::KeyError(format!("Failed to decode hex: {e}")))?;
 
         Ok(SecretVec::new(decoded_bytes.len(), |buffer| {
             buffer.copy_from_slice(&decoded_bytes);

--- a/src/services/signer/solana/vault_transit_signer.rs
+++ b/src/services/signer/solana/vault_transit_signer.rs
@@ -107,10 +107,10 @@ impl<T: VaultServiceTrait> SolanaSignTrait for VaultTransitSigner<T> {
             .unwrap_or(&vault_signature_str);
 
         let sig_bytes = base64_decode(base64_sig)
-            .map_err(|e| SignerError::SigningError(format!("Failed to decode signature: {}", e)))?;
+            .map_err(|e| SignerError::SigningError(format!("Failed to decode signature: {e}")))?;
 
         Ok(Signature::try_from(sig_bytes.as_slice()).map_err(|e| {
-            SignerError::SigningError(format!("Failed to create signature from bytes: {}", e))
+            SignerError::SigningError(format!("Failed to create signature from bytes: {e}"))
         })?)
     }
 }

--- a/src/services/signer/stellar/google_cloud_kms_signer.rs
+++ b/src/services/signer/stellar/google_cloud_kms_signer.rs
@@ -70,7 +70,7 @@ impl<T: GoogleCloudKmsStellarService + GoogleCloudKmsServiceTrait> Signer
     ) -> Result<SignTransactionResponse, SignerError> {
         let stellar_data = tx
             .get_stellar_transaction_data()
-            .map_err(|e| SignerError::SigningError(format!("Failed to get tx data: {}", e)))?;
+            .map_err(|e| SignerError::SigningError(format!("Failed to get tx data: {e}")))?;
 
         let passphrase = &stellar_data.network_passphrase;
         let hash_bytes: [u8; 32] = Sha256::digest(passphrase.as_bytes()).into();
@@ -82,8 +82,7 @@ impl<T: GoogleCloudKmsStellarService + GoogleCloudKmsServiceTrait> Signer
                 // Build transaction from operations and sign
                 let transaction = Transaction::try_from(stellar_data).map_err(|e| {
                     SignerError::SigningError(format!(
-                        "Failed to build Stellar transaction from operations: {}",
-                        e
+                        "Failed to build Stellar transaction from operations: {e}"
                     ))
                 })?;
 
@@ -123,12 +122,12 @@ impl<T: GoogleCloudKmsStellarService + GoogleCloudKmsServiceTrait> GoogleCloudKm
 
         // Create the appropriate signature payload based on envelope type
         let payload = create_signature_payload(envelope, network_id)
-            .map_err(|e| SignerError::SigningError(format!("Failed to create payload: {}", e)))?;
+            .map_err(|e| SignerError::SigningError(format!("Failed to create payload: {e}")))?;
 
         // Serialize and hash the payload
-        let payload_bytes = payload.to_xdr(Limits::none()).map_err(|e| {
-            SignerError::SigningError(format!("Failed to serialize payload: {}", e))
-        })?;
+        let payload_bytes = payload
+            .to_xdr(Limits::none())
+            .map_err(|e| SignerError::SigningError(format!("Failed to serialize payload: {e}")))?;
 
         let hash = Sha256::digest(&payload_bytes);
 
@@ -139,7 +138,7 @@ impl<T: GoogleCloudKmsStellarService + GoogleCloudKmsServiceTrait> GoogleCloudKm
         )
         .await
         .map_err(|e| {
-            SignerError::SigningError(format!("Google Cloud KMS signing operation failed: {}", e))
+            SignerError::SigningError(format!("Google Cloud KMS signing operation failed: {e}"))
         })?;
 
         // Create decorated signature with improved error handling
@@ -158,9 +157,9 @@ impl<T: GoogleCloudKmsStellarService + GoogleCloudKmsServiceTrait> GoogleCloudKm
         let payload = create_transaction_signature_payload(transaction, network_id);
 
         // Serialize and hash the payload
-        let payload_bytes = payload.to_xdr(Limits::none()).map_err(|e| {
-            SignerError::SigningError(format!("Failed to serialize payload: {}", e))
-        })?;
+        let payload_bytes = payload
+            .to_xdr(Limits::none())
+            .map_err(|e| SignerError::SigningError(format!("Failed to serialize payload: {e}")))?;
 
         let hash = Sha256::digest(&payload_bytes);
 
@@ -171,7 +170,7 @@ impl<T: GoogleCloudKmsStellarService + GoogleCloudKmsServiceTrait> GoogleCloudKm
         )
         .await
         .map_err(|e| {
-            SignerError::SigningError(format!("Google Cloud KMS signing operation failed: {}", e))
+            SignerError::SigningError(format!("Google Cloud KMS signing operation failed: {e}"))
         })?;
 
         // Create decorated signature with improved error handling
@@ -218,8 +217,7 @@ impl<T: GoogleCloudKmsStellarService + GoogleCloudKmsServiceTrait> GoogleCloudKm
                 .await
                 .map_err(|e| {
                     SignerError::SigningError(format!(
-                        "Failed to retrieve Stellar address from Google Cloud KMS: {}",
-                        e
+                        "Failed to retrieve Stellar address from Google Cloud KMS: {e}"
                     ))
                 })?;
 
@@ -230,8 +228,7 @@ impl<T: GoogleCloudKmsStellarService + GoogleCloudKmsServiceTrait> GoogleCloudKm
                 use stellar_strkey::ed25519::PublicKey;
                 let pk = PublicKey::from_string(&addr).map_err(|e| {
                     SignerError::SigningError(format!(
-                        "Failed to parse Stellar address '{}': {}",
-                        addr, e
+                        "Failed to parse Stellar address '{addr}': {e}"
                     ))
                 })?;
                 let pk_bytes = pk.0;
@@ -253,8 +250,7 @@ impl<T: GoogleCloudKmsStellarService + GoogleCloudKmsServiceTrait> GoogleCloudKm
                 Ok(SignatureHint(hint_bytes))
             }
             _ => Err(SignerError::SigningError(format!(
-                "Expected Stellar address, got: {:?}",
-                stellar_address
+                "Expected Stellar address, got: {stellar_address:?}"
             ))),
         }
     }
@@ -273,7 +269,7 @@ impl<T: GoogleCloudKmsStellarService + GoogleCloudKmsServiceTrait> StellarSignTr
 
         // Parse the unsigned XDR
         let mut envelope = parse_transaction_xdr(unsigned_xdr, false)
-            .map_err(|e| SignerError::SigningError(format!("Invalid XDR: {}", e)))?;
+            .map_err(|e| SignerError::SigningError(format!("Invalid XDR: {e}")))?;
 
         // Create network ID from passphrase
         let hash_bytes: [u8; 32] = Sha256::digest(network_passphrase.as_bytes()).into();
@@ -284,11 +280,11 @@ impl<T: GoogleCloudKmsStellarService + GoogleCloudKmsServiceTrait> StellarSignTr
 
         // Attach the signature to the envelope
         attach_signatures_to_envelope(&mut envelope, vec![signature.clone()])
-            .map_err(|e| SignerError::SigningError(format!("Failed to attach signature: {}", e)))?;
+            .map_err(|e| SignerError::SigningError(format!("Failed to attach signature: {e}")))?;
 
         // Serialize the signed envelope
         let signed_xdr = envelope.to_xdr_base64(Limits::none()).map_err(|e| {
-            SignerError::SigningError(format!("Failed to serialize signed XDR: {}", e))
+            SignerError::SigningError(format!("Failed to serialize signed XDR: {e}"))
         })?;
 
         Ok(SignXdrTransactionResponseStellar {

--- a/src/services/signer/stellar/local_signer.rs
+++ b/src/services/signer/stellar/local_signer.rs
@@ -156,7 +156,7 @@ impl StellarSignTrait for LocalSigner {
     ) -> Result<SignXdrTransactionResponseStellar, SignerError> {
         // Parse the unsigned XDR
         let mut envelope = parse_transaction_xdr(unsigned_xdr, false)
-            .map_err(|e| SignerError::SigningError(format!("Invalid XDR: {}", e)))?;
+            .map_err(|e| SignerError::SigningError(format!("Invalid XDR: {e}")))?;
 
         // Create network ID from passphrase
         let hash_bytes: [u8; 32] = sha2::Sha256::digest(network_passphrase.as_bytes()).into();
@@ -167,11 +167,11 @@ impl StellarSignTrait for LocalSigner {
 
         // Attach the signature to the envelope
         attach_signatures_to_envelope(&mut envelope, vec![signature.clone()])
-            .map_err(|e| SignerError::SigningError(format!("Failed to attach signature: {}", e)))?;
+            .map_err(|e| SignerError::SigningError(format!("Failed to attach signature: {e}")))?;
 
         // Serialize the signed envelope
         let signed_xdr = envelope.to_xdr_base64(Limits::none()).map_err(|e| {
-            SignerError::SigningError(format!("Failed to serialize signed XDR: {}", e))
+            SignerError::SigningError(format!("Failed to serialize signed XDR: {e}"))
         })?;
 
         Ok(SignXdrTransactionResponseStellar {

--- a/src/services/signer/stellar/turnkey_signer.rs
+++ b/src/services/signer/stellar/turnkey_signer.rs
@@ -62,7 +62,7 @@ impl<T: TurnkeyServiceTrait> TurnkeySigner<T> {
         let signature_payload = create_transaction_signature_payload(transaction, network_id);
 
         let payload_bytes = signature_payload.to_xdr(Limits::none()).map_err(|e| {
-            SignerError::SigningError(format!("Failed to serialize signature payload: {}", e))
+            SignerError::SigningError(format!("Failed to serialize signature payload: {e}"))
         })?;
 
         debug!(
@@ -83,11 +83,11 @@ impl<T: TurnkeyServiceTrait> TurnkeySigner<T> {
         network_id: &Hash,
     ) -> Result<Vec<u8>, SignerError> {
         let signature_payload = create_signature_payload(envelope, network_id).map_err(|e| {
-            SignerError::SigningError(format!("Failed to create signature payload: {}", e))
+            SignerError::SigningError(format!("Failed to create signature payload: {e}"))
         })?;
 
         let payload_bytes = signature_payload.to_xdr(Limits::none()).map_err(|e| {
-            SignerError::SigningError(format!("Failed to serialize signature payload: {}", e))
+            SignerError::SigningError(format!("Failed to serialize signature payload: {e}"))
         })?;
 
         debug!(
@@ -110,10 +110,8 @@ impl<T: TurnkeyServiceTrait> TurnkeySigner<T> {
 
         match stellar_address {
             Address::Stellar(addr) => {
-                let public_key =
-                    stellar_strkey::ed25519::PublicKey::from_string(&addr).map_err(|e| {
-                        SignerError::KeyError(format!("Invalid Stellar address: {}", e))
-                    })?;
+                let public_key = stellar_strkey::ed25519::PublicKey::from_string(&addr)
+                    .map_err(|e| SignerError::KeyError(format!("Invalid Stellar address: {e}")))?;
 
                 let payload = public_key.0;
                 let mut key_bytes = [0u8; 32];
@@ -185,10 +183,10 @@ impl<T: TurnkeyServiceTrait> StellarSignTrait for TurnkeySigner<T> {
 
         let mut envelope = envelope;
         attach_signatures_to_envelope(&mut envelope, vec![decorated_signature.clone()])
-            .map_err(|e| SignerError::SigningError(format!("Failed to attach signature: {}", e)))?;
+            .map_err(|e| SignerError::SigningError(format!("Failed to attach signature: {e}")))?;
 
         let signed_xdr = envelope.to_xdr_base64(Limits::none()).map_err(|e| {
-            SignerError::SigningError(format!("Failed to serialize signed transaction: {}", e))
+            SignerError::SigningError(format!("Failed to serialize signed transaction: {e}"))
         })?;
 
         Ok(SignXdrTransactionResponseStellar {
@@ -211,7 +209,7 @@ impl<T: TurnkeyServiceTrait> Signer for TurnkeySigner<T> {
         transaction: NetworkTransactionData,
     ) -> Result<SignTransactionResponse, SignerError> {
         let stellar_data = transaction.get_stellar_transaction_data().map_err(|e| {
-            SignerError::SigningError(format!("Failed to get Stellar transaction data: {}", e))
+            SignerError::SigningError(format!("Failed to get Stellar transaction data: {e}"))
         })?;
 
         let network_passphrase = &stellar_data.network_passphrase;
@@ -228,8 +226,7 @@ impl<T: TurnkeyServiceTrait> Signer for TurnkeySigner<T> {
             TransactionInput::Operations(_) => {
                 let transaction = Transaction::try_from(stellar_data).map_err(|e| {
                     SignerError::SigningError(format!(
-                        "Failed to build Stellar transaction from operations: {}",
-                        e
+                        "Failed to build Stellar transaction from operations: {e}"
                     ))
                 })?;
                 self.sign_transaction_directly(&transaction, &network_id)

--- a/src/services/signer/stellar/vault_signer.rs
+++ b/src/services/signer/stellar/vault_signer.rs
@@ -183,7 +183,7 @@ impl<T: VaultServiceTrait + Clone> VaultSigner<T> {
         }
 
         let decoded_bytes = hex::decode(hex_str)
-            .map_err(|e| SignerError::KeyError(format!("Failed to decode hex: {}", e)))?;
+            .map_err(|e| SignerError::KeyError(format!("Failed to decode hex: {e}")))?;
 
         Ok(SecretVec::new(decoded_bytes.len(), |buffer| {
             buffer.copy_from_slice(&decoded_bytes);

--- a/src/services/turnkey/mod.rs
+++ b/src/services/turnkey/mod.rs
@@ -230,14 +230,14 @@ impl TurnkeyService {
         })
     }
 
-    /// Converts the public key to an Solana address
+    /// Converts the public key to a Solana address
     pub fn address_solana(&self) -> Result<Address, TurnkeyError> {
         if self.public_key.is_empty() {
             return Err(TurnkeyError::ConfigError("Public key is empty".to_string()));
         }
 
         let raw_pubkey = hex::decode(&self.public_key)
-            .map_err(|e| TurnkeyError::ConfigError(format!("Invalid public key hex: {}", e)))?;
+            .map_err(|e| TurnkeyError::ConfigError(format!("Invalid public key hex: {e}")))?;
 
         let pubkey_bs58 = bs58::encode(&raw_pubkey).into_string();
 
@@ -247,7 +247,7 @@ impl TurnkeyService {
     /// Converts the public key to an EVM address
     pub fn address_evm(&self) -> Result<Address, TurnkeyError> {
         let public_key = hex::decode(&self.public_key)
-            .map_err(|e| TurnkeyError::ConfigError(format!("Invalid public key hex: {}", e)))?;
+            .map_err(|e| TurnkeyError::ConfigError(format!("Invalid public key hex: {e}")))?;
 
         // Remove the first byte (0x04 prefix)
         let pub_key_no_prefix = &public_key[1..];
@@ -279,11 +279,11 @@ impl TurnkeyService {
 
         // For Stellar, we expect Ed25519 public key in hex format
         let raw_pubkey = hex::decode(&self.public_key)
-            .map_err(|e| TurnkeyError::ConfigError(format!("Invalid public key hex: {}", e)))?;
+            .map_err(|e| TurnkeyError::ConfigError(format!("Invalid public key hex: {e}")))?;
 
         // Stellar uses StrKey encoding with 'G' prefix for account addresses
         let stellar_address = stellar_strkey::ed25519::PublicKey::from_payload(&raw_pubkey)
-            .map_err(|e| TurnkeyError::ConfigError(format!("Invalid Ed25519 public key: {}", e)))?
+            .map_err(|e| TurnkeyError::ConfigError(format!("Invalid Ed25519 public key: {e}")))?
             .to_string();
 
         Ok(Address::Stellar(stellar_address))
@@ -291,17 +291,15 @@ impl TurnkeyService {
 
     /// Creates a digital stamp for API authentication
     fn stamp(&self, message: &str) -> TurnkeyResult<String> {
-        let private_api_key_bytes =
-            hex::decode(self.api_private_key.to_str().as_str()).map_err(|e| {
-                TurnkeyError::ConfigError(format!("Failed to decode private key: {}", e))
-            })?;
+        let private_api_key_bytes = hex::decode(self.api_private_key.to_str().as_str())
+            .map_err(|e| TurnkeyError::ConfigError(format!("Failed to decode private key: {e}")))?;
 
         let key_array: [u8; 32] = private_api_key_bytes
             .as_slice()
             .try_into()
             .map_err(|_| TurnkeyError::ConfigError("Invalid private key length".to_string()))?;
         let signing_key: SigningKey = SigningKey::from_bytes(&FieldBytes::from(key_array))
-            .map_err(|e| TurnkeyError::SigningError(format!("Turnkey stamp error: {}", e)))?;
+            .map_err(|e| TurnkeyError::SigningError(format!("Turnkey stamp error: {e}")))?;
 
         let signature: P256Signature = signing_key.sign(message.as_bytes());
 
@@ -312,7 +310,7 @@ impl TurnkeyService {
         };
 
         let json_stamp = serde_json::to_string(&stamp).map_err(|e| {
-            TurnkeyError::SerializationError(format!("Serialization stamp error: {}", e))
+            TurnkeyError::SerializationError(format!("Serialization stamp error: {e}"))
         })?;
         let encoded_stamp = base64_url_encode(json_stamp.as_bytes());
 
@@ -327,7 +325,7 @@ impl TurnkeyService {
     {
         // Serialize the request body
         let body = serde_json::to_string(request_body).map_err(|e| {
-            TurnkeyError::SerializationError(format!("Request serialization error: {}", e))
+            TurnkeyError::SerializationError(format!("Request serialization error: {e}"))
         })?;
 
         // Create the authentication stamp
@@ -380,7 +378,7 @@ impl TurnkeyService {
                 };
 
                 let signature_bytes = hex::decode(&concatenated_hex).map_err(|e| {
-                    TurnkeyError::SigningError(format!("Turnkey signing error {}", e))
+                    TurnkeyError::SigningError(format!("Turnkey signing error {e}"))
                 })?;
 
                 return Ok(signature_bytes);
@@ -444,9 +442,7 @@ impl TurnkeyService {
             .and_then(|result| result.sign_transaction_result)
             .map(|tx_result| hex::decode(&tx_result.signed_transaction))
             .transpose()
-            .map_err(|e| {
-                TurnkeyError::SigningError(format!("Failed to decode transaction: {}", e))
-            })?
+            .map_err(|e| TurnkeyError::SigningError(format!("Failed to decode transaction: {e}")))?
             .ok_or_else(|| TurnkeyError::OtherError("Missing transaction result".into()))
     }
 
@@ -483,23 +479,20 @@ impl TurnkeyService {
                                     Err(e) => {
                                         debug!(error = %e, "failed to parse error response as json");
                                         Err(TurnkeyError::HttpError(format!(
-                                            "HTTP {} error: {}",
-                                            status, body_text
+                                            "HTTP {status} error: {body_text}"
                                         )))
                                     }
                                 }
                             } else {
                                 Err(TurnkeyError::HttpError(format!(
-                                    "HTTP {} error: {}",
-                                    status, body_text
+                                    "HTTP {status} error: {body_text}"
                                 )))
                             }
                         }
                         Err(e) => {
                             info!(error = %e, "failed to read error response body");
                             Err(TurnkeyError::HttpError(format!(
-                                "HTTP {} error (failed to read body): {}",
-                                status, e
+                                "HTTP {status} error (failed to read body): {e}"
                             )))
                         }
                     }
@@ -522,7 +515,7 @@ impl TurnkeyServiceTrait for TurnkeyService {
         }
 
         let raw_pubkey = hex::decode(&self.public_key)
-            .map_err(|e| TurnkeyError::ConfigError(format!("Invalid public key hex: {}", e)))?;
+            .map_err(|e| TurnkeyError::ConfigError(format!("Invalid public key hex: {e}")))?;
 
         let pubkey_bs58 = bs58::encode(&raw_pubkey).into_string();
 
@@ -531,7 +524,7 @@ impl TurnkeyServiceTrait for TurnkeyService {
 
     fn address_evm(&self) -> Result<Address, TurnkeyError> {
         let public_key = hex::decode(&self.public_key)
-            .map_err(|e| TurnkeyError::ConfigError(format!("Invalid public key hex: {}", e)))?;
+            .map_err(|e| TurnkeyError::ConfigError(format!("Invalid public key hex: {e}")))?;
 
         // Remove the first byte (0x04 prefix)
         let pub_key_no_prefix = &public_key[1..];
@@ -585,12 +578,12 @@ impl TurnkeyServiceTrait for TurnkeyService {
         let serialized_message = transaction.message_data();
 
         let public_key = Pubkey::from_str(&self.address_solana()?.to_string())
-            .map_err(|e| TurnkeyError::ConfigError(format!("Invalid pubkey: {}", e)))?;
+            .map_err(|e| TurnkeyError::ConfigError(format!("Invalid pubkey: {e}")))?;
 
         let signature_bytes = self.sign_bytes_solana(&serialized_message).await?;
 
         let signature = Signature::try_from(signature_bytes.as_slice())
-            .map_err(|e| TurnkeyError::SignatureError(format!("Invalid signature: {}", e)))?;
+            .map_err(|e| TurnkeyError::SignatureError(format!("Invalid signature: {e}")))?;
 
         let index = transaction
             .message

--- a/src/services/vault/mod.rs
+++ b/src/services/vault/mod.rs
@@ -199,12 +199,11 @@ impl VaultService {
         }
 
         let auth_settings = auth_settings_builder.build().map_err(|e| {
-            VaultError::ConfigError(format!("Failed to build Vault client settings: {}", e))
+            VaultError::ConfigError(format!("Failed to build Vault client settings: {e}"))
         })?;
 
-        let client = VaultClient::new(auth_settings).map_err(|e| {
-            VaultError::ConfigError(format!("Failed to create Vault client: {}", e))
-        })?;
+        let client = VaultClient::new(auth_settings)
+            .map_err(|e| VaultError::ConfigError(format!("Failed to create Vault client: {e}")))?;
 
         let token = login(
             &client,
@@ -227,14 +226,11 @@ impl VaultService {
         }
 
         let transit_settings = transit_settings_builder.build().map_err(|e| {
-            VaultError::ConfigError(format!("Failed to build Vault client settings: {}", e))
+            VaultError::ConfigError(format!("Failed to build Vault client settings: {e}"))
         })?;
 
         let client = Arc::new(VaultClient::new(transit_settings).map_err(|e| {
-            VaultError::ConfigError(format!(
-                "Failed to create authenticated Vault client: {}",
-                e
-            ))
+            VaultError::ConfigError(format!("Failed to create authenticated Vault client: {e}"))
         })?);
 
         Ok(client)
@@ -253,7 +249,7 @@ impl VaultServiceTrait for VaultService {
         let value = secret["value"]
             .as_str()
             .ok_or_else(|| {
-                VaultError::SecretNotFound(format!("Secret value invalid for key: {}", key_name))
+                VaultError::SecretNotFound(format!("Secret value invalid for key: {key_name}"))
             })?
             .to_string();
 
@@ -271,7 +267,7 @@ impl VaultServiceTrait for VaultService {
             None,
         )
         .await
-        .map_err(|e| VaultError::SigningError(format!("Failed to sign with Vault: {}", e)))?;
+        .map_err(|e| VaultError::SigningError(format!("Failed to sign with Vault: {e}")))?;
 
         let vault_signature_str = &vault_signature.signature;
 

--- a/src/utils/encryption.rs
+++ b/src/utils/encryption.rs
@@ -124,10 +124,10 @@ impl FieldEncryption {
 
         // Decode nonce and ciphertext
         let nonce_bytes = base64_decode(&encrypted_data.nonce)
-            .map_err(|e| EncryptionError::InvalidFormat(format!("Invalid nonce: {}", e)))?;
+            .map_err(|e| EncryptionError::InvalidFormat(format!("Invalid nonce: {e}")))?;
 
         let ciphertext_bytes = base64_decode(&encrypted_data.ciphertext)
-            .map_err(|e| EncryptionError::InvalidFormat(format!("Invalid ciphertext: {}", e)))?;
+            .map_err(|e| EncryptionError::InvalidFormat(format!("Invalid ciphertext: {e}")))?;
 
         if nonce_bytes.len() != 12 {
             return Err(EncryptionError::InvalidFormat(format!(
@@ -154,9 +154,8 @@ impl FieldEncryption {
     /// Encrypts a string and returns base64-encoded encrypted data (opaque format)
     pub fn encrypt_string(&self, plaintext: &str) -> Result<String, EncryptionError> {
         let encrypted_data = self.encrypt(plaintext.as_bytes())?;
-        let json_data = serde_json::to_string(&encrypted_data).map_err(|e| {
-            EncryptionError::EncryptionFailed(format!("Serialization failed: {}", e))
-        })?;
+        let json_data = serde_json::to_string(&encrypted_data)
+            .map_err(|e| EncryptionError::EncryptionFailed(format!("Serialization failed: {e}")))?;
 
         // Base64 encode the entire JSON to make it opaque
         Ok(base64_encode(json_data.as_bytes()))
@@ -166,19 +165,18 @@ impl FieldEncryption {
     pub fn decrypt_string(&self, encrypted_base64: &str) -> Result<String, EncryptionError> {
         // Decode from base64 to get the JSON
         let json_bytes = base64_decode(encrypted_base64)
-            .map_err(|e| EncryptionError::InvalidFormat(format!("Invalid base64: {}", e)))?;
+            .map_err(|e| EncryptionError::InvalidFormat(format!("Invalid base64: {e}")))?;
 
         let encrypted_json = String::from_utf8(json_bytes).map_err(|e| {
-            EncryptionError::InvalidFormat(format!("Invalid UTF-8 in decoded data: {}", e))
+            EncryptionError::InvalidFormat(format!("Invalid UTF-8 in decoded data: {e}"))
         })?;
 
-        let encrypted_data: EncryptedData = serde_json::from_str(&encrypted_json).map_err(|e| {
-            EncryptionError::InvalidFormat(format!("Invalid JSON structure: {}", e))
-        })?;
+        let encrypted_data: EncryptedData = serde_json::from_str(&encrypted_json)
+            .map_err(|e| EncryptionError::InvalidFormat(format!("Invalid JSON structure: {e}")))?;
 
         let plaintext_bytes = self.decrypt(&encrypted_data)?;
         String::from_utf8(plaintext_bytes).map_err(|e| {
-            EncryptionError::DecryptionFailed(format!("Invalid UTF-8 in plaintext: {}", e))
+            EncryptionError::DecryptionFailed(format!("Invalid UTF-8 in plaintext: {e}"))
         })
     }
 
@@ -222,9 +220,8 @@ pub fn encrypt_sensitive_field(data: &str) -> Result<String, EncryptionError> {
     } else {
         // For development/testing when encryption is not configured,
         // base64-encode the JSON string for consistency
-        let json_data = serde_json::to_string(data).map_err(|e| {
-            EncryptionError::EncryptionFailed(format!("JSON encoding failed: {}", e))
-        })?;
+        let json_data = serde_json::to_string(data)
+            .map_err(|e| EncryptionError::EncryptionFailed(format!("JSON encoding failed: {e}")))?;
         Ok(base64_encode(json_data.as_bytes()))
     }
 }
@@ -233,10 +230,10 @@ pub fn encrypt_sensitive_field(data: &str) -> Result<String, EncryptionError> {
 pub fn decrypt_sensitive_field(data: &str) -> Result<String, EncryptionError> {
     // Always try to decode base64 first
     let json_bytes = base64_decode(data)
-        .map_err(|e| EncryptionError::InvalidFormat(format!("Invalid base64: {}", e)))?;
+        .map_err(|e| EncryptionError::InvalidFormat(format!("Invalid base64: {e}")))?;
 
     let json_str = String::from_utf8(json_bytes)
-        .map_err(|e| EncryptionError::InvalidFormat(format!("Invalid UTF-8: {}", e)))?;
+        .map_err(|e| EncryptionError::InvalidFormat(format!("Invalid UTF-8: {e}")))?;
 
     // Try to parse as encrypted data first (if encryption is configured)
     if FieldEncryption::is_configured() {
@@ -246,7 +243,7 @@ pub fn decrypt_sensitive_field(data: &str) -> Result<String, EncryptionError> {
                 // This is encrypted data, decrypt it
                 let plaintext_bytes = encryption.decrypt(&encrypted_data)?;
                 return String::from_utf8(plaintext_bytes).map_err(|e| {
-                    EncryptionError::DecryptionFailed(format!("Invalid UTF-8 in plaintext: {}", e))
+                    EncryptionError::DecryptionFailed(format!("Invalid UTF-8 in plaintext: {e}"))
                 });
             }
         }
@@ -255,7 +252,7 @@ pub fn decrypt_sensitive_field(data: &str) -> Result<String, EncryptionError> {
     // If we get here, either encryption is not configured, or this is fallback data
     // Try to parse as JSON string (fallback format)
     serde_json::from_str(&json_str)
-        .map_err(|e| EncryptionError::DecryptionFailed(format!("Invalid JSON string: {}", e)))
+        .map_err(|e| EncryptionError::DecryptionFailed(format!("Invalid JSON string: {e}")))
 }
 
 /// Utility function to generate a new encryption key

--- a/src/utils/serde/repository_encryption.rs
+++ b/src/utils/serde/repository_encryption.rs
@@ -18,7 +18,7 @@ where
 
     // Then encrypt the base64 string for secure storage
     let encrypted = encrypt_sensitive_field(&base64)
-        .map_err(|e| serde::ser::Error::custom(format!("Encryption failed: {}", e)))?;
+        .map_err(|e| serde::ser::Error::custom(format!("Encryption failed: {e}")))?;
 
     serializer.serialize_str(&encrypted)
 }
@@ -32,11 +32,11 @@ where
 
     // First decrypt the encrypted string to get the base64 string
     let base64_str = decrypt_sensitive_field(&encrypted_str)
-        .map_err(|e| serde::de::Error::custom(format!("Decryption failed: {}", e)))?;
+        .map_err(|e| serde::de::Error::custom(format!("Decryption failed: {e}")))?;
 
     // Then decode the base64 to get the raw secret bytes
     let decoded = base64_decode(&base64_str)
-        .map_err(|e| serde::de::Error::custom(format!("Invalid base64: {}", e)))?;
+        .map_err(|e| serde::de::Error::custom(format!("Invalid base64: {e}")))?;
 
     Ok(SecretVec::new(decoded.len(), |v| {
         v.copy_from_slice(&decoded)
@@ -50,7 +50,7 @@ where
 {
     let secret_content = secret.to_str();
     let encrypted = encrypt_sensitive_field(&secret_content)
-        .map_err(|e| serde::ser::Error::custom(format!("Encryption failed: {}", e)))?;
+        .map_err(|e| serde::ser::Error::custom(format!("Encryption failed: {e}")))?;
 
     let encoded = base64_encode(encrypted.as_bytes());
 
@@ -66,15 +66,15 @@ where
 
     // First decode the base64 to get the encrypted bytes
     let encrypted_bytes = base64_decode(&base64_str)
-        .map_err(|e| serde::de::Error::custom(format!("Invalid base64: {}", e)))?;
+        .map_err(|e| serde::de::Error::custom(format!("Invalid base64: {e}")))?;
 
     // Convert encrypted bytes back to string
     let encrypted_str = String::from_utf8(encrypted_bytes)
-        .map_err(|e| serde::de::Error::custom(format!("Invalid UTF-8: {}", e)))?;
+        .map_err(|e| serde::de::Error::custom(format!("Invalid UTF-8: {e}")))?;
 
     // Then decrypt the encrypted string to get the original content
     let decrypted = decrypt_sensitive_field(&encrypted_str)
-        .map_err(|e| serde::de::Error::custom(format!("Decryption failed: {}", e)))?;
+        .map_err(|e| serde::de::Error::custom(format!("Decryption failed: {e}")))?;
 
     Ok(SecretString::new(&decrypted))
 }
@@ -91,7 +91,7 @@ where
         Some(secret_string) => {
             let secret_content = secret_string.to_str();
             let encrypted = encrypt_sensitive_field(&secret_content)
-                .map_err(|e| serde::ser::Error::custom(format!("Encryption failed: {}", e)))?;
+                .map_err(|e| serde::ser::Error::custom(format!("Encryption failed: {e}")))?;
 
             let encoded = base64_encode(encrypted.as_bytes());
             serializer.serialize_some(&encoded)
@@ -113,15 +113,15 @@ where
         Some(base64_str) => {
             // First decode the base64 to get the encrypted bytes
             let encrypted_bytes = base64_decode(&base64_str)
-                .map_err(|e| serde::de::Error::custom(format!("Invalid base64: {}", e)))?;
+                .map_err(|e| serde::de::Error::custom(format!("Invalid base64: {e}")))?;
 
             // Convert encrypted bytes back to string
             let encrypted_str = String::from_utf8(encrypted_bytes)
-                .map_err(|e| serde::de::Error::custom(format!("Invalid UTF-8: {}", e)))?;
+                .map_err(|e| serde::de::Error::custom(format!("Invalid UTF-8: {e}")))?;
 
             // Then decrypt the encrypted string to get the original content
             let decrypted = decrypt_sensitive_field(&encrypted_str)
-                .map_err(|e| serde::de::Error::custom(format!("Decryption failed: {}", e)))?;
+                .map_err(|e| serde::de::Error::custom(format!("Decryption failed: {e}")))?;
 
             Ok(Some(SecretString::new(&decrypted)))
         }


### PR DESCRIPTION
# Summary

This PR will bump rust toolchain to newer version, 1.88.
Clippy warnings fixes included.

## Testing Process

## Checklist

- [ ] Add a reference to related issues in the PR description.
- [ ] Add unit tests if applicable.

> [!NOTE]
> If you are using Relayer in your stack, consider adding your team or organization to our list of [Relayer Users in the Wild](../INTHEWILD.md)!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated minimum supported Rust version from 1.86 to 1.88 across toolchain configuration and documentation.
  * Improved error message formatting consistency throughout the codebase.

* **Refactor**
  * Restructured plugin error handling to optimize memory allocation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->