### PR TITLE
feat(evm): add status_reason for failed on-chain transactions (#522)

### DIFF
--- a/src/domain/transaction/evm/status.rs
+++ b/src/domain/transaction/evm/status.rs
@@ -300,9 +300,12 @@ where
         &self,
         tx: TransactionRepoModel,
         new_status: TransactionStatus,
+        status_reason: Option<String>,
     ) -> Result<TransactionRepoModel, TransactionError> {
         if tx.status != new_status {
-            return self.update_transaction_status(tx, new_status).await;
+            return self
+                .update_transaction_status(tx, new_status, status_reason)
+                .await;
         }
         Ok(tx)
     }
@@ -357,7 +360,7 @@ where
             return Ok(resubmitted_tx);
         }
 
-        self.update_transaction_status_if_needed(tx, TransactionStatus::Submitted)
+        self.update_transaction_status_if_needed(tx, TransactionStatus::Submitted, None)
             .await
     }
 
@@ -476,7 +479,7 @@ where
         &self,
         tx: TransactionRepoModel,
     ) -> Result<TransactionRepoModel, TransactionError> {
-        self.update_transaction_status_if_needed(tx, TransactionStatus::Mined)
+        self.update_transaction_status_if_needed(tx, TransactionStatus::Mined, None)
             .await
     }
 
@@ -485,8 +488,10 @@ where
         &self,
         tx: TransactionRepoModel,
         status: TransactionStatus,
+        status_reason: Option<String>,
     ) -> Result<TransactionRepoModel, TransactionError> {
-        self.update_transaction_status_if_needed(tx, status).await
+        self.update_transaction_status_if_needed(tx, status, status_reason)
+            .await
     }
 
     /// Marks a transaction as Failed with a given reason.
@@ -689,7 +694,9 @@ where
         // For other states (Mined/Confirmed/Failed/etc), process immediately regardless of age.
         if is_too_early_to_resubmit(&tx)? && is_pending_transaction(&status) {
             // Update status if it changed, then return
-            return self.update_transaction_status_if_needed(tx, status).await;
+            return self
+                .update_transaction_status_if_needed(tx, status, None)
+                .await;
         }
 
         // 4. Handle based on status (including complex operations like resubmission)
@@ -698,10 +705,19 @@ where
             TransactionStatus::Sent => self.handle_sent_state(tx).await,
             TransactionStatus::Submitted => self.handle_submitted_state(tx).await,
             TransactionStatus::Mined => self.handle_mined_state(tx).await,
+            TransactionStatus::Failed => {
+                // Provide a descriptive status_reason when transitioning to Failed
+                // from an on-chain receipt check (i.e., receipt status was false).
+                let status_reason = if tx.status != TransactionStatus::Failed {
+                    Some("Transaction reverted on-chain (receipt status: failed)".to_string())
+                } else {
+                    None
+                };
+                self.handle_final_state(tx, status, status_reason).await
+            }
             TransactionStatus::Confirmed
-            | TransactionStatus::Failed
             | TransactionStatus::Expired
-            | TransactionStatus::Canceled => self.handle_final_state(tx, status).await,
+            | TransactionStatus::Canceled => self.handle_final_state(tx, status, None).await,
         }
     }
 
@@ -760,7 +776,7 @@ where
             self.send_transaction_resubmit_job(&tx).await?;
         }
 
-        self.update_transaction_status_if_needed(tx, TransactionStatus::Sent)
+        self.update_transaction_status_if_needed(tx, TransactionStatus::Sent, None)
             .await
     }
 
@@ -1665,7 +1681,7 @@ mod tests {
             // When new status is the same as current, update_transaction_status_if_needed
             // should simply return the original transaction.
             let updated_tx = evm_transaction
-                .update_transaction_status_if_needed(tx.clone(), TransactionStatus::Submitted)
+                .update_transaction_status_if_needed(tx.clone(), TransactionStatus::Submitted, None)
                 .await
                 .unwrap();
             assert_eq!(updated_tx.status, TransactionStatus::Submitted);
@@ -1696,11 +1712,48 @@ mod tests {
 
             let evm_transaction = make_test_evm_relayer_transaction(relayer, mocks);
             let updated_tx = evm_transaction
-                .update_transaction_status_if_needed(tx.clone(), TransactionStatus::Mined)
+                .update_transaction_status_if_needed(tx.clone(), TransactionStatus::Mined, None)
                 .await
                 .unwrap();
 
             assert_eq!(updated_tx.status, TransactionStatus::Mined);
+        }
+
+        #[tokio::test]
+        async fn test_updates_with_status_reason() {
+            let mut mocks = default_test_mocks();
+            let relayer = create_test_relayer();
+            let tx = make_test_transaction(TransactionStatus::Submitted);
+
+            mocks
+                .tx_repo
+                .expect_partial_update()
+                .withf(|_, update| {
+                    update.status == Some(TransactionStatus::Failed)
+                        && update.status_reason == Some("Transaction reverted on-chain".to_string())
+                })
+                .returning(|_, update| {
+                    let mut updated_tx = make_test_transaction(TransactionStatus::Submitted);
+                    updated_tx.status = update.status.unwrap_or(updated_tx.status);
+                    updated_tx.status_reason = update.status_reason.clone();
+                    Ok(updated_tx)
+                });
+
+            let evm_transaction = make_test_evm_relayer_transaction(relayer, mocks);
+            let updated_tx = evm_transaction
+                .update_transaction_status_if_needed(
+                    tx.clone(),
+                    TransactionStatus::Failed,
+                    Some("Transaction reverted on-chain".to_string()),
+                )
+                .await
+                .unwrap();
+
+            assert_eq!(updated_tx.status, TransactionStatus::Failed);
+            assert_eq!(
+                updated_tx.status_reason.as_deref(),
+                Some("Transaction reverted on-chain")
+            );
         }
     }
 
@@ -2048,7 +2101,7 @@ mod tests {
 
             let evm_transaction = make_test_evm_relayer_transaction(relayer, mocks);
             let result = evm_transaction
-                .handle_final_state(tx.clone(), TransactionStatus::Confirmed)
+                .handle_final_state(tx.clone(), TransactionStatus::Confirmed, None)
                 .await
                 .unwrap();
             assert_eq!(result.status, TransactionStatus::Confirmed);
@@ -2060,22 +2113,25 @@ mod tests {
             let relayer = create_test_relayer();
             let tx = make_test_transaction(TransactionStatus::Submitted);
 
-            // Expect partial_update to update status to Failed.
+            // Expect partial_update to update status to Failed with status_reason.
             mocks
                 .tx_repo
                 .expect_partial_update()
                 .returning(|_, update| {
                     let mut updated_tx = make_test_transaction(TransactionStatus::Submitted);
                     updated_tx.status = update.status.unwrap_or(updated_tx.status);
+                    updated_tx.status_reason = update.status_reason.clone();
                     Ok(updated_tx)
                 });
 
+            let reason = "Transaction reverted on-chain (receipt status: failed)".to_string();
             let evm_transaction = make_test_evm_relayer_transaction(relayer, mocks);
             let result = evm_transaction
-                .handle_final_state(tx.clone(), TransactionStatus::Failed)
+                .handle_final_state(tx.clone(), TransactionStatus::Failed, Some(reason.clone()))
                 .await
                 .unwrap();
             assert_eq!(result.status, TransactionStatus::Failed);
+            assert_eq!(result.status_reason.as_deref(), Some(reason.as_str()));
         }
 
         #[tokio::test]
@@ -2096,7 +2152,7 @@ mod tests {
 
             let evm_transaction = make_test_evm_relayer_transaction(relayer, mocks);
             let result = evm_transaction
-                .handle_final_state(tx.clone(), TransactionStatus::Expired)
+                .handle_final_state(tx.clone(), TransactionStatus::Expired, None)
                 .await
                 .unwrap();
             assert_eq!(result.status, TransactionStatus::Expired);
@@ -2240,6 +2296,62 @@ mod tests {
             let evm_transaction = make_test_evm_relayer_transaction(relayer, mocks);
             let result = evm_transaction.handle_status_impl(tx, None).await.unwrap();
             assert_eq!(result.status, TransactionStatus::Failed);
+        }
+
+        /// Verifies that a Submitted transaction with a failed on-chain receipt
+        /// transitions to Failed status with a descriptive status_reason.
+        #[tokio::test]
+        async fn test_impl_submitted_to_failed_sets_status_reason() {
+            let mut mocks = default_test_mocks();
+            let relayer = create_test_relayer();
+            let mut tx = make_test_transaction(TransactionStatus::Submitted);
+            tx.created_at = (Utc::now() - Duration::minutes(1)).to_rfc3339();
+            if let NetworkTransactionData::Evm(ref mut evm_data) = tx.network_data {
+                evm_data.hash = Some("0xFakeHash".to_string());
+            }
+
+            // Simulate a receipt with status=false (reverted on-chain).
+            mocks
+                .provider
+                .expect_get_transaction_receipt()
+                .returning(|_| Box::pin(async { Ok(Some(make_mock_receipt(false, Some(100)))) }));
+
+            // Mock get_by_id for the DB reload after status change.
+            let tx_clone = tx.clone();
+            mocks.tx_repo.expect_get_by_id().returning(move |_| {
+                let mut reloaded = tx_clone.clone();
+                reloaded.status = TransactionStatus::Submitted;
+                Ok(reloaded)
+            });
+
+            // Expect partial_update with status=Failed and a status_reason.
+            mocks
+                .tx_repo
+                .expect_partial_update()
+                .withf(|_, update| {
+                    update.status == Some(TransactionStatus::Failed)
+                        && update.status_reason.is_some()
+                })
+                .returning(|_, update| {
+                    let mut updated_tx = make_test_transaction(TransactionStatus::Submitted);
+                    updated_tx.status = update.status.unwrap_or(updated_tx.status);
+                    updated_tx.status_reason = update.status_reason.clone();
+                    Ok(updated_tx)
+                });
+
+            let evm_transaction = make_test_evm_relayer_transaction(relayer, mocks);
+            let result = evm_transaction.handle_status_impl(tx, None).await.unwrap();
+            assert_eq!(result.status, TransactionStatus::Failed);
+            assert!(result.status_reason.is_some());
+            assert!(
+                result
+                    .status_reason
+                    .as_ref()
+                    .unwrap()
+                    .contains("reverted on-chain"),
+                "Expected on-chain revert reason, got: {:?}",
+                result.status_reason
+            );
         }
 
         #[tokio::test]


### PR DESCRIPTION
## Summary
EVM transactions that revert on-chain were marked as `Failed` without a descriptive reason. This PR threads a `status_reason: Option<String>` parameter through `update_transaction_status`, `update_transaction_status_if_needed`, and `handle_final_state` in the EVM transaction flow so that receipt-based failures now include `"Transaction reverted on-chain (receipt status: failed)"`, matching existing Stellar/Solana behavior.

Closes #522

## Testing Process
- `test_final_state_failed` — verifies `handle_final_state` propagates `status_reason` when transitioning to Failed
- `test_updates_with_status_reason` — verifies `update_transaction_status_if_needed` threads the reason through to the update request
- `test_impl_submitted_to_failed_sets_status_reason` — end-to-end: Submitted tx with a failed on-chain receipt transitions to Failed with a descriptive `status_reason`
- All 176 existing EVM transaction tests pass

## Checklist

- [x] Add a reference to related issues in the PR description.
- [x] Add unit tests if applicable.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Transactions now include comprehensive status reason information when status changes occur.

* **Improvements**
  * Transaction failures now display descriptive reasons, such as on-chain reversion details, for better visibility into what went wrong.

* **Tests**
  * Added tests to ensure status reasons are properly propagated during transaction state transitions and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->