### PR TITLE
fix: honour status query param in list transactions endpoint

### DIFF
--- a/src/api/controllers/relayer.rs
+++ b/src/api/controllers/relayer.rs
@@ -24,7 +24,7 @@ use crate::{
         },
         ApiError, ApiResponse, CreateRelayerRequest, DefaultAppState, NetworkRepoModel,
         NetworkTransactionRequest, NetworkType, NotificationRepoModel, PaginationMeta,
-        PaginationQuery, Relayer as RelayerDomainModel, RelayerRepoModel, RelayerRepoUpdater,
+        PaginationQuery, TransactionListQuery, Relayer as RelayerDomainModel, RelayerRepoModel, RelayerRepoUpdater,
         RelayerResponse, Signer as SignerDomainModel, SignerRepoModel, ThinDataAppState,
         TransactionRepoModel, TransactionResponse, TransactionStatus, UpdateRelayerRequestRaw,
     },
@@ -540,7 +540,7 @@ where
 /// A paginated list of transactions
 pub async fn list_transactions<J, RR, TR, NR, NFR, SR, TCR, PR, AKR>(
     relayer_id: String,
-    query: PaginationQuery,
+    query: TransactionListQuery,
     state: ThinDataAppState<J, RR, TR, NR, NFR, SR, TCR, PR, AKR>,
 ) -> Result<HttpResponse, ApiError>
 where
@@ -556,10 +556,21 @@ where
 {
     get_relayer_by_id(relayer_id.clone(), &state).await?;
 
-    let transactions = state
-        .transaction_repository
-        .find_by_relayer_id(&relayer_id, query)
-        .await?;
+    let pagination = PaginationQuery::from(query.clone());
+    let transactions = match query.status {
+        Some(status) => {
+            state
+                .transaction_repository
+                .find_by_status_paginated(&relayer_id, &[status], pagination, false)
+                .await?
+        }
+        None => {
+            state
+                .transaction_repository
+                .find_by_relayer_id(&relayer_id, pagination)
+                .await?
+        }
+    };
 
     let transaction_response_list: Vec<TransactionResponse> =
         transactions.items.into_iter().map(|t| t.into()).collect();

--- a/src/api/routes/relayer.rs
+++ b/src/api/routes/relayer.rs
@@ -8,7 +8,7 @@ use crate::{
         transaction::request::{
             SponsoredTransactionBuildRequest, SponsoredTransactionQuoteRequest,
         },
-        CreateRelayerRequest, DefaultAppState, PaginationQuery,
+        CreateRelayerRequest, DefaultAppState, PaginationQuery, TransactionListQuery,
     },
 };
 use actix_web::{delete, get, patch, post, put, web, Responder};
@@ -115,11 +115,11 @@ async fn get_transaction_by_nonce(
     relayer::get_transaction_by_nonce(params.0, params.1, data).await
 }
 
-/// Lists all transactions for a specific relayer with pagination.
+/// Lists all transactions for a specific relayer with pagination and optional status filter.
 #[get("/relayers/{relayer_id}/transactions")]
 async fn list_transactions(
     relayer_id: web::Path<String>,
-    query: web::Query<PaginationQuery>,
+    query: web::Query<TransactionListQuery>,
     data: web::ThinData<DefaultAppState>,
 ) -> impl Responder {
     relayer::list_transactions(relayer_id.into_inner(), query.into_inner(), data).await

--- a/src/models/pagination.rs
+++ b/src/models/pagination.rs
@@ -1,3 +1,4 @@
+use crate::models::TransactionStatus;
 use serde::Deserialize;
 use utoipa::ToSchema;
 
@@ -7,6 +8,25 @@ pub struct PaginationQuery {
     pub page: u32,
     #[serde(default = "default_per_page")]
     pub per_page: u32,
+}
+
+/// Pagination + optional status filter for listing transactions.
+#[derive(Debug, Deserialize, Clone, ToSchema)]
+pub struct TransactionListQuery {
+    #[serde(default = "default_page")]
+    pub page: u32,
+    #[serde(default = "default_per_page")]
+    pub per_page: u32,
+    pub status: Option<TransactionStatus>,
+}
+
+impl From<TransactionListQuery> for PaginationQuery {
+    fn from(q: TransactionListQuery) -> Self {
+        PaginationQuery {
+            page: q.page,
+            per_page: q.per_page,
+        }
+    }
 }
 
 fn default_page() -> u32 {


### PR DESCRIPTION
## Summary

- `GET /relayers/{id}/transactions?status=Sent` (and any other status value) was silently ignored — the endpoint always returned all transactions for the relayer regardless of the requested status.
- Root cause: `PaginationQuery` only had `page` / `per_page` fields. The `?status=` parameter was unknown to the deserializer and dropped. The controller called `find_by_relayer_id`, which applies no status filter.

## Changes

**`src/models/pagination.rs`**
- Add `TransactionListQuery` — a copy of `PaginationQuery` extended with an optional `status: Option<TransactionStatus>` field.
- Add `From<TransactionListQuery> for PaginationQuery` for ergonomic conversion.

**`src/api/routes/relayer.rs`**
- `list_transactions` route now deserialises `TransactionListQuery` instead of `PaginationQuery`.

**`src/api/controllers/relayer.rs`**
- `list_transactions` accepts `TransactionListQuery` and branches on the presence of a status filter:
  - **status present**: delegates to the existing `find_by_status_paginated`, which uses the per-status sorted sets already maintained by the repository for efficient indexed lookups.
  - **status absent**: delegates to `find_by_relayer_id` as before.

No repository changes are required; both methods already exist on `TransactionRepository`.

## Test plan

- [ ] All existing unit tests pass (`cargo test --lib`).
- [ ] `GET /relayers/{id}/transactions?status=Sent` returns only `Sent` transactions.
- [ ] `GET /relayers/{id}/transactions` (no filter) still returns all transactions.
- [ ] `GET /relayers/{id}/transactions?status=Failed` returns only `Failed` transactions.
- [ ] Pagination (`page` / `per_page`) works correctly in both filtered and unfiltered modes.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Transaction listing endpoint now supports optional status-based filtering in addition to pagination. Users can filter transactions by status when querying transaction lists through the relayer API, providing improved control over transaction retrieval and more efficient data management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->