### PR TITLE
chore: Minimise crates logs noise by default

### DIFF
--- a/src/domain/transaction/stellar/status.rs
+++ b/src/domain/transaction/stellar/status.rs
@@ -273,7 +273,6 @@ mod tests {
     use chrono::Duration;
     use mockall::predicate::eq;
     use soroban_rs::stellar_rpc_client::GetTransactionResponse;
-    use soroban_rs::xdr::ReadXdr;
 
     use crate::domain::transaction::stellar::test_helpers::*;
 


### PR DESCRIPTION
# Summary

This PR will add default config that minimises crates logs noise in order to minimise number of logs and to improve readability while debugging.
If needed logs for specific crate could be enabled by defining as part of RUST_LOG env var

## Testing Process

## Checklist

- [ ] Add a reference to related issues in the PR description.
- [x] Add unit tests if applicable.

> [!NOTE]
> If you are using Relayer in your stack, consider adding your team or organization to our list of [Relayer Users in the Wild](../INTHEWILD.md)!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined logging behavior with improved filtering for verbose third-party libraries by default while preserving custom RUST_LOG environment variable configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->