### PR TITLE
chore: Bump Rust toolchain to 1.91.1

### DIFF
--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -14,7 +14,7 @@ runs:
   using: composite
   steps:
     - name: setup rust tool chain
-      uses: dtolnay/rust-toolchain@1.88.0  # v1.88.0
+      uses: dtolnay/rust-toolchain@1.91.1  # v1.91.1
       with:
         components: ${{ (inputs.components != '') && format('{0}, rustfmt, clippy', inputs.components) || 'rustfmt, clippy' }}
     - name: Install libsodium

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "openzeppelin-relayer"
 version = "1.4.0"
 edition = "2021"
-rust-version = "1.88"         #MSRV
+rust-version = "1.91"         #MSRV
 
 [features]
 default = []

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.88.0"
+channel = "1.91.1"
 profile = "minimal"
 components = [
     "rustc",

--- a/src/jobs/handlers/transaction_cleanup_handler.rs
+++ b/src/jobs/handlers/transaction_cleanup_handler.rs
@@ -329,7 +329,7 @@ async fn process_status_cleanup(
         };
 
         let page_result = transaction_repo
-            .find_by_status_paginated(relayer_id, &[status.clone()], query, true)
+            .find_by_status_paginated(relayer_id, std::slice::from_ref(status), query, true)
             .await
             .map_err(|e| {
                 eyre::eyre!(

--- a/src/queues/sqs/worker.rs
+++ b/src/queues/sqs/worker.rs
@@ -903,7 +903,7 @@ fn poll_error_backoff_secs(consecutive_errors: u32) -> u64 {
 
     // Once well past the ceiling, periodically try the base interval
     // to quickly detect when the SQS endpoint recovers.
-    if consecutive_errors >= 7 && consecutive_errors % RECOVERY_PROBE_EVERY == 0 {
+    if consecutive_errors >= 7 && consecutive_errors.is_multiple_of(RECOVERY_PROBE_EVERY) {
         return base;
     }
 

--- a/src/repositories/api_key/api_key_in_memory.rs
+++ b/src/repositories/api_key/api_key_in_memory.rs
@@ -39,7 +39,7 @@ impl InMemoryApiKeyRepository {
         }
     }
 
-    async fn acquire_lock<T>(lock: &Mutex<T>) -> Result<MutexGuard<T>, RepositoryError> {
+    async fn acquire_lock<T>(lock: &Mutex<T>) -> Result<MutexGuard<'_, T>, RepositoryError> {
         Ok(lock.lock().await)
     }
 }

--- a/src/repositories/network/network_in_memory.rs
+++ b/src/repositories/network/network_in_memory.rs
@@ -40,7 +40,7 @@ impl InMemoryNetworkRepository {
         }
     }
 
-    async fn acquire_lock<T>(lock: &Mutex<T>) -> Result<MutexGuard<T>, RepositoryError> {
+    async fn acquire_lock<T>(lock: &Mutex<T>) -> Result<MutexGuard<'_, T>, RepositoryError> {
         Ok(lock.lock().await)
     }
 

--- a/src/repositories/notification/notification_in_memory.rs
+++ b/src/repositories/notification/notification_in_memory.rs
@@ -39,7 +39,7 @@ impl InMemoryNotificationRepository {
         }
     }
 
-    async fn acquire_lock<T>(lock: &Mutex<T>) -> Result<MutexGuard<T>, RepositoryError> {
+    async fn acquire_lock<T>(lock: &Mutex<T>) -> Result<MutexGuard<'_, T>, RepositoryError> {
         Ok(lock.lock().await)
     }
 }

--- a/src/repositories/plugin/plugin_in_memory.rs
+++ b/src/repositories/plugin/plugin_in_memory.rs
@@ -60,7 +60,7 @@ impl InMemoryPluginRepository {
         Ok(store.get(id).cloned())
     }
 
-    async fn acquire_lock<T>(lock: &Mutex<T>) -> Result<MutexGuard<T>, RepositoryError> {
+    async fn acquire_lock<T>(lock: &Mutex<T>) -> Result<MutexGuard<'_, T>, RepositoryError> {
         Ok(lock.lock().await)
     }
 }

--- a/src/repositories/relayer/relayer_in_memory.rs
+++ b/src/repositories/relayer/relayer_in_memory.rs
@@ -30,7 +30,7 @@ impl InMemoryRelayerRepository {
             store: Mutex::new(HashMap::new()),
         }
     }
-    async fn acquire_lock<T>(lock: &Mutex<T>) -> Result<MutexGuard<T>, RepositoryError> {
+    async fn acquire_lock<T>(lock: &Mutex<T>) -> Result<MutexGuard<'_, T>, RepositoryError> {
         Ok(lock.lock().await)
     }
 }

--- a/src/repositories/signer/signer_in_memory.rs
+++ b/src/repositories/signer/signer_in_memory.rs
@@ -38,7 +38,7 @@ impl InMemorySignerRepository {
         }
     }
 
-    async fn acquire_lock<T>(lock: &Mutex<T>) -> Result<MutexGuard<T>, RepositoryError> {
+    async fn acquire_lock<T>(lock: &Mutex<T>) -> Result<MutexGuard<'_, T>, RepositoryError> {
         Ok(lock.lock().await)
     }
 }

--- a/src/repositories/transaction/transaction_in_memory.rs
+++ b/src/repositories/transaction/transaction_in_memory.rs
@@ -43,7 +43,7 @@ impl InMemoryTransactionRepository {
         }
     }
 
-    async fn acquire_lock<T>(lock: &Mutex<T>) -> Result<MutexGuard<T>, RepositoryError> {
+    async fn acquire_lock<T>(lock: &Mutex<T>) -> Result<MutexGuard<'_, T>, RepositoryError> {
         Ok(lock.lock().await)
     }
 

--- a/src/services/plugins/pool_executor.rs
+++ b/src/services/plugins/pool_executor.rs
@@ -485,7 +485,7 @@ impl PoolManager {
                     last_log_time = now;
                 } else {
                     suppressed_count += 1;
-                    if suppressed_count % 100 == 0 {
+                    if suppressed_count.is_multiple_of(100) {
                         tracing::warn!(
                             target: "pool_server",
                             suppressed = suppressed_count,


### PR DESCRIPTION
Resolves cargo-doc build failure on Netlify caused by locked deps `rustc >= 1.91.1`.
- rust-toolchain.toml: 1.88.0 -> 1.91.1
- Cargo.toml MSRV: 1.88 -> 1.91
- Bump `1.91.1` in github actions workflows
- Apply new clippy lints from 1.91

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated minimum supported Rust toolchain version to 1.91.1 for improved compatibility and performance.

* **Refactor**
  * Internal code optimizations across message queue worker and data repositories to improve efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->