### PR TITLE
ci: add SCANOSS license compliance scanning

### DIFF
--- a/.github/workflows/scanoss.yml
+++ b/.github/workflows/scanoss.yml
@@ -1,0 +1,128 @@
+name: SCANOSS License Compliance
+
+on:
+  pull_request:
+    branches: [main, master]
+  push:
+    branches: [main, master]
+
+permissions:
+  contents: read
+  pull-requests: write
+  checks: write
+
+concurrency:
+  group: scanoss-${{ github.repository }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  scanoss-pr:
+    name: SCANOSS License Scan (PR)
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: SCANOSS Delta Scan
+        uses: scanoss/gha-code-scan@v1
+        with:
+          api.key: ${{ secrets.SCANOSS_API_KEY }}
+          github.token: ${{ steps.app-token.outputs.token }}
+          policies: copyleft
+          policies.halt_on_failure: false
+          scanMode: delta
+          dependencies.enabled: false
+          output.filepath: scanoss-results.json
+
+  scanoss-full:
+    name: SCANOSS Full Scan (post-merge)
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Remove non-source files that crash SCANOSS
+        run: |
+          find . -type f \( \
+            -name '*.pcap' -o -name '*.pcapng' -o -name '*.tsv' -o -name '*.csv' \
+            -o -name '*.bin' -o -name '*.png' -o -name '*.jpg' -o -name '*.jpeg' \
+            -o -name '*.gif' -o -name '*.webp' -o -name '*.avif' -o -name '*.svg' \
+            -o -name '*.ico' -o -name '*.pdf' \
+            -o -name '*.mp3' -o -name '*.mp4' -o -name '*.mov' -o -name '*.wav' \
+            -o -name '*.woff' -o -name '*.woff2' -o -name '*.ttf' -o -name '*.otf' \
+            -o -name '*.eot' \
+            -o -name '*.gz' -o -name '*.tar' -o -name '*.zip' -o -name '*.whl' \
+            -o -name '*.7z' -o -name '*.rar' \
+            -o -name '*.o' -o -name '*.a' -o -name '*.so' -o -name '*.dylib' \
+            -o -name '*.dll' -o -name '*.exe' -o -name '*.class' -o -name '*.jar' \
+            -o -name '*.pyc' -o -name '*.pdi' -o -name '*.xsa' -o -name '*.elf' \
+            -o -name '*.hpu' -o -name '*.bcode' -o -name '*.cbor' \
+          \) -delete 2>/dev/null || true
+          rm -rf Datasets assets node_modules __pycache__ .venv bmenv .next dist build 2>/dev/null || true
+
+      - name: SCANOSS Full Scan
+        uses: scanoss/gha-code-scan@v1
+        with:
+          api.key: ${{ secrets.SCANOSS_API_KEY }}
+          github.token: ${{ steps.app-token.outputs.token }}
+          policies: copyleft
+          policies.halt_on_failure: false
+          scanMode: full
+          dependencies.enabled: false
+          output.filepath: scanoss-results.json
+
+  trigger-ort:
+    name: Trigger ORT Scan
+    if: github.event_name == 'push'
+    runs-on: self-hosted
+    steps:
+      - name: Check if ORT scan needed
+        id: check
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 2
+
+      - name: Skip if only NOTICE changed
+        id: filter
+        run: |
+          CHANGED=$(git diff --name-only HEAD~1 HEAD 2>/dev/null || echo "FORCE_SCAN")
+          if [ "$(echo "$CHANGED" | grep -v '^NOTICE$' | grep -v '^$')" = "" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Trigger ORT scan via webhook
+        if: steps.filter.outputs.skip != 'true'
+        run: |
+          REPO_NAME="${GITHUB_REPOSITORY#*/}"
+          HTTP_CODE=$(curl -s -o /tmp/ort-response.json -w "%{http_code}" -X POST "${{ vars.ORT_WEBHOOK_URL }}/scan" -H "Authorization: Bearer ${{ secrets.ORT_WEBHOOK_TOKEN }}" -H "Content-Type: application/json" -d "{\"repo\": \"${REPO_NAME}\"}")
+          echo "HTTP $HTTP_CODE"
+          cat /tmp/ort-response.json
+          if [ "$HTTP_CODE" = "202" ]; then
+            echo "::notice::ORT scan triggered for $REPO_NAME"
+          else
+            echo "::warning::ORT webhook returned $HTTP_CODE — scan may not have started"
+          fi

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,50 @@
+THIRD-PARTY SOFTWARE NOTICES AND INFORMATION
+============================================================
+
+Project: openzeppelin-relayer
+Generated: 2026-04-24
+Tool: SCANOSS (snippet detection with License dataset)
+Components: 2
+
+This file lists all third-party software components detected
+in this repository, along with their licenses and copyright
+notices as required by those licenses.
+
+------------------------------------------------------------
+
+LICENSE SUMMARY
+
+  AGPL-3.0-only [COPYLEFT]: 1 component(s)
+  CC0-1.0: 1 component(s)
+
+------------------------------------------------------------
+
+COMPONENT ATTRIBUTIONS
+
+  network.wasm
+  Version: v1.0.0
+  Source: https://github.com/hazae41/network.wasm
+  PURL: pkg:github/hazae41/network.wasm
+  License: CC0-1.0
+
+  openzeppelin-relayer
+  Version: v0.1.0
+  Source: https://github.com/openzeppelin/openzeppelin-relayer
+  PURL: pkg:github/openzeppelin/openzeppelin-relayer
+  Copyright:
+    Copyright 2007 Free Software Foundation Inc.  https:  fsf.org
+  License: AGPL-3.0-only
+
+------------------------------------------------------------
+
+FULL LICENSE TEXTS
+
+--- CC0-1.0 ---
+
+Full license text available at: https://spdx.org/licenses/CC0-1.0.html
+
+
+--- AGPL-3.0-only ---
+
+Full license text available at: https://spdx.org/licenses/AGPL-3.0-only.html
+

--- a/NOTICE
+++ b/NOTICE
@@ -2,7 +2,7 @@ THIRD-PARTY SOFTWARE NOTICES AND INFORMATION
 ============================================================
 
 Project: openzeppelin-relayer
-Generated: 2026-04-24
+Generated: 2026-04-25
 Tool: SCANOSS (snippet detection with License dataset)
 Components: 2
 
@@ -41,10 +41,29 @@ FULL LICENSE TEXTS
 
 --- CC0-1.0 ---
 
-Full license text available at: https://spdx.org/licenses/CC0-1.0.html
+The person who associated a work with this deed has dedicated the work to
+the public domain by waiving all of his or her rights to the work worldwide
+under copyright law, including all related and neighboring rights, to the
+extent allowed by law.
+
+You can copy, modify, distribute and perform the work, even for commercial
+purposes, all without asking permission.
+
+Full license text: https://creativecommons.org/publicdomain/zero/1.0/legalcode
 
 
 --- AGPL-3.0-only ---
 
-Full license text available at: https://spdx.org/licenses/AGPL-3.0-only.html
+This program is free software: you can redistribute it and/or modify it
+under the terms of the GNU General Public License as published by the Free
+Software Foundation, version 3 of the License.
+
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <https://www.gnu.org/licenses/>.
+
+Full license text: https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/scanoss.json
+++ b/scanoss.json
@@ -1,0 +1,7 @@
+{
+  "bom": {
+    "include": [
+      {"purl":"pkg:github/OpenZeppelin/openzeppelin-relayer","comment":"Known AGPL upstream fork"}
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Add SCANOSS GitHub Action for automated license compliance scanning
- Scans PRs (delta) and pushes to main (full) for copyleft license violations
- Posts findings as PR comments — does NOT block merges
- Add `scanoss.json` configuration for component declarations

Part of org-wide compliance initiative.

## Test plan
- [ ] Verify SCANOSS action runs on next PR
- [ ] Verify no false positives on existing code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated license compliance scanning to the CI/CD pipeline
  * Added third-party license notices documentation to track project dependencies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->