### PR TITLE
test: Verify codecov-action v6.0.2 upload (throwaway, do not merge)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -248,7 +248,7 @@ jobs:
 
       # Upload coverage reports
       - name: Upload AI Coverage to Codecov
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2  # v6.0.0
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v6.0.2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           name: ai-coverage
@@ -256,7 +256,7 @@ jobs:
           flags: ai
           fail_ci_if_error: true
       - name: Upload Developer Coverage to Codecov
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2  # v6.0.0
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v6.0.2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           name: dev-coverage
@@ -322,7 +322,7 @@ jobs:
           CARGO_PROFILE_DEV_DEBUG: 1
         run: cargo hack llvm-cov --locked --ignore-filename-regex "(src/api/routes/docs/.*_docs\.rs$|src/repositories/.*/.*_redis\.rs$)" --lcov --output-path properties-lcov.info --test properties
       - name: Upload Properties Coverage to Codecov
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2  # v6.0.0
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v6.0.2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           name: properties-coverage

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 //! Top-level crate documentation.
+//! (CI smoke test: verify codecov-action v6.0.2 pin uploads — revert before merge)
 //! # OpenZeppelin Relayer
 //!
 //! A blockchain transaction relayer service that supports multiple networks


### PR DESCRIPTION
## Summary
Throwaway PR to exercise CI for #794. The codecov-action SHA bump in #794 only touches `.github/**`, which the CI workflow's `paths-ignore` skips entirely — so the three codecov upload steps never ran.

This branch is #794 + a one-line `.rs` doc-comment change, which makes the workflow run AND flips `changed-tests-files`, triggering the coverage jobs that contain the uploads.

**Note:** `v6.0.2` upstream actually resolves to codecov-action 7.0.0 content (codecov tag mix-up), so this also de-risks that major-version behavior.

**Do not merge.** Close + delete branch once the codecov upload steps pass.

## Testing
This PR *is* the test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Codecov GitHub Action to v6.0.2 in CI workflow.
  * Updated internal documentation referencing the Codecov tooling version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->