### PR TITLE
chore: Update relayer plugin channels to 0.11.0

### DIFF
--- a/examples/channels-plugin-example/channel/package-lock.json
+++ b/examples/channels-plugin-example/channel/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@openzeppelin/relayer-plugin-channels": "^0.11.0",
-        "@openzeppelin/relayer-sdk": "^1.9.0"
+        "@openzeppelin/relayer-sdk": "^1.10.0"
       },
       "devDependencies": {
         "@types/jest": "^29.5.12",
@@ -972,9 +972,9 @@
       }
     },
     "node_modules/@openzeppelin/relayer-sdk": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/relayer-sdk/-/relayer-sdk-1.9.0.tgz",
-      "integrity": "sha512-G3Zhg0imaT9Ej1cE9Cq5d4uQvW+DinD2GvRuiPWo3+O9KI8ivBnGJkjEGgK9Ja3/QsUNIfx8Gk5Mdw2sPXjVWA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/relayer-sdk/-/relayer-sdk-1.10.0.tgz",
+      "integrity": "sha512-C7v4C63VnFR4keISicpcDf4Ix646sa1OdokzddFeSPEGlJIY2b/XJ9sIWiXOBVJVGzbB+RdX3/fbkygAPhcVNw==",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "axios": "^1.7.7"

--- a/examples/channels-plugin-example/channel/package.json
+++ b/examples/channels-plugin-example/channel/package.json
@@ -14,7 +14,7 @@
   "license": "",
   "dependencies": {
     "@openzeppelin/relayer-plugin-channels": "^0.11.0",
-    "@openzeppelin/relayer-sdk": "^1.9.0"
+    "@openzeppelin/relayer-sdk": "^1.10.0"
   },
   "devDependencies": {
     "@types/jest": "^29.5.12",


### PR DESCRIPTION
# Summary

- Update relayer plugin channels version to 0.11.0



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated plugin dependency to the latest compatible version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->