### PR TITLE
fix: Serialize fields as strings to avoid precision loss

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -6993,7 +6993,9 @@
                 ]
               },
               "value": {
-                "type": "string"
+                "type": "string",
+                "description": "Non-negative integer (memo ID) encoded as a decimal string to preserve precision.",
+                "pattern": "^[0-9]+$"
               }
             }
           },
@@ -7264,7 +7266,9 @@
             ],
             "properties": {
               "amount": {
-                "type": "string"
+                "type": "string",
+                "description": "Amount in stroops, encoded as a decimal string to preserve precision.",
+                "pattern": "^-?[0-9]+$"
               },
               "asset": {
                 "$ref": "#/components/schemas/AssetSpec"

--- a/openapi.json
+++ b/openapi.json
@@ -12,7 +12,7 @@
       "name": "AGPL-3.0 license",
       "url": "https://github.com/OpenZeppelin/openzeppelin-relayer/blob/main/LICENSE"
     },
-    "version": "1.4.0"
+    "version": "1.5.0"
   },
   "paths": {
     "/api/v1/health": {
@@ -9944,8 +9944,9 @@
             "type": "string"
           },
           "sequence_number": {
-            "type": "integer",
-            "format": "int64"
+            "type": "string",
+            "description": "Stellar sequence number encoded as a decimal string to preserve precision.",
+            "pattern": "^-?[0-9]+$"
           },
           "source_account": {
             "type": "string"

--- a/openapi.json
+++ b/openapi.json
@@ -6993,9 +6993,7 @@
                 ]
               },
               "value": {
-                "type": "integer",
-                "format": "int64",
-                "minimum": 0
+                "type": "string"
               }
             }
           },
@@ -7266,8 +7264,7 @@
             ],
             "properties": {
               "amount": {
-                "type": "integer",
-                "format": "int64"
+                "type": "string"
               },
               "asset": {
                 "$ref": "#/components/schemas/AssetSpec"

--- a/src/models/transaction/repository.rs
+++ b/src/models/transaction/repository.rs
@@ -526,10 +526,8 @@ pub enum TransactionInput {
     /// Pre-built signed XDR that needs fee-bumping
     SignedXdr {
         xdr: String,
-        // Serialized as a string for the same reason as
-        // `StellarTransactionData::sequence_number`: this i64 is re-encoded by
-        // the partial_update Lua script and would otherwise be floatified by
-        // cjson. The deserializer still accepts legacy integer/float forms.
+        // String-encoded like `sequence_number` to stay precise through storage
+        // serialization; see `serialize_i64`.
         #[serde(serialize_with = "serialize_i64", deserialize_with = "deserialize_i64")]
         max_fee: i64,
     },
@@ -637,12 +635,8 @@ impl TransactionInput {
 pub struct StellarTransactionData {
     pub source_account: String,
     pub fee: Option<u32>,
-    // Serialized as a string so the value survives a Redis/Lua `cjson`
-    // round-trip. Lua 5.1 (bundled by Redis) has no integer type, so a bare
-    // i64 is re-emitted as a float (e.g. `643918676885760.0`) by the
-    // `partial_update` script, which then fails to deserialize back into i64.
-    // The deserializer still accepts the legacy integer and corrupted float
-    // forms for backward compatibility with records already in Redis.
+    // String-encoded to keep large i64s precise through storage serialization;
+    // see `serialize_optional_i64`.
     #[serde(
         serialize_with = "serialize_optional_i64",
         deserialize_with = "deserialize_optional_i64",

--- a/src/models/transaction/repository.rs
+++ b/src/models/transaction/repository.rs
@@ -23,7 +23,10 @@ use crate::{
         RelayerError, RelayerRepoModel, SignerError, StellarNetwork, StellarValidationError,
         TransactionError, U256,
     },
-    utils::{deserialize_optional_u128, serialize_optional_u128},
+    utils::{
+        deserialize_i64, deserialize_optional_i64, deserialize_optional_u128, serialize_i64,
+        serialize_optional_i64, serialize_optional_u128,
+    },
 };
 use alloy::{
     consensus::{TxEip1559, TxLegacy},
@@ -521,7 +524,15 @@ pub enum TransactionInput {
     /// Pre-built unsigned XDR that needs signing
     UnsignedXdr(String),
     /// Pre-built signed XDR that needs fee-bumping
-    SignedXdr { xdr: String, max_fee: i64 },
+    SignedXdr {
+        xdr: String,
+        // Serialized as a string for the same reason as
+        // `StellarTransactionData::sequence_number`: this i64 is re-encoded by
+        // the partial_update Lua script and would otherwise be floatified by
+        // cjson. The deserializer still accepts legacy integer/float forms.
+        #[serde(serialize_with = "serialize_i64", deserialize_with = "deserialize_i64")]
+        max_fee: i64,
+    },
     /// Soroban gas abstraction: FeeForwarder transaction with user's signed auth entry
     /// The XDR is the FeeForwarder transaction from /build, and the signed_auth_entry
     /// contains the user's signed SorobanAuthorizationEntry to be injected.
@@ -626,6 +637,17 @@ impl TransactionInput {
 pub struct StellarTransactionData {
     pub source_account: String,
     pub fee: Option<u32>,
+    // Serialized as a string so the value survives a Redis/Lua `cjson`
+    // round-trip. Lua 5.1 (bundled by Redis) has no integer type, so a bare
+    // i64 is re-emitted as a float (e.g. `643918676885760.0`) by the
+    // `partial_update` script, which then fails to deserialize back into i64.
+    // The deserializer still accepts the legacy integer and corrupted float
+    // forms for backward compatibility with records already in Redis.
+    #[serde(
+        serialize_with = "serialize_optional_i64",
+        deserialize_with = "deserialize_optional_i64",
+        default
+    )]
     pub sequence_number: Option<i64>,
     pub memo: Option<MemoSpec>,
     pub valid_until: Option<String>,
@@ -1748,6 +1770,106 @@ mod tests {
         let tx = test_stellar_tx_data();
         let updated = tx.with_sequence_number(42);
         assert_eq!(updated.sequence_number, Some(42));
+    }
+
+    #[test]
+    fn test_stellar_sequence_number_serializes_as_string() {
+        // sequence_number must serialize as a JSON string so it survives a
+        // Redis/Lua cjson decode->encode round-trip. Lua 5.1 (bundled by
+        // Redis) has no integer type, so a large i64 stored as a bare JSON
+        // number is re-emitted as a float (e.g. 643918676885760.0), which
+        // then fails to deserialize back into i64. A quoted string is opaque
+        // to cjson and round-trips untouched.
+        let mut tx = test_stellar_tx_data();
+        tx.sequence_number = Some(643918676885760);
+
+        let json = serde_json::to_string(&tx).unwrap();
+
+        assert!(
+            json.contains(r#""sequence_number":"643918676885760""#),
+            "sequence_number should serialize as a string, got: {json}"
+        );
+    }
+
+    #[test]
+    fn test_stellar_sequence_number_deserializes_from_corrupted_float() {
+        // Regression for the GCP crash: transactions already stored in Redis
+        // hold sequence_number as a float (643918676885760.0) after a cjson
+        // round-trip. Deserialization must recover the integer value rather
+        // than erroring with "invalid type: floating point ..., expected i64".
+        let mut value = serde_json::to_value(test_stellar_tx_data()).unwrap();
+        value["sequence_number"] = serde_json::json!(643918676885760.0);
+        let json = serde_json::to_string(&value).unwrap();
+
+        let tx: StellarTransactionData = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(tx.sequence_number, Some(643918676885760));
+    }
+
+    #[test]
+    fn test_stellar_sequence_number_deserializes_from_legacy_integer() {
+        // Backward compat: records written before this fix hold a bare integer.
+        // (Passes today; guards us against regressing the legacy on-disk form.)
+        let mut value = serde_json::to_value(test_stellar_tx_data()).unwrap();
+        value["sequence_number"] = serde_json::json!(643918676885760_i64);
+        let json = serde_json::to_string(&value).unwrap();
+
+        let tx: StellarTransactionData = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(tx.sequence_number, Some(643918676885760));
+    }
+
+    fn signed_xdr_tx_data(max_fee: i64) -> StellarTransactionData {
+        let mut tx = test_stellar_tx_data();
+        tx.transaction_input = TransactionInput::SignedXdr {
+            xdr: "AAAA".to_string(),
+            max_fee,
+        };
+        tx
+    }
+
+    #[test]
+    fn test_stellar_signed_xdr_max_fee_serializes_as_string() {
+        // SignedXdr.max_fee is an i64 stored in Redis and re-encoded by the
+        // partial_update Lua script, so it has the same cjson float-corruption
+        // exposure as sequence_number and must serialize as a string too.
+        let json = serde_json::to_string(&signed_xdr_tx_data(643918676885760)).unwrap();
+
+        assert!(
+            json.contains(r#""max_fee":"643918676885760""#),
+            "max_fee should serialize as a string, got: {json}"
+        );
+    }
+
+    #[test]
+    fn test_stellar_signed_xdr_max_fee_deserializes_from_corrupted_float() {
+        // Regression: a SignedXdr tx whose max_fee was floatified by a cjson
+        // round-trip must still deserialize.
+        let mut value = serde_json::to_value(signed_xdr_tx_data(643918676885760)).unwrap();
+        value["transaction_input"]["SignedXdr"]["max_fee"] = serde_json::json!(643918676885760.0);
+        let json = serde_json::to_string(&value).unwrap();
+
+        let tx: StellarTransactionData = serde_json::from_str(&json).unwrap();
+
+        match tx.transaction_input {
+            TransactionInput::SignedXdr { max_fee, .. } => assert_eq!(max_fee, 643918676885760),
+            other => panic!("expected SignedXdr, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_stellar_signed_xdr_max_fee_deserializes_from_legacy_integer() {
+        // Backward compat with bare-integer records written before this fix.
+        let mut value = serde_json::to_value(signed_xdr_tx_data(35014)).unwrap();
+        value["transaction_input"]["SignedXdr"]["max_fee"] = serde_json::json!(35014_i64);
+        let json = serde_json::to_string(&value).unwrap();
+
+        let tx: StellarTransactionData = serde_json::from_str(&json).unwrap();
+
+        match tx.transaction_input {
+            TransactionInput::SignedXdr { max_fee, .. } => assert_eq!(max_fee, 35014),
+            other => panic!("expected SignedXdr, got {other:?}"),
+        }
     }
 
     #[test]

--- a/src/models/transaction/response.rs
+++ b/src/models/transaction/response.rs
@@ -7,7 +7,10 @@ use crate::{
         evm::Speed, EvmTransactionDataSignature, NetworkTransactionData, SolanaInstructionSpec,
         TransactionRepoModel, TransactionStatus, U256,
     },
-    utils::{deserialize_optional_u128, deserialize_optional_u64, serialize_optional_u128},
+    utils::{
+        deserialize_i64, deserialize_optional_u128, deserialize_optional_u64, serialize_i64,
+        serialize_optional_u128,
+    },
 };
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
@@ -107,6 +110,9 @@ pub struct StellarTransactionResponse {
     pub confirmed_at: Option<String>,
     pub source_account: String,
     pub fee: u32,
+    /// Stellar sequence number encoded as a decimal string to preserve precision.
+    #[serde(serialize_with = "serialize_i64", deserialize_with = "deserialize_i64")]
+    #[schema(value_type = String, pattern = "^-?[0-9]+$")]
     pub sequence_number: i64,
     pub relayer_id: String,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -417,6 +423,33 @@ mod tests {
             }
             _ => panic!("Expected StellarTransactionResponse"),
         }
+    }
+
+    #[test]
+    fn test_stellar_sequence_number_serializes_as_string() {
+        let response = StellarTransactionResponse {
+            id: "tx123".to_string(),
+            hash: None,
+            status: TransactionStatus::Confirmed,
+            status_reason: None,
+            created_at: "2024-01-01T00:00:00Z".to_string(),
+            sent_at: None,
+            confirmed_at: None,
+            source_account: "source_account_id".to_string(),
+            fee: 100,
+            sequence_number: 643918676885760,
+            relayer_id: "relayer3".to_string(),
+            transaction_result_xdr: None,
+        };
+
+        let json = serde_json::to_string(&response).unwrap();
+        assert!(
+            json.contains(r#""sequence_number":"643918676885760""#),
+            "sequence_number should serialize as a string, got: {json}"
+        );
+
+        let decoded: StellarTransactionResponse = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded.sequence_number, 643918676885760);
     }
 
     #[test]

--- a/src/models/transaction/stellar/memo.rs
+++ b/src/models/transaction/stellar/memo.rs
@@ -1,11 +1,13 @@
 //! Memo types and conversions for Stellar transactions
 
-use crate::models::SignerError;
-use crate::utils::{deserialize_u64, serialize_u64};
+use std::convert::TryFrom;
+
 use serde::{Deserialize, Serialize};
 use soroban_rs::xdr::{Hash, Memo, StringM};
-use std::convert::TryFrom;
 use utoipa::ToSchema;
+
+use crate::models::SignerError;
+use crate::utils::{deserialize_u64, serialize_u64};
 
 #[derive(Debug, Clone, Serialize, PartialEq, Deserialize, ToSchema)]
 #[serde(tag = "type", rename_all = "snake_case")]

--- a/src/models/transaction/stellar/memo.rs
+++ b/src/models/transaction/stellar/memo.rs
@@ -15,13 +15,12 @@ pub enum MemoSpec {
         value: String,
     }, // ≤ 28 UTF-8 bytes
     Id {
-        // Stored in Redis and re-encoded by the partial_update Lua script;
-        // serialized as a string so large memo IDs survive the cjson round-trip
-        // without being floatified. Legacy integer/float forms still accepted.
-        // `value_type = String` keeps the OpenAPI schema in sync with the wire
-        // format (utoipa ignores serialize_with).
+        /// Non-negative integer (memo ID) encoded as a decimal string to preserve precision.
+        // String serde keeps large integers precise through storage
+        // serialization; `value_type = String` syncs the OpenAPI schema.
+        // See `serialize_u64`.
         #[serde(serialize_with = "serialize_u64", deserialize_with = "deserialize_u64")]
-        #[schema(value_type = String)]
+        #[schema(value_type = String, pattern = "^[0-9]+$")]
         value: u64,
     },
     Hash {

--- a/src/models/transaction/stellar/memo.rs
+++ b/src/models/transaction/stellar/memo.rs
@@ -1,6 +1,7 @@
 //! Memo types and conversions for Stellar transactions
 
 use crate::models::SignerError;
+use crate::utils::{deserialize_u64, serialize_u64};
 use serde::{Deserialize, Serialize};
 use soroban_rs::xdr::{Hash, Memo, StringM};
 use std::convert::TryFrom;
@@ -14,6 +15,13 @@ pub enum MemoSpec {
         value: String,
     }, // ≤ 28 UTF-8 bytes
     Id {
+        // Stored in Redis and re-encoded by the partial_update Lua script;
+        // serialized as a string so large memo IDs survive the cjson round-trip
+        // without being floatified. Legacy integer/float forms still accepted.
+        // `value_type = String` keeps the OpenAPI schema in sync with the wire
+        // format (utoipa ignores serialize_with).
+        #[serde(serialize_with = "serialize_u64", deserialize_with = "deserialize_u64")]
+        #[schema(value_type = String)]
         value: u64,
     },
     Hash {
@@ -46,6 +54,36 @@ impl TryFrom<MemoSpec> for Memo {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // MemoSpec::Id.value is a u64 stored in Redis and re-encoded by the
+    // partial_update Lua script, so it must serialize as a cjson-safe string.
+    #[test]
+    fn test_memo_id_serializes_as_string() {
+        let memo = MemoSpec::Id {
+            value: 18446744073709551615,
+        };
+        let json = serde_json::to_string(&memo).unwrap();
+        assert!(
+            json.contains(r#""value":"18446744073709551615""#),
+            "memo id should serialize as a string, got: {json}"
+        );
+    }
+
+    #[test]
+    fn test_memo_id_deserializes_from_corrupted_float() {
+        let mut value = serde_json::to_value(MemoSpec::Id {
+            value: 1099511627776,
+        })
+        .unwrap();
+        value["value"] = serde_json::json!(1099511627776.0);
+        let json = serde_json::to_string(&value).unwrap();
+
+        let parsed: MemoSpec = serde_json::from_str(&json).unwrap();
+        match parsed {
+            MemoSpec::Id { value } => assert_eq!(value, 1099511627776),
+            other => panic!("expected Id, got {other:?}"),
+        }
+    }
 
     #[test]
     fn test_memo_none() {
@@ -100,10 +138,12 @@ mod tests {
             serde_json::json!({"type": "text", "value": "hello"})
         );
 
-        // Test Id
+        // Test Id — value is serialized as a string so large memo IDs survive
+        // the Redis/Lua cjson round-trip (deserialization still accepts the
+        // legacy integer form for backward compatibility).
         let id = MemoSpec::Id { value: 12345 };
         let id_json = serde_json::to_value(&id).unwrap();
-        assert_eq!(id_json, serde_json::json!({"type": "id", "value": 12345}));
+        assert_eq!(id_json, serde_json::json!({"type": "id", "value": "12345"}));
 
         // Test Hash
         let hash = MemoSpec::Hash { value: [0x42; 32] };

--- a/src/models/transaction/stellar/operation.rs
+++ b/src/models/transaction/stellar/operation.rs
@@ -36,13 +36,12 @@ pub enum AuthSpec {
 pub enum OperationSpec {
     Payment {
         destination: String,
-        // Stored in Redis and re-encoded by the partial_update Lua script;
-        // serialized as a string so large stroop amounts survive the cjson
-        // round-trip without being floatified. Legacy integer/float forms are
-        // still accepted on read. `value_type = String` keeps the OpenAPI schema
-        // in sync with the wire format (utoipa ignores serialize_with).
+        /// Amount in stroops, encoded as a decimal string to preserve precision.
+        // String serde keeps large integers precise through storage
+        // serialization; `value_type = String` syncs the OpenAPI schema.
+        // See `serialize_i64`.
         #[serde(serialize_with = "serialize_i64", deserialize_with = "deserialize_i64")]
-        #[schema(value_type = String)]
+        #[schema(value_type = String, pattern = "^-?[0-9]+$")]
         amount: i64,
         asset: AssetSpec,
     },

--- a/src/models/transaction/stellar/operation.rs
+++ b/src/models/transaction/stellar/operation.rs
@@ -3,6 +3,7 @@
 use crate::models::transaction::stellar::asset::AssetSpec;
 use crate::models::transaction::stellar::host_function::{ContractSource, WasmSource};
 use crate::models::SignerError;
+use crate::utils::{deserialize_i64, serialize_i64};
 use serde::{Deserialize, Serialize};
 use soroban_rs::xdr::{
     HostFunction, InvokeHostFunctionOp, MuxedAccount as XdrMuxedAccount, MuxedAccountMed25519,
@@ -35,6 +36,13 @@ pub enum AuthSpec {
 pub enum OperationSpec {
     Payment {
         destination: String,
+        // Stored in Redis and re-encoded by the partial_update Lua script;
+        // serialized as a string so large stroop amounts survive the cjson
+        // round-trip without being floatified. Legacy integer/float forms are
+        // still accepted on read. `value_type = String` keeps the OpenAPI schema
+        // in sync with the wire format (utoipa ignores serialize_with).
+        #[serde(serialize_with = "serialize_i64", deserialize_with = "deserialize_i64")]
+        #[schema(value_type = String)]
         amount: i64,
         asset: AssetSpec,
     },
@@ -310,6 +318,41 @@ mod tests {
     const TEST_CONTRACT: &str = "CA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUWDA";
     const TEST_MUXED: &str =
         "MAAAAAAAAAAAAAB7BQ2L7E5NBWMXDUCMZSIPOBKRDSBYVLMXGSSKF6YNPIB7Y77ITLVL6";
+
+    // Payment.amount is an i64 stored in Redis and re-encoded by the
+    // partial_update Lua script, so it must be serialized as a cjson-safe
+    // string (large stroop amounts would otherwise be floatified).
+    #[test]
+    fn test_payment_amount_serializes_as_string() {
+        let op = OperationSpec::Payment {
+            destination: TEST_PK.to_string(),
+            amount: 643918676885760,
+            asset: AssetSpec::Native,
+        };
+        let json = serde_json::to_string(&op).unwrap();
+        assert!(
+            json.contains(r#""amount":"643918676885760""#),
+            "amount should serialize as a string, got: {json}"
+        );
+    }
+
+    #[test]
+    fn test_payment_amount_deserializes_from_corrupted_float() {
+        let op = OperationSpec::Payment {
+            destination: TEST_PK.to_string(),
+            amount: 643918676885760,
+            asset: AssetSpec::Native,
+        };
+        let mut value = serde_json::to_value(&op).unwrap();
+        value["amount"] = serde_json::json!(643918676885760.0);
+        let json = serde_json::to_string(&value).unwrap();
+
+        let parsed: OperationSpec = serde_json::from_str(&json).unwrap();
+        match parsed {
+            OperationSpec::Payment { amount, .. } => assert_eq!(amount, 643918676885760),
+            other => panic!("expected Payment, got {other:?}"),
+        }
+    }
 
     mod parse_destination_address_tests {
         use super::*;

--- a/src/repositories/transaction/transaction_redis.rs
+++ b/src/repositories/transaction/transaction_redis.rs
@@ -2225,7 +2225,10 @@ impl TransactionRepository for RedisTransactionRepository {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::models::{evm::Speed, EvmTransactionData, NetworkType};
+    use crate::models::{
+        evm::Speed, EvmTransactionData, MemoSpec, NetworkType, StellarTransactionData,
+        TransactionInput,
+    };
     use alloy::primitives::U256;
     use deadpool_redis::{Config, Runtime};
     use lazy_static::lazy_static;
@@ -2280,6 +2283,35 @@ mod tests {
     fn create_test_transaction_with_relayer(id: &str, relayer_id: &str) -> TransactionRepoModel {
         let mut tx = create_test_transaction(id);
         tx.relayer_id = relayer_id.to_string();
+        tx
+    }
+
+    fn create_stellar_test_transaction(
+        id: &str,
+        relayer_id: &str,
+        sequence_number: i64,
+        max_fee: i64,
+        memo_id: u64,
+    ) -> TransactionRepoModel {
+        let mut tx = create_test_transaction_with_relayer(id, relayer_id);
+        tx.network_type = NetworkType::Stellar;
+        tx.network_data = NetworkTransactionData::Stellar(StellarTransactionData {
+            source_account: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF".to_string(),
+            fee: Some(100),
+            sequence_number: Some(sequence_number),
+            memo: Some(MemoSpec::Id { value: memo_id }),
+            valid_until: None,
+            network_passphrase: "Test SDF Network ; September 2015".to_string(),
+            signatures: vec![],
+            hash: None,
+            simulation_transaction_data: None,
+            transaction_input: TransactionInput::SignedXdr {
+                xdr: "AAAA".to_string(),
+                max_fee,
+            },
+            signed_envelope_xdr: None,
+            transaction_result_xdr: None,
+        });
         tx
     }
 
@@ -3073,6 +3105,59 @@ mod tests {
             updated.sent_at,
             Some("2025-01-27T16:00:00.000000+00:00".to_string())
         );
+    }
+
+    #[tokio::test]
+    #[ignore = "Requires active Redis instance"]
+    async fn test_partial_update_preserves_large_stellar_i64_fields() {
+        // End-to-end regression against a real Redis: large i64/u64 fields
+        // (sequence_number, SignedXdr.max_fee, and the memo Id) must survive the
+        // partial_update Lua `cjson` decode->encode round-trip. Before the
+        // string-serde fix, cjson re-emitted these as floats (e.g.
+        // 643918676885760.0) and the read-back failed with "invalid type:
+        // floating point, expected i64".
+        let repo = setup_test_repo().await;
+        let relayer_id = Uuid::new_v4().to_string();
+        let tx_id = Uuid::new_v4().to_string();
+        // All values exceed 2^32 so they exercise the large-integer path that
+        // the pre-fix code corrupted.
+        let seq = 643918676885760_i64;
+        let max_fee = 549755813888_i64;
+        let memo_id = 1099511627776_u64;
+
+        let tx = create_stellar_test_transaction(&tx_id, &relayer_id, seq, max_fee, memo_id);
+        repo.create(tx).await.unwrap();
+
+        let update = TransactionUpdateRequest {
+            status: Some(TransactionStatus::Sent),
+            sent_at: Some("2025-01-27T16:00:00.000000+00:00".to_string()),
+            ..Default::default()
+        };
+
+        // The Lua script returns the re-encoded JSON; this deserialization is
+        // exactly where the float corruption used to blow up.
+        let updated = repo.partial_update(tx_id.clone(), update).await.unwrap();
+        assert_large_stellar_fields(&updated, seq, max_fee, memo_id);
+
+        // Re-read from Redis to confirm what was actually persisted, not just
+        // the script's return value.
+        let reloaded = repo.get_by_id(tx_id).await.unwrap();
+        assert_large_stellar_fields(&reloaded, seq, max_fee, memo_id);
+    }
+
+    fn assert_large_stellar_fields(
+        tx: &TransactionRepoModel,
+        seq: i64,
+        max_fee: i64,
+        memo_id: u64,
+    ) {
+        let stellar = tx.network_data.get_stellar_transaction_data().unwrap();
+        assert_eq!(stellar.sequence_number, Some(seq));
+        assert_eq!(stellar.memo, Some(MemoSpec::Id { value: memo_id }));
+        match stellar.transaction_input {
+            TransactionInput::SignedXdr { max_fee: mf, .. } => assert_eq!(mf, max_fee),
+            other => panic!("expected SignedXdr, got {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/src/utils/serde/i64_serializer.rs
+++ b/src/utils/serde/i64_serializer.rs
@@ -1,0 +1,193 @@
+//! Serde helpers for i64 values stored as strings.
+//!
+//! Large i64 values (e.g. Stellar sequence numbers) must be serialized as JSON
+//! strings so they survive a Redis/Lua `cjson` decode -> encode round-trip.
+//! Redis bundles Lua 5.1, which represents every number as an IEEE-754 double,
+//! so a bare integer is re-emitted as a float (e.g. `643918676885760.0`). That
+//! both loses precision above 2^53 and fails to deserialize back into `i64`
+//! ("invalid type: floating point ..., expected i64"). A quoted string is
+//! opaque to `cjson` and round-trips untouched.
+//!
+//! The deserializer accepts three historical on-disk forms for backward
+//! compatibility:
+//! - the string form (`"643918676885760"`) written after this fix,
+//! - the legacy bare integer (`643918676885760`) written before it, and
+//! - the corrupted float (`643918676885760.0`) already sitting in Redis.
+
+use std::fmt;
+
+use serde::{de, Deserialize, Deserializer, Serializer};
+
+use super::safe_float::f64_to_safe_integer;
+
+#[derive(Debug)]
+struct I64Visitor;
+
+impl de::Visitor<'_> for I64Visitor {
+    type Value = i64;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("a string, integer, or float representing an i64")
+    }
+
+    // String form written after this fix: "643918676885760".
+    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        value.parse::<i64>().map_err(de::Error::custom)
+    }
+
+    // Legacy bare integer form: 643918676885760.
+    fn visit_i64<E>(self, value: i64) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(value)
+    }
+
+    fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        i64::try_from(value).map_err(de::Error::custom)
+    }
+
+    // Corrupted form left in Redis by a Lua cjson round-trip: 643918676885760.0.
+    // Values beyond 2^53 are rejected (see `safe_float`) because precision was
+    // already lost and the original integer cannot be recovered.
+    fn visit_f64<E>(self, value: f64) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        let n = f64_to_safe_integer::<E>(value)?;
+        i64::try_from(n).map_err(de::Error::custom)
+    }
+}
+
+/// Deserialize a non-optional `i64`, accepting string, integer, or float JSON
+/// forms. See the module docs for why all three forms must be tolerated.
+pub fn deserialize_i64<'de, D>(deserializer: D) -> Result<i64, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    deserializer.deserialize_any(I64Visitor)
+}
+
+/// Serialize a non-optional `i64` as a JSON string so it survives a Redis/Lua
+/// `cjson` round-trip.
+pub fn serialize_i64<S>(value: &i64, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    serializer.serialize_str(&value.to_string())
+}
+
+/// Deserialize `Option<i64>`, accepting string, integer, or float JSON forms.
+///
+/// See the module docs for why all three forms must be tolerated.
+pub fn deserialize_optional_i64<'de, D>(deserializer: D) -> Result<Option<i64>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    struct Helper(#[serde(deserialize_with = "deserialize_i64")] i64);
+
+    let helper = Option::<Helper>::deserialize(deserializer)?;
+    Ok(helper.map(|Helper(value)| value))
+}
+
+/// Serialize `Option<i64>` as a JSON string (or `null`) so it survives a
+/// Redis/Lua `cjson` round-trip.
+pub fn serialize_optional_i64<S>(value: &Option<i64>, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    match value {
+        Some(v) => serializer.serialize_some(&v.to_string()),
+        None => serializer.serialize_none(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(serde::Serialize, serde::Deserialize, PartialEq, Debug)]
+    struct Wrapper {
+        #[serde(
+            serialize_with = "serialize_optional_i64",
+            deserialize_with = "deserialize_optional_i64",
+            default
+        )]
+        seq: Option<i64>,
+    }
+
+    #[test]
+    fn serializes_as_string() {
+        let json = serde_json::to_string(&Wrapper {
+            seq: Some(643918676885760),
+        })
+        .unwrap();
+        assert_eq!(json, r#"{"seq":"643918676885760"}"#);
+    }
+
+    #[test]
+    fn serializes_none_as_null() {
+        let json = serde_json::to_string(&Wrapper { seq: None }).unwrap();
+        assert_eq!(json, r#"{"seq":null}"#);
+    }
+
+    #[test]
+    fn deserializes_from_string() {
+        let w: Wrapper = serde_json::from_str(r#"{"seq":"643918676885760"}"#).unwrap();
+        assert_eq!(w.seq, Some(643918676885760));
+    }
+
+    #[test]
+    fn deserializes_from_legacy_integer() {
+        let w: Wrapper = serde_json::from_str(r#"{"seq":643918676885760}"#).unwrap();
+        assert_eq!(w.seq, Some(643918676885760));
+    }
+
+    #[test]
+    fn deserializes_from_corrupted_float() {
+        let w: Wrapper = serde_json::from_str(r#"{"seq":643918676885760.0}"#).unwrap();
+        assert_eq!(w.seq, Some(643918676885760));
+    }
+
+    #[test]
+    fn deserializes_negative() {
+        let w: Wrapper = serde_json::from_str(r#"{"seq":-5}"#).unwrap();
+        assert_eq!(w.seq, Some(-5));
+        let w: Wrapper = serde_json::from_str(r#"{"seq":"-5"}"#).unwrap();
+        assert_eq!(w.seq, Some(-5));
+    }
+
+    #[test]
+    fn deserializes_null_and_missing() {
+        let w: Wrapper = serde_json::from_str(r#"{"seq":null}"#).unwrap();
+        assert_eq!(w.seq, None);
+        let w: Wrapper = serde_json::from_str(r#"{}"#).unwrap();
+        assert_eq!(w.seq, None);
+    }
+
+    #[test]
+    fn rejects_non_integral_float() {
+        assert!(serde_json::from_str::<Wrapper>(r#"{"seq":1.5}"#).is_err());
+    }
+
+    #[test]
+    fn rejects_float_beyond_safe_integer_range() {
+        // 2^53 + 1 cannot be represented exactly; recovering it from a float
+        // would silently return the wrong value, so we reject it instead.
+        assert!(serde_json::from_str::<Wrapper>(r#"{"seq":9007199254740993.0}"#).is_err());
+    }
+
+    #[test]
+    fn deserializes_large_string_beyond_safe_range() {
+        // The going-forward string form has no precision limit.
+        let w: Wrapper = serde_json::from_str(r#"{"seq":"9007199254740993"}"#).unwrap();
+        assert_eq!(w.seq, Some(9007199254740993));
+    }
+}

--- a/src/utils/serde/mod.rs
+++ b/src/utils/serde/mod.rs
@@ -1,8 +1,13 @@
 mod u128_deserializer;
 pub use u128_deserializer::*;
 
+mod safe_float;
+
 mod u64_deserializer;
 pub use u64_deserializer::*;
+
+mod i64_serializer;
+pub use i64_serializer::*;
 
 pub mod field_as_string;
 

--- a/src/utils/serde/safe_float.rs
+++ b/src/utils/serde/safe_float.rs
@@ -1,0 +1,71 @@
+//! Shared guard for recovering integers from floats produced by a Redis/Lua
+//! `cjson` round-trip.
+//!
+//! When a large integer is re-encoded by Lua's `cjson` it can come back as a
+//! float (e.g. `643918676885760.0`). For values within the exactly
+//! representable range this is a lossless reformatting we can recover from, but
+//! beyond 2^53 distinct integers collapse onto the same `f64`, so the original
+//! value is no longer knowable. In that case we reject rather than return a
+//! silently wrong number.
+
+use serde::de;
+
+/// 2^53 - 1: the largest-magnitude integer that `f64` represents exactly.
+/// Beyond this, `n` and `n + 1` can map to the same double, so a floatified
+/// value can no longer be recovered without an authoritative source.
+pub(crate) const MAX_SAFE_INTEGER_F64: f64 = 9_007_199_254_740_991.0;
+
+/// Convert a JSON float that should have been an integer back into an `i128`,
+/// rejecting non-integral values and any magnitude beyond the exactly
+/// representable range (where precision may already have been lost).
+pub(crate) fn f64_to_safe_integer<E>(value: f64) -> Result<i128, E>
+where
+    E: de::Error,
+{
+    if !value.is_finite() || value.fract() != 0.0 {
+        return Err(E::custom(format!(
+            "cannot convert non-integral float {value} to an integer"
+        )));
+    }
+    if value.abs() > MAX_SAFE_INTEGER_F64 {
+        return Err(E::custom(format!(
+            "float {value} exceeds the exactly-representable integer range \
+             (2^53-1); it was floatified by a Lua cjson round-trip and cannot \
+             be recovered safely"
+        )));
+    }
+    Ok(value as i128)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::de::value::Error;
+
+    #[test]
+    fn accepts_value_at_safe_boundary() {
+        assert_eq!(
+            f64_to_safe_integer::<Error>(9_007_199_254_740_991.0).unwrap(),
+            9_007_199_254_740_991
+        );
+    }
+
+    #[test]
+    fn accepts_real_world_corrupted_value() {
+        assert_eq!(
+            f64_to_safe_integer::<Error>(643918676885760.0).unwrap(),
+            643918676885760
+        );
+    }
+
+    #[test]
+    fn rejects_value_beyond_safe_range() {
+        // 2^53 + 1 is not representable and arrives as 2^53; we cannot trust it.
+        assert!(f64_to_safe_integer::<Error>(9_007_199_254_740_993.0).is_err());
+    }
+
+    #[test]
+    fn rejects_non_integral() {
+        assert!(f64_to_safe_integer::<Error>(1.5).is_err());
+    }
+}

--- a/src/utils/serde/safe_float.rs
+++ b/src/utils/serde/safe_float.rs
@@ -59,6 +59,14 @@ mod tests {
     }
 
     #[test]
+    fn accepts_negative_value_at_safe_boundary() {
+        assert_eq!(
+            f64_to_safe_integer::<Error>(-9_007_199_254_740_991.0).unwrap(),
+            -9_007_199_254_740_991
+        );
+    }
+
+    #[test]
     fn accepts_real_world_corrupted_value() {
         assert_eq!(
             f64_to_safe_integer::<Error>(643918676885760.0).unwrap(),
@@ -75,5 +83,16 @@ mod tests {
     #[test]
     fn rejects_non_integral() {
         assert!(f64_to_safe_integer::<Error>(1.5).is_err());
+    }
+
+    #[test]
+    fn rejects_infinite() {
+        assert!(f64_to_safe_integer::<Error>(f64::INFINITY).is_err());
+        assert!(f64_to_safe_integer::<Error>(f64::NEG_INFINITY).is_err());
+    }
+
+    #[test]
+    fn rejects_nan() {
+        assert!(f64_to_safe_integer::<Error>(f64::NAN).is_err());
     }
 }

--- a/src/utils/serde/safe_float.rs
+++ b/src/utils/serde/safe_float.rs
@@ -3,16 +3,19 @@
 //!
 //! When a large integer is re-encoded by Lua's `cjson` it can come back as a
 //! float (e.g. `643918676885760.0`). For values within the exactly
-//! representable range this is a lossless reformatting we can recover from, but
-//! beyond 2^53 distinct integers collapse onto the same `f64`, so the original
-//! value is no longer knowable. In that case we reject rather than return a
-//! silently wrong number.
+//! representable range this is a lossless reformatting we can recover from.
+//! Beyond 2^53, however, consecutive integers can no longer all be represented
+//! distinctly as `f64`, so the original value is no longer knowable — in that
+//! case we reject rather than return a silently wrong number.
 
 use serde::de;
 
-/// 2^53 - 1: the largest-magnitude integer that `f64` represents exactly.
-/// Beyond this, `n` and `n + 1` can map to the same double, so a floatified
-/// value can no longer be recovered without an authoritative source.
+/// 2^53 - 1, i.e. JavaScript's `Number.MAX_SAFE_INTEGER`: the largest `N` such
+/// that *every* integer in `[-N, N]` is exactly representable as `f64` and
+/// round-trips uniquely. Individual larger integers (e.g. 2^53) are still
+/// representable, but 2^53 + 1 is not — it collapses onto 2^53 — so once a value
+/// exceeds this bound it can no longer be recovered from a float without an
+/// authoritative source.
 pub(crate) const MAX_SAFE_INTEGER_F64: f64 = 9_007_199_254_740_991.0;
 
 /// Convert a JSON float that should have been an integer back into an `i128`,
@@ -22,7 +25,12 @@ pub(crate) fn f64_to_safe_integer<E>(value: f64) -> Result<i128, E>
 where
     E: de::Error,
 {
-    if !value.is_finite() || value.fract() != 0.0 {
+    if !value.is_finite() {
+        return Err(E::custom(format!(
+            "cannot convert non-finite float {value} to an integer"
+        )));
+    }
+    if value.fract() != 0.0 {
         return Err(E::custom(format!(
             "cannot convert non-integral float {value} to an integer"
         )));

--- a/src/utils/serde/u64_deserializer.rs
+++ b/src/utils/serde/u64_deserializer.rs
@@ -1,10 +1,15 @@
-//! Deserialization utilities for u64 values
+//! Serde utilities for u64 values.
 //!
-//! This module provides a custom deserializer for u64 values.
+//! Provides a tolerant deserializer (string / integer / float) and a
+//! string serializer so large u64 values survive a Redis/Lua `cjson`
+//! round-trip. See `super::safe_float` for why the float form is tolerated and
+//! why values beyond 2^53 are rejected rather than silently truncated.
 
 use std::fmt;
 
-use serde::{de, Deserializer};
+use serde::{de, Deserializer, Serializer};
+
+use super::safe_float::f64_to_safe_integer;
 
 #[derive(Debug)]
 struct U64Visitor;
@@ -46,6 +51,16 @@ impl de::Visitor<'_> for U64Visitor {
             Ok(value as u64)
         }
     }
+
+    // Corrupted form left in Redis by a Lua cjson round-trip (e.g. 123.0).
+    // Values beyond 2^53 are rejected because precision was already lost.
+    fn visit_f64<E>(self, value: f64) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        let n = f64_to_safe_integer::<E>(value)?;
+        u64::try_from(n).map_err(de::Error::custom)
+    }
 }
 
 pub fn deserialize_u64<'de, D>(deserializer: D) -> Result<u64, D::Error>
@@ -53,6 +68,15 @@ where
     D: Deserializer<'de>,
 {
     deserializer.deserialize_any(U64Visitor)
+}
+
+/// Serialize a u64 as a JSON string so it survives a Redis/Lua `cjson`
+/// round-trip.
+pub fn serialize_u64<S>(value: &u64, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    serializer.serialize_str(&value.to_string())
 }
 
 #[cfg(test)]
@@ -112,5 +136,35 @@ mod tests {
         let deserializer = I64Deserializer::<ValueError>::new(input);
         let result = deserialize_u64(deserializer);
         assert!(result.is_err());
+    }
+
+    #[derive(serde::Serialize, serde::Deserialize, PartialEq, Debug)]
+    struct Wrapper {
+        #[serde(serialize_with = "serialize_u64", deserialize_with = "deserialize_u64")]
+        id: u64,
+    }
+
+    #[test]
+    fn serializes_as_string() {
+        let json = serde_json::to_string(&Wrapper {
+            id: 18446744073709551615,
+        })
+        .unwrap();
+        assert_eq!(json, r#"{"id":"18446744073709551615"}"#);
+    }
+
+    #[test]
+    fn deserializes_from_string_integer_and_corrupted_float() {
+        let from_str: Wrapper = serde_json::from_str(r#"{"id":"1099511627776"}"#).unwrap();
+        assert_eq!(from_str.id, 1099511627776);
+        let from_int: Wrapper = serde_json::from_str(r#"{"id":1099511627776}"#).unwrap();
+        assert_eq!(from_int.id, 1099511627776);
+        let from_float: Wrapper = serde_json::from_str(r#"{"id":1099511627776.0}"#).unwrap();
+        assert_eq!(from_float.id, 1099511627776);
+    }
+
+    #[test]
+    fn rejects_corrupted_float_beyond_safe_range() {
+        assert!(serde_json::from_str::<Wrapper>(r#"{"id":9007199254740993.0}"#).is_err());
     }
 }


### PR DESCRIPTION
# Summary

Fixes Stellar integer precision loss across Redis/Lua JSON round-trips by serializing large i64/u64 fields as decimal strings while preserving tolerant deserialization from legacy numeric values.

Also updates affected OpenAPI schemas, aligns Stellar transaction response sequence_number with Stellar/Horizon string semantics, and adds regression coverage for safe float recovery, string serialization, and Redis preservation of large Stellar fields.

## Testing Process

## Checklist

- [ ] Add a reference to related issues in the PR description.
- [x] Add unit tests if applicable.

> [!NOTE]
> If you are using Relayer in your stack, consider adding your team or organization to our list of [Relayer Users in the Wild](../INTHEWILD.md)!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed precision loss of large integer values (sequence numbers, transaction fees, memo IDs) in transaction data when stored and retrieved from Redis.
  * Enhanced backward compatibility to accept legacy and corrupted numeric formats.

* **API Changes**
  * Updated API schema to represent transaction amounts and memo IDs as strings instead of integers for improved precision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->