### PR TITLE
fix(workflows): fix shell syntax error and correct action version comments

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           egress-policy: audit
       - name: Checkout repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v4.5.4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -36,7 +36,7 @@ jobs:
           if [[ ! "$INPUT_COMMIT_SHA" =~ ^[0-9a-f]{40}$ ]]; then
             echo "Invalid commit SHA: $INPUT_COMMIT_SHA. Please provide the full 40-character SHA."
             echo "Provided SHA: $INPUT_COMMIT_SHA"
-            echo "Length: ${#$INPUT_COMMIT_SHA}"
+            echo "Length: ${#INPUT_COMMIT_SHA}"
             exit 1
           fi
           echo "Valid commit SHA: $INPUT_COMMIT_SHA"

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -53,7 +53,7 @@ jobs:
         env:
           DOCKER_METADATA_SHORT_SHA_LENGTH: 10
       - name: Login to Dockerhub
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef  # v3.6.0
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PAT }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -128,10 +128,6 @@ jobs:
         with:
           app-id: ${{ vars.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-      - name: Get PR details
-        id: release-branch
-        run: |
-          echo "pr head branch name: >>>>> ${{ needs.release-please.outputs.release_branch }}"
       - name: Checkout release branch
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
         with:
@@ -183,10 +179,6 @@ jobs:
         with:
           app-id: ${{ vars.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-      - name: Get PR details
-        id: release-branch
-        run: |
-          echo "pr head branch name: >>>>> ${{ needs.release-please.outputs.release_branch }}"
       - name: Checkout release branch
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
         with:

--- a/.github/workflows/release-sbom.yml
+++ b/.github/workflows/release-sbom.yml
@@ -52,7 +52,7 @@ jobs:
           GH_TOKEN: ${{ steps.gh-app-token.outputs.token }}
         run: gh release upload ${{ inputs.tag }} openzeppelin-relayer-${{ inputs.tag }}-spdx.json
       - name: SBOM attestation
-        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a  # main
+        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a  # v3.0.0
         with:
           subject-path: ./openzeppelin-relayer-${{ inputs.tag }}-spdx.json
           github-token: ${{ steps.gh-app-token.outputs.token }}

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           egress-policy: audit
       - name: Checkout code
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v4.5.4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
         with:
           persist-credentials: false
       - name: Run analysis


### PR DESCRIPTION
## Summary

Fixes a confirmed bash syntax error and corrects misleading action version comments across 6 workflow files.

## Changes

- **`rc.yml:39`** - Fix bash bad substitution error: `${#$INPUT_COMMIT_SHA}` → `${#INPUT_COMMIT_SHA}`. The incorrect syntax causes the validation step to crash with "bad substitution" instead of showing the intended error message when an invalid commit SHA is provided.

- **Version comment corrections** (verified via GitHub API):
  - `scorecard.yml` and `codeql.yml`: `# v4.5.4` → `# v6.0.1` (tag v4.5.4 does not exist)
  - `release-sbom.yml`: `# main` → `# v3.0.0` for `actions/attest-build-provenance`
  - `release-docker.yml`: Add `# v3.6.0` to `docker/login-action` (was missing)

- **Cleanup**: Remove debug echo statements from `release-please.yml` (`"pr head branch name: >>>>> ..."`)

All changes are cosmetic fixes except for the bash syntax error, which is a confirmed bug that will fail on next use.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration infrastructure with latest action versions for enhanced security and performance.
  * Streamlined release pipeline by removing unnecessary diagnostic steps.
  * Enhanced deployment configuration with clarifying documentation.

* **Bug Fixes**
  * Corrected shell parameter expansion in build validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->