### PR TITLE
fix: Fix SDK breaking change for calling plugins method

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -924,13 +924,13 @@
         ]
       }
     },
-    "/api/v1/plugins/{plugin_id}/call{route}": {
+    "/api/v1/plugins/{plugin_id}/call": {
       "get": {
         "tags": [
           "Plugins"
         ],
         "summary": "Execute a plugin via GET (must be enabled per plugin)",
-        "description": "This endpoint is disabled by default. To enable it for a given plugin, set\n`allow_get_invocation: true` in the plugin configuration.\n\nWhen invoked via GET:\n- `params` is an empty object (`{}`)\n- query parameters are passed to the plugin handler via `context.query`\n- wildcard route routing is supported the same way as POST (see `doc_call_plugin`)",
+        "description": "This endpoint is disabled by default. To enable it for a given plugin, set\n`allow_get_invocation: true` in the plugin configuration.\n\nWhen invoked via GET:\n- `params` is an empty object (`{}`)\n- query parameters are passed to the plugin handler via `context.query`\n- wildcard route routing is supported the same way as POST (see `doc_call_plugin`)\n- Use the `route` query parameter or append the route to the URL path",
         "operationId": "callPluginGet",
         "parameters": [
           {
@@ -944,13 +944,12 @@
           },
           {
             "name": "route",
-            "in": "path",
-            "description": "Optional route suffix captured by the server. Use an empty string for the default route, or include a leading slash (e.g. '/supported'). May include additional slashes for nested routes.",
-            "required": true,
+            "in": "query",
+            "description": "Optional route suffix for custom routing (e.g., '/verify'). Alternative to appending the route to the URL path.",
+            "required": false,
             "schema": {
               "type": "string"
-            },
-            "example": "/supported"
+            }
           }
         ],
         "responses": {
@@ -1051,7 +1050,7 @@
           "Plugins"
         ],
         "summary": "Execute a plugin with optional wildcard route routing",
-        "description": "Logs and traces are only returned when the plugin is configured with `emit_logs` / `emit_traces`.\nPlugin-provided errors are normalized into a consistent payload (`code`, `details`) and a derived\nmessage so downstream clients receive a stable shape regardless of how the handler threw.\n\nThe endpoint supports wildcard route routing, allowing plugins to implement custom routing logic:\n- `/api/v1/plugins/{plugin_id}/call` - Default endpoint (route = \"\")\n- `/api/v1/plugins/{plugin_id}/call/verify` - Custom route (route = \"/verify\")\n- `/api/v1/plugins/{plugin_id}/call/settle` - Custom route (route = \"/settle\")\n- `/api/v1/plugins/{plugin_id}/call/api/v1/action` - Nested route (route = \"/api/v1/action\")\n\nThe route is passed to the plugin handler via the `context.route` field.",
+        "description": "Logs and traces are only returned when the plugin is configured with `emit_logs` / `emit_traces`.\nPlugin-provided errors are normalized into a consistent payload (`code`, `details`) and a derived\nmessage so downstream clients receive a stable shape regardless of how the handler threw.\n\nThe endpoint supports wildcard route routing, allowing plugins to implement custom routing logic:\n- `/api/v1/plugins/{plugin_id}/call` - Default endpoint (route = \"\")\n- `/api/v1/plugins/{plugin_id}/call?route=/verify` - Custom route via query parameter\n- `/api/v1/plugins/{plugin_id}/call/verify` - Custom route via URL path (route = \"/verify\")\n\nThe route is passed to the plugin handler via the `context.route` field.\nYou can specify a custom route either by appending it to the URL path or by using the `route` query parameter.",
         "operationId": "callPlugin",
         "parameters": [
           {
@@ -1065,13 +1064,12 @@
           },
           {
             "name": "route",
-            "in": "path",
-            "description": "Optional route suffix captured by the server. Use an empty string for the default route, or include a leading slash (e.g. '/verify'). May include additional slashes for nested routes (e.g. '/api/v1/action').",
-            "required": true,
+            "in": "query",
+            "description": "Optional route suffix for custom routing (e.g., '/verify'). Alternative to appending the route to the URL path.",
+            "required": false,
             "schema": {
               "type": "string"
-            },
-            "example": "/verify"
+            }
           }
         ],
         "requestBody": {
@@ -4499,6 +4497,10 @@
                       "type": "boolean",
                       "description": "Whether to include traces in the HTTP response"
                     },
+                    "forward_logs": {
+                      "type": "boolean",
+                      "description": "Whether to forward plugin logs into the relayer's tracing output"
+                    },
                     "id": {
                       "type": "string",
                       "description": "Plugin ID"
@@ -6985,6 +6987,10 @@
           "emit_traces": {
             "type": "boolean",
             "description": "Whether to include traces in the HTTP response"
+          },
+          "forward_logs": {
+            "type": "boolean",
+            "description": "Whether to forward plugin logs into the relayer's tracing output"
           },
           "id": {
             "type": "string",

--- a/src/api/routes/docs/plugin_docs.rs
+++ b/src/api/routes/docs/plugin_docs.rs
@@ -12,14 +12,14 @@ use crate::{
 ///
 /// The endpoint supports wildcard route routing, allowing plugins to implement custom routing logic:
 /// - `/api/v1/plugins/{plugin_id}/call` - Default endpoint (route = "")
-/// - `/api/v1/plugins/{plugin_id}/call/verify` - Custom route (route = "/verify")
-/// - `/api/v1/plugins/{plugin_id}/call/settle` - Custom route (route = "/settle")
-/// - `/api/v1/plugins/{plugin_id}/call/api/v1/action` - Nested route (route = "/api/v1/action")
+/// - `/api/v1/plugins/{plugin_id}/call?route=/verify` - Custom route via query parameter
+/// - `/api/v1/plugins/{plugin_id}/call/verify` - Custom route via URL path (route = "/verify")
 ///
 /// The route is passed to the plugin handler via the `context.route` field.
+/// You can specify a custom route either by appending it to the URL path or by using the `route` query parameter.
 #[utoipa::path(
     post,
-    path = "/api/v1/plugins/{plugin_id}/call{route}",
+    path = "/api/v1/plugins/{plugin_id}/call",
     tag = "Plugins",
     operation_id = "callPlugin",
     summary = "Execute a plugin with optional wildcard route routing",
@@ -28,12 +28,7 @@ use crate::{
     ),
     params(
         ("plugin_id" = String, Path, description = "The unique identifier of the plugin"),
-        (
-            "route" = String,
-            Path,
-            description = "Optional route suffix captured by the server. Use an empty string for the default route, or include a leading slash (e.g. '/verify'). May include additional slashes for nested routes (e.g. '/api/v1/action').",
-            example = "/verify"
-        )
+        ("route" = Option<String>, Query, description = "Optional route suffix for custom routing (e.g., '/verify'). Alternative to appending the route to the URL path.")
     ),
     request_body = PluginCallRequest,
     responses(
@@ -134,9 +129,10 @@ fn doc_call_plugin() {}
 /// - `params` is an empty object (`{}`)
 /// - query parameters are passed to the plugin handler via `context.query`
 /// - wildcard route routing is supported the same way as POST (see `doc_call_plugin`)
+/// - Use the `route` query parameter or append the route to the URL path
 #[utoipa::path(
     get,
-    path = "/api/v1/plugins/{plugin_id}/call{route}",
+    path = "/api/v1/plugins/{plugin_id}/call",
     tag = "Plugins",
     operation_id = "callPluginGet",
     summary = "Execute a plugin via GET (must be enabled per plugin)",
@@ -145,12 +141,7 @@ fn doc_call_plugin() {}
     ),
     params(
         ("plugin_id" = String, Path, description = "The unique identifier of the plugin"),
-        (
-            "route" = String,
-            Path,
-            description = "Optional route suffix captured by the server. Use an empty string for the default route, or include a leading slash (e.g. '/supported'). May include additional slashes for nested routes.",
-            example = "/supported"
-        )
+        ("route" = Option<String>, Query, description = "Optional route suffix for custom routing (e.g., '/verify'). Alternative to appending the route to the URL path.")
     ),
     responses(
         (


### PR DESCRIPTION
# Summary

This PR will fix recently merged change that causes sdk callPlugin breaking change by removing route param from api docs.

SDK PR: https://github.com/OpenZeppelin/openzeppelin-relayer-sdk/pull/240

## Testing Process

## Checklist

- [ ] Add a reference to related issues in the PR description.
- [ ] Add unit tests if applicable.

> [!NOTE]
> If you are using Relayer in your stack, consider adding your team or organization to our list of [Relayer Users in the Wild](../INTHEWILD.md)!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `forward_logs` configuration field to control plugin log output
  * Plugin endpoints now support custom routes via query parameters as an alternative to URL path routing

* **Changes**
  * Route parameters for plugin endpoints are now optional, providing more flexible API usage options

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->