### PR TITLE
docs: align config processing order docs with behavior

### DIFF
--- a/src/bootstrap/config_processor.rs
+++ b/src/bootstrap/config_processor.rs
@@ -328,10 +328,12 @@ where
 /// Process a complete configuration file by initializing all repositories.
 ///
 /// This function processes the entire configuration file in the following order:
-/// 1. Process signers
-/// 2. Process notifications
-/// 3. Process networks
-/// 4. Process relayers
+/// 1. Process plugins
+/// 2. Process signers
+/// 3. Process notifications
+/// 4. Process networks
+/// 5. Process relayers
+/// 6. Process API key
 pub async fn process_config_file<J, RR, TR, NR, NFR, SR, TCR, PR, AKR>(
     config_file: Config,
     server_config: Arc<ServerConfig>,


### PR DESCRIPTION
The doc comment above process_config_file described an outdated processing order and omitted plugins and API key initialization, which could mislead maintainers about how configuration is loaded at startup.
Updated doc comment to list all processed components (plugins, signers, notifications, networks, relayers, API key) 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configuration processing now prioritizes plugin initialization as the first step and API key processing as the final step.
  * Server configuration is now considered in the processing flow to support storage reset behavior.
  * Storage reset logic now clears all repositories when enabled before processing configurations.

* **Documentation**
  * Updated configuration processing documentation to reflect new order and API key handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->