### PR TITLE
feat: Optimise getRelayerStatus method

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -2795,6 +2795,33 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "include_balance",
+            "in": "query",
+            "description": "Whether to include balance (default: true)",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "include_pending_count",
+            "in": "query",
+            "description": "Whether to include pending transaction count (default: true)",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "include_last_confirmed_tx",
+            "in": "query",
+            "description": "Whether to include last confirmed transaction timestamp (default: true)",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
           }
         ],
         "responses": {
@@ -5143,8 +5170,6 @@
               {
                 "type": "object",
                 "required": [
-                  "balance",
-                  "pending_transactions_count",
                   "system_disabled",
                   "paused",
                   "nonce",
@@ -5152,7 +5177,10 @@
                 ],
                 "properties": {
                   "balance": {
-                    "type": "string"
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   },
                   "last_confirmed_transaction_timestamp": {
                     "type": [
@@ -5173,7 +5201,10 @@
                     "type": "boolean"
                   },
                   "pending_transactions_count": {
-                    "type": "integer",
+                    "type": [
+                      "integer",
+                      "null"
+                    ],
                     "format": "int64",
                     "minimum": 0
                   },
@@ -5185,8 +5216,6 @@
               {
                 "type": "object",
                 "required": [
-                  "balance",
-                  "pending_transactions_count",
                   "system_disabled",
                   "paused",
                   "sequence_number",
@@ -5194,7 +5223,10 @@
                 ],
                 "properties": {
                   "balance": {
-                    "type": "string"
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   },
                   "last_confirmed_transaction_timestamp": {
                     "type": [
@@ -5212,7 +5244,10 @@
                     "type": "boolean"
                   },
                   "pending_transactions_count": {
-                    "type": "integer",
+                    "type": [
+                      "integer",
+                      "null"
+                    ],
                     "format": "int64",
                     "minimum": 0
                   },
@@ -5227,15 +5262,16 @@
               {
                 "type": "object",
                 "required": [
-                  "balance",
-                  "pending_transactions_count",
                   "system_disabled",
                   "paused",
                   "network_type"
                 ],
                 "properties": {
                   "balance": {
-                    "type": "string"
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   },
                   "last_confirmed_transaction_timestamp": {
                     "type": [
@@ -5253,7 +5289,10 @@
                     "type": "boolean"
                   },
                   "pending_transactions_count": {
-                    "type": "integer",
+                    "type": [
+                      "integer",
+                      "null"
+                    ],
                     "format": "int64",
                     "minimum": 0
                   },
@@ -8014,8 +8053,6 @@
           {
             "type": "object",
             "required": [
-              "balance",
-              "pending_transactions_count",
               "system_disabled",
               "paused",
               "nonce",
@@ -8023,7 +8060,10 @@
             ],
             "properties": {
               "balance": {
-                "type": "string"
+                "type": [
+                  "string",
+                  "null"
+                ]
               },
               "last_confirmed_transaction_timestamp": {
                 "type": [
@@ -8044,7 +8084,10 @@
                 "type": "boolean"
               },
               "pending_transactions_count": {
-                "type": "integer",
+                "type": [
+                  "integer",
+                  "null"
+                ],
                 "format": "int64",
                 "minimum": 0
               },
@@ -8056,8 +8099,6 @@
           {
             "type": "object",
             "required": [
-              "balance",
-              "pending_transactions_count",
               "system_disabled",
               "paused",
               "sequence_number",
@@ -8065,7 +8106,10 @@
             ],
             "properties": {
               "balance": {
-                "type": "string"
+                "type": [
+                  "string",
+                  "null"
+                ]
               },
               "last_confirmed_transaction_timestamp": {
                 "type": [
@@ -8083,7 +8127,10 @@
                 "type": "boolean"
               },
               "pending_transactions_count": {
-                "type": "integer",
+                "type": [
+                  "integer",
+                  "null"
+                ],
                 "format": "int64",
                 "minimum": 0
               },
@@ -8098,15 +8145,16 @@
           {
             "type": "object",
             "required": [
-              "balance",
-              "pending_transactions_count",
               "system_disabled",
               "paused",
               "network_type"
             ],
             "properties": {
               "balance": {
-                "type": "string"
+                "type": [
+                  "string",
+                  "null"
+                ]
               },
               "last_confirmed_transaction_timestamp": {
                 "type": [
@@ -8124,7 +8172,10 @@
                 "type": "boolean"
               },
               "pending_transactions_count": {
-                "type": "integer",
+                "type": [
+                  "integer",
+                  "null"
+                ],
                 "format": "int64",
                 "minimum": 0
               },

--- a/plugins/lib/plugin.ts
+++ b/plugins/lib/plugin.ts
@@ -164,9 +164,15 @@ export type Relayer = {
 
   /**
    * Gets the relayer status (balance, nonce/sequence number, etc).
+   * @param options - Optional parameters.
+   * @param options.includeBalance - Whether to include balance (default: true).
    * @returns The relayer status information.
    */
-  getRelayerStatus: () => Promise<ApiResponseRelayerStatusData>;
+  getRelayerStatus: (options?: {
+    includeBalance?: boolean;
+    includePendingCount?: boolean;
+    includeLastConfirmedTx?: boolean;
+  }) => Promise<ApiResponseRelayerStatusData>;
   /**
    * Gets the relayer info including address.
    * @returns The relayer information.
@@ -561,7 +567,8 @@ export class DefaultPluginAPI implements PluginAPI {
       },
       getTransaction: (payload: GetTransactionRequest) =>
         this._send<TransactionResponse>(relayerId, 'getTransaction', payload),
-      getRelayerStatus: () => this._send<ApiResponseRelayerStatusData>(relayerId, 'getRelayerStatus', {}),
+      getRelayerStatus: (options?: { includeBalance?: boolean }) =>
+        this._send<ApiResponseRelayerStatusData>(relayerId, 'getRelayerStatus', options ?? {}),
       signTransaction: (payload: SignTransactionRequest) =>
         this._send<SignTransactionResponse>(relayerId, 'signTransaction', payload),
       getRelayer: () => this._send<ApiResponseRelayerResponseData>(relayerId, 'getRelayer', {}),

--- a/plugins/lib/pool-executor.ts
+++ b/plugins/lib/pool-executor.ts
@@ -497,8 +497,12 @@ class PluginAPIImpl implements PluginAPI {
       },
       getTransaction: (payload: { transactionId: string }) =>
         this.send(relayerId, 'getTransaction', payload),
-      getRelayerStatus: () =>
-        this.send<ApiResponseRelayerStatusData>(relayerId, 'getRelayerStatus', {}),
+      getRelayerStatus: (options?: {
+        includeBalance?: boolean;
+        includePendingCount?: boolean;
+        includeLastConfirmedTx?: boolean;
+      }) =>
+        this.send<ApiResponseRelayerStatusData>(relayerId, 'getRelayerStatus', options ?? {}),
       signTransaction: (payload: SignTransactionRequest) =>
         this.send<SignTransactionResponse>(relayerId, 'signTransaction', payload),
       getRelayer: () =>

--- a/src/api/controllers/relayer.rs
+++ b/src/api/controllers/relayer.rs
@@ -22,11 +22,12 @@ use crate::{
         transaction::request::{
             SponsoredTransactionBuildRequest, SponsoredTransactionQuoteRequest,
         },
-        ApiError, ApiResponse, CreateRelayerRequest, DefaultAppState, NetworkRepoModel,
-        NetworkTransactionRequest, NetworkType, NotificationRepoModel, PaginationMeta,
-        PaginationQuery, Relayer as RelayerDomainModel, RelayerRepoModel, RelayerRepoUpdater,
-        RelayerResponse, Signer as SignerDomainModel, SignerRepoModel, ThinDataAppState,
-        TransactionRepoModel, TransactionResponse, TransactionStatus, UpdateRelayerRequestRaw,
+        ApiError, ApiResponse, CreateRelayerRequest, DefaultAppState, GetStatusOptions,
+        NetworkRepoModel, NetworkTransactionRequest, NetworkType, NotificationRepoModel,
+        PaginationMeta, PaginationQuery, Relayer as RelayerDomainModel, RelayerRepoModel,
+        RelayerRepoUpdater, RelayerResponse, Signer as SignerDomainModel, SignerRepoModel,
+        ThinDataAppState, TransactionRepoModel, TransactionResponse, TransactionStatus,
+        UpdateRelayerRequestRaw,
     },
     repositories::{
         ApiKeyRepositoryTrait, NetworkRepository, PluginRepositoryTrait, RelayerRepository,
@@ -353,6 +354,7 @@ where
 /// The status of the specified relayer.
 pub async fn get_relayer_status<J, RR, TR, NR, NFR, SR, TCR, PR, AKR>(
     relayer_id: String,
+    options: GetStatusOptions,
     state: ThinDataAppState<J, RR, TR, NR, NFR, SR, TCR, PR, AKR>,
 ) -> Result<HttpResponse, ApiError>
 where
@@ -368,7 +370,7 @@ where
 {
     let relayer = get_network_relayer(relayer_id, &state).await?;
 
-    let status = relayer.get_status().await?;
+    let status = relayer.get_status(options).await?;
 
     Ok(HttpResponse::Ok().json(ApiResponse::success(status)))
 }

--- a/src/api/routes/docs/relayer_docs.rs
+++ b/src/api/routes/docs/relayer_docs.rs
@@ -373,7 +373,10 @@ fn doc_delete_relayer() {}
         ("bearer_auth" = [])
     ),
     params(
-        ("relayer_id" = String, Path, description = "The unique identifier of the relayer")
+        ("relayer_id" = String, Path, description = "The unique identifier of the relayer"),
+        ("include_balance" = Option<bool>, Query, description = "Whether to include balance (default: true)"),
+        ("include_pending_count" = Option<bool>, Query, description = "Whether to include pending transaction count (default: true)"),
+        ("include_last_confirmed_tx" = Option<bool>, Query, description = "Whether to include last confirmed transaction timestamp (default: true)")
     ),
     responses(
         (status = 200, description = "Relayer status retrieved successfully", body = ApiResponse<RelayerStatus>),

--- a/src/api/routes/relayer.rs
+++ b/src/api/routes/relayer.rs
@@ -61,13 +61,39 @@ async fn delete_relayer(
     relayer::delete_relayer(relayer_id.into_inner(), data).await
 }
 
+/// Query parameters for the relayer status endpoint.
+#[derive(Debug, Deserialize)]
+pub struct StatusQuery {
+    #[serde(default = "default_true")]
+    pub include_balance: bool,
+    #[serde(default = "default_true")]
+    pub include_pending_count: bool,
+    #[serde(default = "default_true")]
+    pub include_last_confirmed_tx: bool,
+}
+
+fn default_true() -> bool {
+    true
+}
+
 /// Fetches the current status of a specific relayer.
 #[get("/relayers/{relayer_id}/status")]
 async fn get_relayer_status(
     relayer_id: web::Path<String>,
+    query: web::Query<StatusQuery>,
     data: web::ThinData<DefaultAppState>,
 ) -> impl Responder {
-    relayer::get_relayer_status(relayer_id.into_inner(), data).await
+    let q = query.into_inner();
+    relayer::get_relayer_status(
+        relayer_id.into_inner(),
+        crate::models::GetStatusOptions {
+            include_balance: q.include_balance,
+            include_pending_count: q.include_pending_count,
+            include_last_confirmed_tx: q.include_last_confirmed_tx,
+        },
+        data,
+    )
+    .await
 }
 
 /// Retrieves the balance of a specific relayer.
@@ -555,5 +581,56 @@ mod tests {
         assert_ne!(resp.status(), StatusCode::NOT_FOUND);
 
         Ok(())
+    }
+
+    #[actix_web::test]
+    async fn test_status_query_defaults() {
+        // Empty JSON object should default all fields to true
+        let query: StatusQuery = serde_json::from_value(serde_json::json!({})).unwrap();
+        assert!(query.include_balance);
+        assert!(query.include_pending_count);
+        assert!(query.include_last_confirmed_tx);
+    }
+
+    #[actix_web::test]
+    async fn test_status_query_all_false() {
+        let query: StatusQuery = serde_json::from_value(serde_json::json!({
+            "include_balance": false,
+            "include_pending_count": false,
+            "include_last_confirmed_tx": false,
+        }))
+        .unwrap();
+        assert!(!query.include_balance);
+        assert!(!query.include_pending_count);
+        assert!(!query.include_last_confirmed_tx);
+    }
+
+    #[actix_web::test]
+    async fn test_status_query_partial() {
+        // Only override one param, others should default to true
+        let query: StatusQuery = serde_json::from_value(serde_json::json!({
+            "include_balance": false,
+        }))
+        .unwrap();
+        assert!(!query.include_balance);
+        assert!(query.include_pending_count);
+        assert!(query.include_last_confirmed_tx);
+    }
+
+    #[actix_web::test]
+    async fn test_status_route_accepts_query_params() {
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(get_test_app_state().await))
+                .configure(init),
+        )
+        .await;
+
+        // With query params — route should still be registered (not 404)
+        let req = test::TestRequest::get()
+            .uri("/relayers/test-id/status?include_balance=false&include_pending_count=false")
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+        assert_ne!(resp.status(), StatusCode::NOT_FOUND);
     }
 }

--- a/src/domain/relayer/mod.rs
+++ b/src/domain/relayer/mod.rs
@@ -24,8 +24,8 @@ use crate::{
             SponsoredTransactionBuildRequest, SponsoredTransactionQuoteRequest,
         },
         AppState, DecoratedSignature, DeletePendingTransactionsResponse,
-        EncodedSerializedTransaction, EvmNetwork, EvmTransactionDataSignature, JsonRpcRequest,
-        JsonRpcResponse, NetworkRepoModel, NetworkRpcRequest, NetworkRpcResult,
+        EncodedSerializedTransaction, EvmNetwork, EvmTransactionDataSignature, GetStatusOptions,
+        JsonRpcRequest, JsonRpcResponse, NetworkRepoModel, NetworkRpcRequest, NetworkRpcResult,
         NetworkTransactionRequest, NetworkType, NotificationRepoModel, RelayerError,
         RelayerRepoModel, RelayerStatus, SignerRepoModel, SponsoredTransactionBuildResponse,
         SponsoredTransactionQuoteResponse, TransactionError, TransactionRepoModel,
@@ -143,7 +143,7 @@ pub trait Relayer {
     ///
     /// A `Result` containing `RelayerStatus` on success, or a
     /// `RelayerError` on failure.
-    async fn get_status(&self) -> Result<RelayerStatus, RelayerError>;
+    async fn get_status(&self, options: GetStatusOptions) -> Result<RelayerStatus, RelayerError>;
 
     /// Initializes the relayer.
     ///
@@ -332,11 +332,11 @@ impl<
         }
     }
 
-    async fn get_status(&self) -> Result<RelayerStatus, RelayerError> {
+    async fn get_status(&self, options: GetStatusOptions) -> Result<RelayerStatus, RelayerError> {
         match self {
-            NetworkRelayer::Evm(relayer) => relayer.get_status().await,
-            NetworkRelayer::Solana(relayer) => relayer.get_status().await,
-            NetworkRelayer::Stellar(relayer) => relayer.get_status().await,
+            NetworkRelayer::Evm(relayer) => relayer.get_status(options).await,
+            NetworkRelayer::Solana(relayer) => relayer.get_status(options).await,
+            NetworkRelayer::Stellar(relayer) => relayer.get_status(options).await,
         }
     }
 


### PR DESCRIPTION
# Summary

This PR will:
- Optimise Stellar get status method by using internal transaction counter sequence number
- Optimise get status method by allowing conditionally fetching field (lower impact in high throughput systems)

## Testing Process

## Checklist

- [ ] Add a reference to related issues in the PR description.
- [ ] Add unit tests if applicable.

> [!NOTE]
> If you are using Relayer in your stack, consider adding your team or organization to our list of [Relayer Users in the Wild](../INTHEWILD.md)!
