### PR TITLE
feat: Vault Transit secrets engine signer support for Stellar

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ The repository includes several ready-to-use examples to help you get started wi
 | [`basic-example-metrics`](./examples/basic-example-metrics/)                         | Setup with Prometheus and Grafana metrics                |
 | [`vault-secret-signer`](./examples/vault-secret-signer/)                             | Using HashiCorp Vault for key management                 |
 | [`vault-transit-signer`](./examples/vault-transit-signer/)                           | Using Vault Transit for secure signing                   |
+| [`stellar-vault-transit-signer`](./examples/stellar-vault-transit-signer/)           | Using Vault Transit for Stellar secure signing           |
 | [`evm-azure-key-vault-signer`](./examples/evm-azure-key-vault-signer/)               | Using Azure Key Vault for EVM secure signing             |
 | [`evm-turnkey-signer`](./examples/evm-turnkey-signer/)                               | Using Turnkey Signer for EVM secure signing              |
 | [`solana-turnkey-signer`](./examples/solana-turnkey-signer/)                         | Using Turnkey Signer for Solana secure signing           |

--- a/docs/configuration/signers.mdx
+++ b/docs/configuration/signers.mdx
@@ -48,7 +48,7 @@ The following table shows which signer types are compatible with each network ty
 | --- | --- | --- | --- |
 | `local` | ✅ Supported | ✅ Supported | ✅ Supported |
 | `vault` | ✅ Supported | ✅ Supported | ❌ Not supported |
-| `vault_transit` | ❌ Not supported | ✅ Supported | ❌ Not supported |
+| `vault_transit` | ❌ Not supported | ✅ Supported | ✅ Supported |
 | `turnkey` | ✅ Supported | ✅ Supported | ✅ Supported |
 | `google_cloud_kms` | ✅ Supported | ✅ Supported | ✅ Supported |
 | `aws_kms` | ✅ Supported | ✅ Supported | ✅ Supported |
@@ -62,7 +62,7 @@ The following table shows which signer types are compatible with each network ty
 
 * ***EVM Networks***: Use secp256k1 cryptography. Most signers support EVM networks with proper key generation.
 * ***Solana Networks***: Use ed25519 cryptography. Ensure your signer supports ed25519 key generation and signing.
-* ***Stellar Networks***: Use ed25519 cryptography with specific Stellar requirements. Supported by local, AWS KMS, Google Cloud KMS, and Turnkey signers.
+* ***Stellar Networks***: Use ed25519 cryptography with specific Stellar requirements. Supported by local, Vault Transit, AWS KMS, Google Cloud KMS, and Turnkey signers.
 * ***AWS KMS***: Supports secp256k1 (EVM) and ed25519 (Solana, Stellar) key types.
 * ***Azure Key Vault***: Supports EVM networks with secp256k1 keys stored in Azure Key Vault.
 * ***Google Cloud KMS***: Supports secp256k1 (EVM) and ed25519 (Solana, Stellar) key types.
@@ -179,7 +179,12 @@ Configuration fields:
 | key_name | String | The name of the cryptographic key within Vault’s Transit engine that is used for signing operations |
 | mount_point | String | The mount point for the Transit secrets engine in Vault. Defaults to `transit` if not explicitly specified. Optional. |
 | namespace | String | The Vault namespace for API calls. This is used only in Vault Enterprise environments. Optional. |
-| pubkey | String | Public key of the cryptographic key within Vault’s Transit engine that is used for signing operations |
+| pubkey | String | Public key of the cryptographic key within Vault’s Transit engine that is used for signing operations. For Solana and Stellar, provide the raw Ed25519 public key encoded in standard base64 as returned by Vault Transit |
+
+Vault Transit-specific requirements:
+* Supported for Solana and Stellar networks
+* Use an Ed25519 key in Vault Transit
+* Grant the configured AppRole permission to sign with the Transit key
 
 ## Turnkey Signer Configuration
 
@@ -441,5 +446,11 @@ Configuration fields:
 * Verify Vault server address and network connectivity
 * Check AppRole credentials and permissions
 * Ensure the secret/transit engine is properly mounted and configured
+
+***Vault Transit signing failures***
+
+* Confirm the Transit key is an Ed25519 key and the configured `pubkey` matches the key exported by Vault
+* Verify the AppRole policy allows `update` on the Transit signing path for the configured key
+* Check that the Transit mount point is correct if you are not using the default `transit`
 
 For additional troubleshooting help, check the application logs and refer to the specific cloud provider or service documentation.

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -218,6 +218,7 @@ For quick setup with various configurations, check the [examples directory](http
 * `basic-example-metrics`: Setup with Prometheus and Grafana metrics
 * `vault-secret-signer`: Using HashiCorp Vault for key management
 * `vault-transit-signer`: Using Vault Transit for secure signing
+* `stellar-vault-transit-signer`: Using Vault Transit for Stellar secure signing
 * `evm-gcp-kms-signer`: Using Google Cloud KMS for EVM secure signing
 * `evm-turnkey-signer`: Using Turnkey for EVM secure signing
 * `solana-turnkey-signer`:  Using Turnkey for Solana secure signing

--- a/docs/stellar.mdx
+++ b/docs/stellar.mdx
@@ -526,12 +526,16 @@ Soroban operations support different authorization modes:
 Stellar networks support the following signer types:
 
 * ***Local Signer***: Uses encrypted keystore files (suitable for development)
+* ***Vault Transit***: Uses HashiCorp Vault Transit with an Ed25519 key for hosted signing
+* ***AWS KMS***: Uses AWS Key Management Service with Ed25519 keys (recommended for production)
 * ***Google Cloud KMS***: Uses Google Cloud Key Management Service with ED25519 keys (recommended for production)
 * ***Turnkey***: Uses Turnkey’s secure key management infrastructure with ED25519 keys (recommended for production)
 
 For detailed signer configuration, see the [Signers Configuration](/relayer/configuration/signers) guide.
 
 For complete examples:
+- Vault Transit: [vault-transit-signer example](https://github.com/OpenZeppelin/openzeppelin-relayer/tree/main/examples/vault-transit-signer)
+- AWS KMS: [aws-kms-signer example](https://github.com/OpenZeppelin/openzeppelin-relayer/tree/main/examples/aws-kms-signer)
 - Google Cloud KMS: [stellar-gcp-kms-signer example](https://github.com/OpenZeppelin/openzeppelin-relayer/tree/main/examples/stellar-gcp-kms-signer)
 - Turnkey: [stellar-turnkey-signer example](https://github.com/OpenZeppelin/openzeppelin-relayer/tree/main/examples/stellar-turnkey-signer)
 

--- a/docs/stellar.mdx
+++ b/docs/stellar.mdx
@@ -535,7 +535,7 @@ For detailed signer configuration, see the [Signers Configuration](/relayer/conf
 
 For complete examples:
 - Vault Transit: [vault-transit-signer example](https://github.com/OpenZeppelin/openzeppelin-relayer/tree/main/examples/vault-transit-signer)
-- AWS KMS: [aws-kms-signer example](https://github.com/OpenZeppelin/openzeppelin-relayer/tree/main/examples/aws-kms-signer)
+- AWS KMS: [aws-kms-signer example](https://github.com/OpenZeppelin/openzeppelin-relayer/tree/main/examples/evm-aws-kms-signer)
 - Google Cloud KMS: [stellar-gcp-kms-signer example](https://github.com/OpenZeppelin/openzeppelin-relayer/tree/main/examples/stellar-gcp-kms-signer)
 - Turnkey: [stellar-turnkey-signer example](https://github.com/OpenZeppelin/openzeppelin-relayer/tree/main/examples/stellar-turnkey-signer)
 

--- a/examples/stellar-vault-transit-signer/.env.example
+++ b/examples/stellar-vault-transit-signer/.env.example
@@ -1,0 +1,10 @@
+# Redis Configuration
+REDIS_URL=redis://redis:6379
+
+# API Configuration
+API_KEY=
+WEBHOOK_SIGNING_KEY=
+
+# Vault Transit AppRole Configuration
+VAULT_ROLE_ID=
+VAULT_SECRET_ID=

--- a/examples/stellar-vault-transit-signer/README.md
+++ b/examples/stellar-vault-transit-signer/README.md
@@ -1,0 +1,213 @@
+# Using HashiCorp Vault Transit for Secure Stellar Transaction Signing in OpenZeppelin Relayer
+
+This example demonstrates how to use HashiCorp Vault's Transit engine to securely sign Stellar transactions in OpenZeppelin Relayer. It uses a Stellar testnet relayer with a Vault Transit Ed25519 key, and includes a Docker Compose setup with Vault running in development mode.
+
+> **Note:** This example uses Vault in development mode, which is not suitable for production. For production deployments, use a properly configured and sealed Vault instance with appropriate security controls.
+
+## Prerequisites
+
+1. [Docker](https://docs.docker.com/get-docker/)
+2. [Docker Compose](https://docs.docker.com/compose/install/)
+3. [HashiCorp Vault CLI](https://developer.hashicorp.com/vault/tutorials/get-started/install-binary?productSlug=vault&tutorialSlug=getting-started&tutorialSlug=getting-started-install) (optional but recommended)
+4. Rust and Cargo installed
+5. Git
+
+## Getting Started
+
+### Step 1: Clone the Repository
+
+```bash
+git clone https://github.com/OpenZeppelin/openzeppelin-relayer
+cd openzeppelin-relayer
+```
+
+### Step 2: Start Vault
+
+Start the Vault service:
+
+```bash
+docker compose -f examples/stellar-vault-transit-signer/docker-compose.yaml up vault
+```
+
+Vault will run in dev mode and be available at [http://localhost:8200](http://localhost:8200).
+
+### Step 3: Configure the Vault CLI
+
+If you have the Vault CLI installed, point it at the dev server:
+
+```bash
+export VAULT_ADDR='http://0.0.0.0:8200'
+export VAULT_TOKEN='dev-only-token'
+```
+
+### Step 4: Enable Transit and Create a Stellar Signing Key
+
+Enable the Transit engine:
+
+```bash
+vault secrets enable transit
+```
+
+Create an exportable Ed25519 signing key:
+
+```bash
+vault write -f transit/keys/my_signing_key type=ed25519 exportable=true
+```
+
+### Step 5: Create the Vault Policy
+
+Create a policy that allows signing and verification with the Transit key:
+
+```bash
+vault policy write transit-sign-policy -<<EOF
+path "transit/sign/my_signing_key" {
+  capabilities = ["update"]
+}
+
+path "transit/verify/my_signing_key" {
+  capabilities = ["update"]
+}
+EOF
+```
+
+### Step 6: Enable AppRole Authentication
+
+```bash
+vault auth enable approle
+```
+
+Create an AppRole for the relayer:
+
+```bash
+vault write auth/approle/role/my-role \
+  policies="transit-sign-policy" \
+  token_ttl=1h \
+  token_max_ttl=4h
+```
+
+### Step 7: Retrieve the Role ID, Secret ID, and Base64 Public Key
+
+Retrieve the AppRole `role_id`:
+
+```bash
+vault read auth/approle/role/my-role/role-id
+```
+
+Generate a `secret_id`:
+
+```bash
+vault write -f auth/approle/role/my-role/secret-id
+```
+
+Retrieve the Transit public key from Vault. In the Vault UI, open `transit/my_signing_key`, choose the key version, and copy the public key value.
+
+For this Stellar signer, the `pubkey` field in the relayer config must contain the raw Ed25519 public key encoded as standard base64.
+
+### Step 8: Configure the Relayer Files
+
+Copy the environment example:
+
+```bash
+cp examples/stellar-vault-transit-signer/.env.example examples/stellar-vault-transit-signer/.env
+```
+
+Update `examples/stellar-vault-transit-signer/.env`:
+
+```env
+VAULT_ROLE_ID=your_role_id
+VAULT_SECRET_ID=your_secret_id
+```
+
+Update `examples/stellar-vault-transit-signer/config/config.json` and set the signer `pubkey` to the base64 public key from Vault.
+
+### Step 9: Generate API and Webhook Keys
+
+Generate an API key:
+
+```bash
+cargo run --example generate_uuid
+```
+
+Generate a webhook signing key:
+
+```bash
+cargo run --example generate_uuid
+```
+
+Add both values to `examples/stellar-vault-transit-signer/.env`:
+
+```env
+API_KEY=generated_api_key
+WEBHOOK_SIGNING_KEY=generated_webhook_key
+```
+
+### Step 10: Configure the Webhook URL
+
+Update `examples/stellar-vault-transit-signer/config/config.json` and set `notifications[0].url`.
+
+For testing, you can use [Webhook.site](https://webhook.site).
+
+### Step 11: Start the Relayer and Redis
+
+```bash
+docker compose -f examples/stellar-vault-transit-signer/docker-compose.yaml up -d
+```
+
+### Step 12: Test the Relayer
+
+Check that the relayer is running:
+
+```bash
+curl -X GET http://localhost:8080/api/v1/relayers \
+  -H "Content-Type: application/json" \
+  -H "AUTHORIZATION: Bearer YOUR_API_KEY"
+```
+
+This should return the Stellar relayer and its address derived from the Vault Transit public key.
+
+### Step 13: Test a Stellar Payment Transaction
+
+Submit a Stellar testnet payment transaction:
+
+```bash
+curl -X POST http://localhost:8080/api/v1/relayers/stellar-example/transactions \
+  -H "Content-Type: application/json" \
+  -H "AUTHORIZATION: Bearer YOUR_API_KEY" \
+  -d '{
+    "network": "testnet",
+    "operations": [
+      {
+        "type": "payment",
+        "destination": "GDESTINATION_ADDRESS_HERE",
+        "asset": { "type": "native" },
+        "amount": 1000000
+      }
+    ],
+    "memo": { "type": "text", "value": "Vault Transit test payment" }
+  }'
+```
+
+This creates a payment of `0.1 XLM` (`1,000,000` stroops) on Stellar testnet, signs it through Vault Transit, and submits it through the relayer.
+
+## Troubleshooting
+
+1. **Vault connection issues**
+   - Verify `VAULT_ROLE_ID` and `VAULT_SECRET_ID`
+   - Confirm Vault is reachable at `http://localhost:8200`
+   - Ensure the Transit engine is mounted at `transit`
+
+2. **Signing failures**
+   - Confirm the Transit key is Ed25519
+   - Verify the policy grants `update` access to `transit/sign/my_signing_key`
+   - Check that the configured `pubkey` is the raw Ed25519 public key in standard base64
+
+3. **Stellar transaction issues**
+   - Make sure the destination account is a valid Stellar address
+   - Ensure the relayer account has testnet funds before submitting transactions
+
+## Additional Resources
+
+- [HashiCorp Vault Documentation](https://www.vaultproject.io/docs/)
+- [AppRole Authentication](https://developer.hashicorp.com/vault/docs/auth/approle)
+- [Stellar Documentation](https://developers.stellar.org/)
+- [OpenZeppelin Relayer Documentation](https://docs.openzeppelin.com/relayer)

--- a/examples/stellar-vault-transit-signer/README.md
+++ b/examples/stellar-vault-transit-signer/README.md
@@ -36,7 +36,7 @@ Vault will run in dev mode and be available at [http://localhost:8200](http://lo
 If you have the Vault CLI installed, point it at the dev server:
 
 ```bash
-export VAULT_ADDR='http://0.0.0.0:8200'
+export VAULT_ADDR='http://127.0.0.1:8200'
 export VAULT_TOKEN='dev-only-token'
 ```
 

--- a/examples/stellar-vault-transit-signer/config/config.json
+++ b/examples/stellar-vault-transit-signer/config/config.json
@@ -40,7 +40,7 @@
           "value": "VAULT_SECRET_ID"
         },
         "key_name": "my_signing_key",
-        "pubkey": ""
+        "pubkey": "REPLACE_WITH_BASE64_ED25519_PUBLIC_KEY"
       }
     }
   ],

--- a/examples/stellar-vault-transit-signer/config/config.json
+++ b/examples/stellar-vault-transit-signer/config/config.json
@@ -1,0 +1,49 @@
+{
+  "relayers": [
+    {
+      "id": "stellar-example",
+      "name": "Stellar Testnet Example",
+      "network": "testnet",
+      "paused": false,
+      "notification_id": "notification-example",
+      "signer_id": "stellar-vault-transit-signer",
+      "network_type": "stellar",
+      "policies": {
+        "min_balance": 0,
+        "fee_payment_strategy": "relayer"
+      }
+    }
+  ],
+  "notifications": [
+    {
+      "id": "notification-example",
+      "type": "webhook",
+      "url": "",
+      "signing_key": {
+        "type": "env",
+        "value": "WEBHOOK_SIGNING_KEY"
+      }
+    }
+  ],
+  "signers": [
+    {
+      "id": "stellar-vault-transit-signer",
+      "type": "vault_transit",
+      "config": {
+        "address": "http://vault:8200",
+        "role_id": {
+          "type": "env",
+          "value": "VAULT_ROLE_ID"
+        },
+        "secret_id": {
+          "type": "env",
+          "value": "VAULT_SECRET_ID"
+        },
+        "key_name": "my_signing_key",
+        "pubkey": ""
+      }
+    }
+  ],
+  "networks": "./config/networks",
+  "plugins": []
+}

--- a/examples/stellar-vault-transit-signer/docker-compose.yaml
+++ b/examples/stellar-vault-transit-signer/docker-compose.yaml
@@ -1,0 +1,80 @@
+---
+services:
+  relayer:
+    build:
+      context: ../../
+      dockerfile: Dockerfile.development
+    ports:
+      - 8080:8080/tcp
+    secrets:
+      - api_key
+      - webhook_signing_key
+      - keystore_passphrase
+    environment:
+      REDIS_URL: ${REDIS_URL}
+      RATE_LIMIT_REQUESTS_PER_SECOND: 10
+      RATE_LIMIT_BURST: 50
+      WEBHOOK_SIGNING_KEY: ${WEBHOOK_SIGNING_KEY}
+      API_KEY: ${API_KEY}
+    security_opt:
+      - no-new-privileges
+    networks:
+      - relayer-network
+      - metrics-network
+    volumes:
+      - ./config:/app/config/
+      - ../../config/networks:/app/config/networks
+    depends_on:
+      - redis
+    restart: on-failure:5
+  redis:
+    image: redis:bookworm
+    security_opt:
+      - no-new-privileges
+    volumes:
+      - redis_data:/data
+    command:
+      - redis-server
+      - --appendonly
+      - 'yes'
+      - --save
+      - '60'
+      - '1'
+    networks:
+      - relayer-network
+      - metrics-network
+    restart: on-failure:5
+  vault:
+    image: hashicorp/vault:1.19.0
+    platform: linux/amd64
+    ports:
+      - 8200:8200
+    environment:
+      - VAULT_DEV_ROOT_TOKEN_ID=dev-only-token
+    cap_add:
+      - IPC_LOCK
+    networks:
+      - relayer-network
+    command:
+      - vault
+      - server
+      - -dev
+      - -dev-listen-address=0.0.0.0:8200
+    restart: on-failure
+networks:
+  metrics-network:
+    internal: true
+  relayer-network:
+    driver: bridge
+volumes:
+  redis_data:
+    driver: local
+  vault-data:
+    driver: local
+secrets:
+  api_key:
+    environment: API_KEY
+  webhook_signing_key:
+    environment: WEBHOOK_SIGNING_KEY
+  keystore_passphrase:
+    environment: KEYSTORE_PASSPHRASE

--- a/examples/stellar-vault-transit-signer/docker-compose.yaml
+++ b/examples/stellar-vault-transit-signer/docker-compose.yaml
@@ -26,6 +26,7 @@ services:
       - ../../config/networks:/app/config/networks
     depends_on:
       - redis
+      - vault
     restart: on-failure:5
   redis:
     image: redis:bookworm

--- a/examples/stellar-vault-transit-signer/docker-compose.yaml
+++ b/examples/stellar-vault-transit-signer/docker-compose.yaml
@@ -49,7 +49,7 @@ services:
     image: hashicorp/vault:1.19.0
     platform: linux/amd64
     ports:
-      - 8200:8200
+      - "127.0.0.1:8200:8200"
     environment:
       - VAULT_DEV_ROOT_TOKEN_ID=dev-only-token
     cap_add:

--- a/examples/vault-transit-signer/README.md
+++ b/examples/vault-transit-signer/README.md
@@ -34,7 +34,7 @@ docker compose -f examples/vault-transit-signer/docker-compose.yaml up vault
 
 ```
 
-Vault will run in dev mode and bind to `0.0.0.0:8200`. You can access its UI by navigating to [http://localhost:8200](http://localhost:8200) in your browser.
+Vault will run in dev mode and bind to `127.0.0.1:8200`. You can access its UI by navigating to [http://localhost:8200](http://localhost:8200) in your browser.
 
 
 ### Step 3: Install and Configure the Vault CLI (Optional)
@@ -44,7 +44,7 @@ If you haven't already, install the Vault CLI by following the instructions in t
 Set the necessary environment variables so that your CLI can communicate with Vault:
 
 ```bash
-export VAULT_ADDR='http://0.0.0.0:8200'
+export VAULT_ADDR='http://127.0.0.1:8200'
 export VAULT_TOKEN='dev-only-token'  # This is the default token for dev mode defined in docker-compose fi;e
 ```
 

--- a/examples/vault-transit-signer/config/config.json
+++ b/examples/vault-transit-signer/config/config.json
@@ -44,7 +44,7 @@
           "value": "VAULT_SECRET_ID"
         },
         "key_name": "my_signing_key",
-        "pubkey": ""
+        "pubkey": "REPLACE_WITH_BASE64_ED25519_PUBLIC_KEY"
       }
     }
   ],

--- a/src/services/signer/solana/vault_transit_signer.rs
+++ b/src/services/signer/solana/vault_transit_signer.rs
@@ -103,7 +103,8 @@ impl<T: VaultServiceTrait> SolanaSignTrait for VaultTransitSigner<T> {
         debug!(vault_signature_str = %vault_signature_str, "vault signature string");
 
         let base64_sig = vault_signature_str
-            .strip_prefix("vault:v1:")
+            .rsplit_once(':')
+            .map(|(_, sig)| sig)
             .unwrap_or(&vault_signature_str);
 
         let sig_bytes = base64_decode(base64_sig)
@@ -198,6 +199,36 @@ mod tests {
 
         assert!(result.is_ok());
         let signature = result.unwrap();
+        assert_eq!(signature.as_ref(), &mock_sig_bytes);
+    }
+
+    #[tokio::test]
+    async fn test_sign_with_v2_vault_response() {
+        let mut mock_vault_service = MockVaultServiceTrait::new();
+        let key_name = "test-key";
+        let test_message = b"hello world";
+
+        let mock_sig_bytes = [1u8; 64];
+        let mock_sig_base64 = base64::engine::general_purpose::STANDARD.encode(mock_sig_bytes);
+        let mock_vault_signature = format!("vault:v2:{mock_sig_base64}");
+
+        mock_vault_service
+            .expect_sign()
+            .with(eq(key_name), eq(test_message.to_vec()))
+            .times(1)
+            .returning(move |_, _| {
+                let mock_vault_signature = mock_vault_signature.clone();
+                Box::pin(async move { Ok(mock_vault_signature) })
+            });
+
+        let signer = VaultTransitSigner::new_for_testing(
+            key_name.to_string(),
+            "9zzYYGQM9prm/xXgn6Vwas/TVgteDaACCm1zW1ouKQs=".to_string(),
+            mock_vault_service,
+        );
+
+        let signature = signer.sign(test_message).await.unwrap();
+
         assert_eq!(signature.as_ref(), &mock_sig_bytes);
     }
 

--- a/src/services/signer/stellar/mod.rs
+++ b/src/services/signer/stellar/mod.rs
@@ -156,6 +156,7 @@ impl StellarSignTrait for StellarSigner {
 pub struct StellarSignerFactory;
 
 impl StellarSignerFactory {
+    /// Creates a Stellar signer implementation from the provided signer configuration.
     pub async fn create_stellar_signer(
         m: SignerDomainModel,
     ) -> Result<StellarSigner, SignerFactoryError> {
@@ -221,7 +222,13 @@ impl StellarSignerFactory {
                     token_ttl: None,
                 });
 
-                StellarSigner::VaultTransit(VaultTransitSigner::new(m, vault_service))
+                StellarSigner::VaultTransit(VaultTransitSigner::new(m, vault_service).map_err(
+                    |e| {
+                        SignerFactoryError::InvalidConfig(format!(
+                            "Failed to create Vault Transit signer: {e}"
+                        ))
+                    },
+                )?)
             }
             SignerConfig::AzureKeyVault(_) => {
                 return Err(SignerFactoryError::UnsupportedType(
@@ -237,6 +244,105 @@ impl StellarSignerFactory {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::models::{
+        AzureKeyVaultSignerConfig, LocalSignerConfig, SecretString, StellarTransactionData,
+        TransactionInput, TurnkeySignerConfig, VaultTransitSignerConfig,
+    };
+    use base64::Engine;
+    use secrets::SecretVec;
+    use soroban_rs::xdr::{
+        Limits, SequenceNumber, TransactionEnvelope, TransactionV0, TransactionV0Envelope, Uint256,
+        WriteXdr,
+    };
+
+    /// Returns deterministic private key bytes for local Stellar signer tests.
+    fn test_key_bytes() -> SecretVec<u8> {
+        let seed = [1u8; 32];
+        SecretVec::new(seed.len(), |v| v.copy_from_slice(&seed))
+    }
+
+    /// Builds a local Stellar signer model backed by deterministic test key material.
+    fn create_local_signer_model() -> SignerDomainModel {
+        SignerDomainModel {
+            id: "test".to_string(),
+            config: SignerConfig::Local(LocalSignerConfig {
+                raw_key: test_key_bytes(),
+            }),
+        }
+    }
+
+    /// Builds a Vault Transit signer model with deterministic public key material.
+    fn create_vault_transit_signer_model() -> SignerDomainModel {
+        let pubkey = base64::engine::general_purpose::STANDARD.encode([1u8; 32]);
+        SignerDomainModel {
+            id: "test".to_string(),
+            config: SignerConfig::VaultTransit(VaultTransitSignerConfig {
+                key_name: "test-key".to_string(),
+                address: "https://vault.test.com".to_string(),
+                namespace: None,
+                role_id: SecretString::new("test-role-id"),
+                secret_id: SecretString::new("test-secret-id"),
+                pubkey,
+                mount_point: None,
+            }),
+        }
+    }
+
+    /// Builds a Turnkey signer model with deterministic public key material.
+    fn create_turnkey_signer_model() -> SignerDomainModel {
+        SignerDomainModel {
+            id: "test".to_string(),
+            config: SignerConfig::Turnkey(TurnkeySignerConfig {
+                api_private_key: SecretString::new(
+                    "1111111111111111111111111111111111111111111111111111111111111111",
+                ),
+                api_public_key: "api-public-key".to_string(),
+                organization_id: "organization-id".to_string(),
+                private_key_id: "private-key-id".to_string(),
+                public_key: "0101010101010101010101010101010101010101010101010101010101010101"
+                    .to_string(),
+            }),
+        }
+    }
+
+    /// Creates a minimal unsigned Stellar transaction envelope encoded as base64 XDR.
+    fn create_unsigned_xdr(source_account: &str) -> String {
+        let source_pk = stellar_strkey::ed25519::PublicKey::from_string(source_account).unwrap();
+        let tx = TransactionV0 {
+            source_account_ed25519: Uint256(source_pk.0),
+            fee: 100,
+            seq_num: SequenceNumber(1),
+            time_bounds: None,
+            memo: soroban_rs::xdr::Memo::None,
+            operations: vec![].try_into().unwrap(),
+            ext: soroban_rs::xdr::TransactionV0Ext::V0,
+        };
+
+        TransactionEnvelope::TxV0(TransactionV0Envelope {
+            tx,
+            signatures: vec![].try_into().unwrap(),
+        })
+        .to_xdr_base64(Limits::none())
+        .unwrap()
+    }
+
+    /// Builds minimal Stellar transaction data for module-level dispatch tests.
+    fn create_stellar_transaction_data(source_account: String) -> StellarTransactionData {
+        StellarTransactionData {
+            source_account,
+            fee: Some(100),
+            sequence_number: Some(1),
+            transaction_input: TransactionInput::Operations(vec![]),
+            memo: None,
+            valid_until: None,
+            network_passphrase: "Test SDF Network ; September 2015".to_string(),
+            signatures: Vec::new(),
+            hash: None,
+            simulation_transaction_data: None,
+            signed_envelope_xdr: None,
+            transaction_result_xdr: None,
+        }
+    }
 
     #[test]
     fn test_derive_signature_hint_valid_stellar_address() {
@@ -293,5 +399,193 @@ mod tests {
         let address = Address::Solana("SomeBase58Address".to_string());
         let result = derive_signature_hint(&address);
         assert!(result.is_err());
+    }
+
+    #[test]
+    /// Verifies that the factory creates a local Stellar signer.
+    fn test_create_stellar_signer_local() {
+        let signer =
+            StellarSignerFactory::create_stellar_signer(&create_local_signer_model()).unwrap();
+
+        assert!(matches!(signer, StellarSigner::Local(_)));
+    }
+
+    #[test]
+    /// Verifies that the factory creates a Vault-backed Stellar signer.
+    fn test_create_stellar_signer_vault() {
+        let signer_model = SignerDomainModel {
+            id: "test".to_string(),
+            config: SignerConfig::Vault(VaultSignerConfig {
+                address: "https://vault.test.com".to_string(),
+                namespace: Some("test-namespace".to_string()),
+                role_id: SecretString::new("test-role-id"),
+                secret_id: SecretString::new("test-secret-id"),
+                key_name: "test-key".to_string(),
+                mount_point: Some("secret".to_string()),
+            }),
+        };
+
+        let signer = StellarSignerFactory::create_stellar_signer(&signer_model).unwrap();
+
+        assert!(matches!(signer, StellarSigner::Vault(_)));
+    }
+
+    #[test]
+    /// Verifies that the factory creates a Vault Transit Stellar signer.
+    fn test_create_stellar_signer_vault_transit() {
+        let signer =
+            StellarSignerFactory::create_stellar_signer(&create_vault_transit_signer_model())
+                .unwrap();
+
+        assert!(matches!(signer, StellarSigner::VaultTransit(_)));
+    }
+
+    #[test]
+    /// Verifies that the factory creates a Turnkey-backed Stellar signer.
+    fn test_create_stellar_signer_turnkey() {
+        let signer =
+            StellarSignerFactory::create_stellar_signer(&create_turnkey_signer_model()).unwrap();
+
+        assert!(matches!(signer, StellarSigner::Turnkey(_)));
+    }
+
+    #[test]
+    /// Verifies that Azure Key Vault remains unsupported for Stellar signers.
+    fn test_create_stellar_signer_azure_key_vault_unsupported() {
+        let signer_model = SignerDomainModel {
+            id: "test".to_string(),
+            config: SignerConfig::AzureKeyVault(AzureKeyVaultSignerConfig {
+                auth_type: None,
+                tenant_id: Some(SecretString::new("tenant-id")),
+                client_id: Some(SecretString::new("client-id")),
+                client_secret: Some(SecretString::new("client-secret")),
+                federated_token_file: None,
+                vault_url: SecretString::new("https://example.vault.azure.net"),
+                key_name: SecretString::new("test-key"),
+                key_version: None,
+            }),
+        };
+
+        let result = StellarSignerFactory::create_stellar_signer(&signer_model);
+
+        assert!(matches!(
+            result,
+            Err(SignerFactoryError::UnsupportedType(ref provider))
+                if provider == "Azure Key Vault"
+        ));
+    }
+
+    #[test]
+    /// Verifies that CDP remains unsupported for Stellar signers.
+    fn test_create_stellar_signer_cdp_unsupported() {
+        let signer_model = SignerDomainModel {
+            id: "test".to_string(),
+            config: SignerConfig::Cdp(crate::models::CdpSignerConfig {
+                api_key_id: "api-key-id".to_string(),
+                api_key_secret: SecretString::new("dGVzdA=="),
+                wallet_secret: SecretString::new("dGVzdA=="),
+                account_address: "0xb726167dc2ef2ac582f0a3de4c08ac4abb90626a".to_string(),
+            }),
+        };
+
+        let result = StellarSignerFactory::create_stellar_signer(&signer_model);
+
+        assert!(matches!(
+            result,
+            Err(SignerFactoryError::UnsupportedType(ref provider)) if provider == "CDP"
+        ));
+    }
+
+    #[tokio::test]
+    /// Verifies that address dispatch works for the local Stellar signer variant.
+    async fn test_stellar_signer_local_address_dispatch() {
+        let signer =
+            StellarSignerFactory::create_stellar_signer(&create_local_signer_model()).unwrap();
+
+        let address = signer.address().await.unwrap();
+
+        match address {
+            Address::Stellar(addr) => {
+                assert!(addr.starts_with('G'));
+                assert!(!addr.is_empty());
+            }
+            _ => panic!("Expected Stellar address"),
+        }
+    }
+
+    #[tokio::test]
+    /// Verifies that address dispatch works for the Vault Transit Stellar signer variant.
+    async fn test_stellar_signer_vault_transit_address_dispatch() {
+        let signer =
+            StellarSignerFactory::create_stellar_signer(&create_vault_transit_signer_model())
+                .unwrap();
+
+        let address = signer.address().await.unwrap();
+
+        match address {
+            Address::Stellar(addr) => {
+                assert!(addr.starts_with('G'));
+                assert_eq!(addr.len(), 56);
+            }
+            _ => panic!("Expected Stellar address"),
+        }
+    }
+
+    #[tokio::test]
+    /// Verifies that address dispatch works for the Turnkey Stellar signer variant.
+    async fn test_stellar_signer_turnkey_address_dispatch() {
+        let signer =
+            StellarSignerFactory::create_stellar_signer(&create_turnkey_signer_model()).unwrap();
+
+        let address = signer.address().await.unwrap();
+
+        match address {
+            Address::Stellar(addr) => {
+                assert!(addr.starts_with('G'));
+                assert_eq!(addr.len(), 56);
+            }
+            _ => panic!("Expected Stellar address"),
+        }
+    }
+
+    #[tokio::test]
+    /// Verifies that transaction signing dispatch works for the local Stellar signer variant.
+    async fn test_stellar_signer_local_sign_transaction_dispatch() {
+        let signer =
+            StellarSignerFactory::create_stellar_signer(&create_local_signer_model()).unwrap();
+        let source_account = signer.address().await.unwrap().to_string();
+
+        let result = signer
+            .sign_transaction(NetworkTransactionData::Stellar(
+                create_stellar_transaction_data(source_account),
+            ))
+            .await
+            .unwrap();
+
+        match result {
+            SignTransactionResponse::Stellar(response) => {
+                assert_eq!(response.signature.hint.0.len(), 4);
+                assert_eq!(response.signature.signature.0.len(), 64);
+            }
+            _ => panic!("Expected Stellar signature response"),
+        }
+    }
+
+    #[tokio::test]
+    /// Verifies that XDR signing dispatch works for the local Stellar signer variant.
+    async fn test_stellar_signer_local_sign_xdr_transaction_dispatch() {
+        let signer =
+            StellarSignerFactory::create_stellar_signer(&create_local_signer_model()).unwrap();
+        let source_account = signer.address().await.unwrap().to_string();
+        let unsigned_xdr = create_unsigned_xdr(&source_account);
+
+        let result = signer
+            .sign_xdr_transaction(&unsigned_xdr, "Test SDF Network ; September 2015")
+            .await
+            .unwrap();
+
+        assert!(!result.signed_xdr.is_empty());
+        assert_eq!(result.signature.hint.0.len(), 4);
+        assert_eq!(result.signature.signature.0.len(), 64);
     }
 }

--- a/src/services/signer/stellar/mod.rs
+++ b/src/services/signer/stellar/mod.rs
@@ -1,11 +1,12 @@
 // openzeppelin-relayer/src/services/signer/stellar/mod.rs
-//! Stellar signer implementation (local keystore, Google Cloud KMS, AWS KMS, and Turnkey)
+//! Stellar signer implementation (local keystore, Vault-backed signers, cloud KMS, and Turnkey)
 
 mod aws_kms_signer;
 mod google_cloud_kms_signer;
 mod local_signer;
 mod turnkey_signer;
 mod vault_signer;
+mod vault_transit_signer;
 
 use async_trait::async_trait;
 use aws_kms_signer::*;
@@ -13,6 +14,7 @@ use google_cloud_kms_signer::*;
 use local_signer::*;
 use turnkey_signer::*;
 use vault_signer::*;
+use vault_transit_signer::*;
 
 use soroban_rs::xdr::SignatureHint;
 
@@ -81,6 +83,7 @@ pub trait StellarSignTrait: Sync + Send {
 pub enum StellarSigner {
     Local(Box<LocalSigner>),
     Vault(VaultSigner<VaultService>),
+    VaultTransit(VaultTransitSigner),
     GoogleCloudKms(Box<GoogleCloudKmsSigner>),
     AwsKms(AwsKmsSigner),
     Turnkey(TurnkeySigner),
@@ -92,6 +95,7 @@ impl Signer for StellarSigner {
         match self {
             Self::Local(s) => s.address().await,
             Self::Vault(s) => s.address().await,
+            Self::VaultTransit(s) => s.address().await,
             Self::GoogleCloudKms(s) => s.address().await,
             Self::AwsKms(s) => s.address().await,
             Self::Turnkey(s) => s.address().await,
@@ -105,6 +109,7 @@ impl Signer for StellarSigner {
         match self {
             Self::Local(s) => s.sign_transaction(tx).await,
             Self::Vault(s) => s.sign_transaction(tx).await,
+            Self::VaultTransit(s) => s.sign_transaction(tx).await,
             Self::GoogleCloudKms(s) => s.sign_transaction(tx).await,
             Self::AwsKms(s) => s.sign_transaction(tx).await,
             Self::Turnkey(s) => s.sign_transaction(tx).await,
@@ -125,6 +130,10 @@ impl StellarSignTrait for StellarSigner {
                     .await
             }
             Self::Vault(s) => {
+                s.sign_xdr_transaction(unsigned_xdr, network_passphrase)
+                    .await
+            }
+            Self::VaultTransit(s) => {
                 s.sign_xdr_transaction(unsigned_xdr, network_passphrase)
                     .await
             }
@@ -199,13 +208,25 @@ impl StellarSignerFactory {
                 })?;
                 StellarSigner::AwsKms(AwsKmsSigner::new(aws_kms_service))
             }
+            SignerConfig::VaultTransit(config) => {
+                let vault_service = VaultService::new(VaultConfig {
+                    address: config.address.clone(),
+                    namespace: config.namespace.clone(),
+                    role_id: config.role_id.clone(),
+                    secret_id: config.secret_id.clone(),
+                    mount_path: config
+                        .mount_point
+                        .clone()
+                        .unwrap_or_else(|| "transit".to_string()),
+                    token_ttl: None,
+                });
+
+                StellarSigner::VaultTransit(VaultTransitSigner::new(m, vault_service))
+            }
             SignerConfig::AzureKeyVault(_) => {
                 return Err(SignerFactoryError::UnsupportedType(
                     "Azure Key Vault".into(),
                 ))
-            }
-            SignerConfig::VaultTransit(_) => {
-                return Err(SignerFactoryError::UnsupportedType("Vault Transit".into()))
             }
             SignerConfig::Cdp(_) => return Err(SignerFactoryError::UnsupportedType("CDP".into())),
         };

--- a/src/services/signer/stellar/mod.rs
+++ b/src/services/signer/stellar/mod.rs
@@ -222,7 +222,7 @@ impl StellarSignerFactory {
                     token_ttl: None,
                 });
 
-                StellarSigner::VaultTransit(VaultTransitSigner::new(m, vault_service).map_err(
+                StellarSigner::VaultTransit(VaultTransitSigner::new(&m, vault_service).map_err(
                     |e| {
                         SignerFactoryError::InvalidConfig(format!(
                             "Failed to create Vault Transit signer: {e}"
@@ -401,18 +401,19 @@ mod tests {
         assert!(result.is_err());
     }
 
-    #[test]
+    #[tokio::test]
     /// Verifies that the factory creates a local Stellar signer.
-    fn test_create_stellar_signer_local() {
-        let signer =
-            StellarSignerFactory::create_stellar_signer(&create_local_signer_model()).unwrap();
+    async fn test_create_stellar_signer_local() {
+        let signer = StellarSignerFactory::create_stellar_signer(create_local_signer_model())
+            .await
+            .unwrap();
 
         assert!(matches!(signer, StellarSigner::Local(_)));
     }
 
-    #[test]
+    #[tokio::test]
     /// Verifies that the factory creates a Vault-backed Stellar signer.
-    fn test_create_stellar_signer_vault() {
+    async fn test_create_stellar_signer_vault() {
         let signer_model = SignerDomainModel {
             id: "test".to_string(),
             config: SignerConfig::Vault(VaultSignerConfig {
@@ -425,33 +426,37 @@ mod tests {
             }),
         };
 
-        let signer = StellarSignerFactory::create_stellar_signer(&signer_model).unwrap();
+        let signer = StellarSignerFactory::create_stellar_signer(signer_model)
+            .await
+            .unwrap();
 
         assert!(matches!(signer, StellarSigner::Vault(_)));
     }
 
-    #[test]
+    #[tokio::test]
     /// Verifies that the factory creates a Vault Transit Stellar signer.
-    fn test_create_stellar_signer_vault_transit() {
+    async fn test_create_stellar_signer_vault_transit() {
         let signer =
-            StellarSignerFactory::create_stellar_signer(&create_vault_transit_signer_model())
+            StellarSignerFactory::create_stellar_signer(create_vault_transit_signer_model())
+                .await
                 .unwrap();
 
         assert!(matches!(signer, StellarSigner::VaultTransit(_)));
     }
 
-    #[test]
+    #[tokio::test]
     /// Verifies that the factory creates a Turnkey-backed Stellar signer.
-    fn test_create_stellar_signer_turnkey() {
-        let signer =
-            StellarSignerFactory::create_stellar_signer(&create_turnkey_signer_model()).unwrap();
+    async fn test_create_stellar_signer_turnkey() {
+        let signer = StellarSignerFactory::create_stellar_signer(create_turnkey_signer_model())
+            .await
+            .unwrap();
 
         assert!(matches!(signer, StellarSigner::Turnkey(_)));
     }
 
-    #[test]
+    #[tokio::test]
     /// Verifies that Azure Key Vault remains unsupported for Stellar signers.
-    fn test_create_stellar_signer_azure_key_vault_unsupported() {
+    async fn test_create_stellar_signer_azure_key_vault_unsupported() {
         let signer_model = SignerDomainModel {
             id: "test".to_string(),
             config: SignerConfig::AzureKeyVault(AzureKeyVaultSignerConfig {
@@ -466,7 +471,7 @@ mod tests {
             }),
         };
 
-        let result = StellarSignerFactory::create_stellar_signer(&signer_model);
+        let result = StellarSignerFactory::create_stellar_signer(signer_model).await;
 
         assert!(matches!(
             result,
@@ -475,9 +480,9 @@ mod tests {
         ));
     }
 
-    #[test]
+    #[tokio::test]
     /// Verifies that CDP remains unsupported for Stellar signers.
-    fn test_create_stellar_signer_cdp_unsupported() {
+    async fn test_create_stellar_signer_cdp_unsupported() {
         let signer_model = SignerDomainModel {
             id: "test".to_string(),
             config: SignerConfig::Cdp(crate::models::CdpSignerConfig {
@@ -488,7 +493,7 @@ mod tests {
             }),
         };
 
-        let result = StellarSignerFactory::create_stellar_signer(&signer_model);
+        let result = StellarSignerFactory::create_stellar_signer(signer_model).await;
 
         assert!(matches!(
             result,
@@ -499,8 +504,9 @@ mod tests {
     #[tokio::test]
     /// Verifies that address dispatch works for the local Stellar signer variant.
     async fn test_stellar_signer_local_address_dispatch() {
-        let signer =
-            StellarSignerFactory::create_stellar_signer(&create_local_signer_model()).unwrap();
+        let signer = StellarSignerFactory::create_stellar_signer(create_local_signer_model())
+            .await
+            .unwrap();
 
         let address = signer.address().await.unwrap();
 
@@ -517,7 +523,8 @@ mod tests {
     /// Verifies that address dispatch works for the Vault Transit Stellar signer variant.
     async fn test_stellar_signer_vault_transit_address_dispatch() {
         let signer =
-            StellarSignerFactory::create_stellar_signer(&create_vault_transit_signer_model())
+            StellarSignerFactory::create_stellar_signer(create_vault_transit_signer_model())
+                .await
                 .unwrap();
 
         let address = signer.address().await.unwrap();
@@ -534,8 +541,9 @@ mod tests {
     #[tokio::test]
     /// Verifies that address dispatch works for the Turnkey Stellar signer variant.
     async fn test_stellar_signer_turnkey_address_dispatch() {
-        let signer =
-            StellarSignerFactory::create_stellar_signer(&create_turnkey_signer_model()).unwrap();
+        let signer = StellarSignerFactory::create_stellar_signer(create_turnkey_signer_model())
+            .await
+            .unwrap();
 
         let address = signer.address().await.unwrap();
 
@@ -551,8 +559,9 @@ mod tests {
     #[tokio::test]
     /// Verifies that transaction signing dispatch works for the local Stellar signer variant.
     async fn test_stellar_signer_local_sign_transaction_dispatch() {
-        let signer =
-            StellarSignerFactory::create_stellar_signer(&create_local_signer_model()).unwrap();
+        let signer = StellarSignerFactory::create_stellar_signer(create_local_signer_model())
+            .await
+            .unwrap();
         let source_account = signer.address().await.unwrap().to_string();
 
         let result = signer
@@ -574,8 +583,9 @@ mod tests {
     #[tokio::test]
     /// Verifies that XDR signing dispatch works for the local Stellar signer variant.
     async fn test_stellar_signer_local_sign_xdr_transaction_dispatch() {
-        let signer =
-            StellarSignerFactory::create_stellar_signer(&create_local_signer_model()).unwrap();
+        let signer = StellarSignerFactory::create_stellar_signer(create_local_signer_model())
+            .await
+            .unwrap();
         let source_account = signer.address().await.unwrap().to_string();
         let unsigned_xdr = create_unsigned_xdr(&source_account);
 

--- a/src/services/signer/stellar/vault_transit_signer.rs
+++ b/src/services/signer/stellar/vault_transit_signer.rs
@@ -1,0 +1,466 @@
+//! # Vault Transit Signer for Stellar
+//!
+//! This module provides a Stellar signer implementation that uses HashiCorp Vault's Transit
+//! engine for secure Ed25519 signing operations without exporting the private key.
+
+use async_trait::async_trait;
+use sha2::{Digest, Sha256};
+use soroban_rs::xdr::{
+    DecoratedSignature, Hash, Limits, ReadXdr, Signature, SignatureHint, Transaction,
+    TransactionEnvelope, WriteXdr,
+};
+use tokio::sync::OnceCell;
+use tracing::debug;
+
+use crate::{
+    domain::{
+        attach_signatures_to_envelope, parse_transaction_xdr,
+        stellar::{create_signature_payload, create_transaction_signature_payload},
+        SignTransactionResponse, SignXdrTransactionResponseStellar,
+    },
+    models::{Address, NetworkTransactionData, Signer as SignerDomainModel, SignerError},
+    services::{signer::Signer, VaultService, VaultServiceTrait},
+    utils::base64_decode,
+};
+
+use super::StellarSignTrait;
+
+pub type DefaultVaultService = VaultService;
+
+pub struct VaultTransitSigner<T = DefaultVaultService>
+where
+    T: VaultServiceTrait,
+{
+    vault_service: T,
+    pubkey: String,
+    key_name: String,
+    cached_hint: OnceCell<SignatureHint>,
+}
+
+impl VaultTransitSigner<DefaultVaultService> {
+    pub fn new(signer_model: &SignerDomainModel, vault_service: DefaultVaultService) -> Self {
+        let config = signer_model
+            .config
+            .get_vault_transit()
+            .expect("vault transit config not found");
+
+        Self {
+            vault_service,
+            pubkey: config.pubkey.clone(),
+            key_name: config.key_name.clone(),
+            cached_hint: OnceCell::new(),
+        }
+    }
+}
+
+#[cfg(test)]
+impl<T: VaultServiceTrait> VaultTransitSigner<T> {
+    pub fn new_with_service(signer_model: &SignerDomainModel, vault_service: T) -> Self {
+        let config = signer_model
+            .config
+            .get_vault_transit()
+            .expect("vault transit config not found");
+
+        Self {
+            vault_service,
+            pubkey: config.pubkey.clone(),
+            key_name: config.key_name.clone(),
+            cached_hint: OnceCell::new(),
+        }
+    }
+
+    pub fn new_for_testing(key_name: String, pubkey: String, vault_service: T) -> Self {
+        Self {
+            vault_service,
+            pubkey,
+            key_name,
+            cached_hint: OnceCell::new(),
+        }
+    }
+}
+
+impl<T: VaultServiceTrait> VaultTransitSigner<T> {
+    fn stellar_address_from_pubkey(&self) -> Result<Address, SignerError> {
+        let raw_pubkey =
+            base64_decode(&self.pubkey).map_err(|e| SignerError::KeyError(e.to_string()))?;
+        let public_key_bytes: [u8; 32] = raw_pubkey.as_slice().try_into().map_err(|_| {
+            SignerError::KeyError(format!(
+                "Invalid Stellar Vault Transit public key length: expected 32 bytes, got {}",
+                raw_pubkey.len()
+            ))
+        })?;
+
+        let stellar_address = stellar_strkey::ed25519::PublicKey(public_key_bytes).to_string();
+        Ok(Address::Stellar(stellar_address))
+    }
+
+    async fn sign_hash(&self, hash: &[u8]) -> Result<Vec<u8>, SignerError> {
+        let vault_signature_str = self.vault_service.sign(&self.key_name, hash).await?;
+
+        debug!(vault_signature_str = %vault_signature_str, "vault signature string");
+
+        let base64_sig = vault_signature_str
+            .strip_prefix("vault:v1:")
+            .unwrap_or(&vault_signature_str);
+
+        let signature_bytes = base64_decode(base64_sig)
+            .map_err(|e| SignerError::SigningError(format!("Failed to decode signature: {e}")))?;
+
+        if signature_bytes.len() != 64 {
+            return Err(SignerError::SigningError(format!(
+                "Vault Transit returned invalid Ed25519 signature length: expected 64 bytes, got {}",
+                signature_bytes.len()
+            )));
+        }
+
+        Ok(signature_bytes)
+    }
+
+    async fn sign_envelope(
+        &self,
+        envelope: &TransactionEnvelope,
+        network_id: &Hash,
+    ) -> Result<DecoratedSignature, SignerError> {
+        let payload = create_signature_payload(envelope, network_id)
+            .map_err(|e| SignerError::SigningError(format!("Failed to create payload: {e}")))?;
+
+        let payload_bytes = payload
+            .to_xdr(Limits::none())
+            .map_err(|e| SignerError::SigningError(format!("Failed to serialize payload: {e}")))?;
+
+        let hash = Sha256::digest(&payload_bytes);
+        let signature_bytes = self.sign_hash(&hash).await?;
+
+        self.create_decorated_signature(signature_bytes).await
+    }
+
+    async fn sign_transaction_directly(
+        &self,
+        transaction: &Transaction,
+        network_id: &Hash,
+    ) -> Result<DecoratedSignature, SignerError> {
+        let payload = create_transaction_signature_payload(transaction, network_id);
+
+        let payload_bytes = payload
+            .to_xdr(Limits::none())
+            .map_err(|e| SignerError::SigningError(format!("Failed to serialize payload: {e}")))?;
+
+        let hash = Sha256::digest(&payload_bytes);
+        let signature_bytes = self.sign_hash(&hash).await?;
+
+        self.create_decorated_signature(signature_bytes).await
+    }
+
+    async fn create_decorated_signature(
+        &self,
+        signature_bytes: Vec<u8>,
+    ) -> Result<DecoratedSignature, SignerError> {
+        let hint = self.get_signature_hint().await?;
+        let signature_bytes_m =
+            soroban_rs::xdr::BytesM::try_from(signature_bytes).map_err(|_| {
+                SignerError::SigningError(
+                    "Failed to convert signature to BytesM format".to_string(),
+                )
+            })?;
+
+        Ok(DecoratedSignature {
+            hint,
+            signature: Signature(signature_bytes_m),
+        })
+    }
+
+    async fn get_signature_hint(&self) -> Result<SignatureHint, SignerError> {
+        self.cached_hint
+            .get_or_try_init(|| async {
+                let address = self.stellar_address_from_pubkey()?;
+                super::derive_signature_hint(&address)
+            })
+            .await
+            .cloned()
+    }
+}
+
+#[async_trait]
+impl<T: VaultServiceTrait> Signer for VaultTransitSigner<T> {
+    async fn address(&self) -> Result<Address, SignerError> {
+        self.stellar_address_from_pubkey()
+    }
+
+    async fn sign_transaction(
+        &self,
+        tx: NetworkTransactionData,
+    ) -> Result<SignTransactionResponse, SignerError> {
+        let stellar_data = tx
+            .get_stellar_transaction_data()
+            .map_err(|e| SignerError::SigningError(format!("Failed to get tx data: {e}")))?;
+
+        let passphrase = &stellar_data.network_passphrase;
+        let hash_bytes: [u8; 32] = Sha256::digest(passphrase.as_bytes()).into();
+        let network_id = Hash(hash_bytes);
+
+        let signature = match &stellar_data.transaction_input {
+            crate::models::TransactionInput::Operations(_) => {
+                let transaction = Transaction::try_from(stellar_data).map_err(|e| {
+                    SignerError::SigningError(format!(
+                        "Failed to build Stellar transaction from operations: {e}"
+                    ))
+                })?;
+
+                self.sign_transaction_directly(&transaction, &network_id)
+                    .await?
+            }
+            crate::models::TransactionInput::UnsignedXdr(xdr)
+            | crate::models::TransactionInput::SignedXdr { xdr, .. }
+            | crate::models::TransactionInput::SorobanGasAbstraction { xdr, .. } => {
+                let envelope =
+                    TransactionEnvelope::from_xdr_base64(xdr, Limits::none()).map_err(|e| {
+                        SignerError::SigningError(format!(
+                            "Failed to parse Stellar transaction XDR '{}...': {}",
+                            &xdr[..std::cmp::min(50, xdr.len())],
+                            e
+                        ))
+                    })?;
+
+                self.sign_envelope(&envelope, &network_id).await?
+            }
+        };
+
+        Ok(SignTransactionResponse::Stellar(
+            crate::domain::SignTransactionResponseStellar { signature },
+        ))
+    }
+}
+
+#[async_trait]
+impl<T: VaultServiceTrait> StellarSignTrait for VaultTransitSigner<T> {
+    async fn sign_xdr_transaction(
+        &self,
+        unsigned_xdr: &str,
+        network_passphrase: &str,
+    ) -> Result<SignXdrTransactionResponseStellar, SignerError> {
+        debug!("Signing Stellar XDR transaction with Vault Transit");
+
+        let mut envelope = parse_transaction_xdr(unsigned_xdr, false)
+            .map_err(|e| SignerError::SigningError(format!("Invalid XDR: {e}")))?;
+
+        let hash_bytes: [u8; 32] = Sha256::digest(network_passphrase.as_bytes()).into();
+        let network_id = Hash(hash_bytes);
+
+        let signature = self.sign_envelope(&envelope, &network_id).await?;
+
+        attach_signatures_to_envelope(&mut envelope, vec![signature.clone()])
+            .map_err(|e| SignerError::SigningError(format!("Failed to attach signature: {e}")))?;
+
+        let signed_xdr = envelope.to_xdr_base64(Limits::none()).map_err(|e| {
+            SignerError::SigningError(format!("Failed to serialize signed XDR: {e}"))
+        })?;
+
+        Ok(SignXdrTransactionResponseStellar {
+            signed_xdr,
+            signature,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        models::{
+            SecretString, SignerConfig, StellarTransactionData, TransactionInput,
+            VaultTransitSignerConfig,
+        },
+        services::{vault::VaultError, MockVaultServiceTrait},
+    };
+    use base64::Engine;
+    use mockall::predicate::*;
+    use soroban_rs::xdr::{SequenceNumber, TransactionV0, TransactionV0Envelope, Uint256};
+
+    fn create_test_public_key_bytes() -> [u8; 32] {
+        [7u8; 32]
+    }
+
+    fn create_test_pubkey_base64() -> String {
+        base64::engine::general_purpose::STANDARD.encode(create_test_public_key_bytes())
+    }
+
+    fn create_test_address() -> String {
+        stellar_strkey::ed25519::PublicKey(create_test_public_key_bytes()).to_string()
+    }
+
+    fn create_test_signer_model() -> SignerDomainModel {
+        SignerDomainModel {
+            id: "test-vault-transit-signer".to_string(),
+            config: SignerConfig::VaultTransit(VaultTransitSignerConfig {
+                key_name: "transit-key".to_string(),
+                address: "https://vault.example.com".to_string(),
+                namespace: None,
+                role_id: SecretString::new("role-123"),
+                secret_id: SecretString::new("secret-456"),
+                pubkey: create_test_pubkey_base64(),
+                mount_point: None,
+            }),
+        }
+    }
+
+    fn create_unsigned_xdr(source_address: &str) -> String {
+        let source_pk = stellar_strkey::ed25519::PublicKey::from_string(source_address).unwrap();
+        let tx = TransactionV0 {
+            source_account_ed25519: Uint256(source_pk.0),
+            fee: 100,
+            seq_num: SequenceNumber(1),
+            time_bounds: None,
+            memo: soroban_rs::xdr::Memo::None,
+            operations: vec![].try_into().unwrap(),
+            ext: soroban_rs::xdr::TransactionV0Ext::V0,
+        };
+
+        let envelope = TransactionEnvelope::TxV0(TransactionV0Envelope {
+            tx,
+            signatures: vec![].try_into().unwrap(),
+        });
+
+        envelope.to_xdr_base64(Limits::none()).unwrap()
+    }
+
+    #[test]
+    fn test_new_with_service() {
+        let model = create_test_signer_model();
+        let mock_vault_service = MockVaultServiceTrait::new();
+
+        let signer = VaultTransitSigner::new_with_service(&model, mock_vault_service);
+
+        assert_eq!(signer.key_name, "transit-key");
+        assert_eq!(signer.pubkey, create_test_pubkey_base64());
+    }
+
+    #[tokio::test]
+    async fn test_address_returns_stellar_strkey() {
+        let mock_vault_service = MockVaultServiceTrait::new();
+        let signer = VaultTransitSigner::new_for_testing(
+            "test-key".to_string(),
+            create_test_pubkey_base64(),
+            mock_vault_service,
+        );
+
+        let result = signer.address().await.unwrap();
+        assert_eq!(result, Address::Stellar(create_test_address()));
+    }
+
+    #[tokio::test]
+    async fn test_sign_xdr_transaction_success() {
+        let test_address = create_test_address();
+        let unsigned_xdr = create_unsigned_xdr(&test_address);
+
+        let mut mock_vault_service = MockVaultServiceTrait::new();
+        mock_vault_service
+            .expect_sign()
+            .times(1)
+            .with(eq("transit-key"), always())
+            .returning(|_, _| {
+                let signature = vec![1u8; 64];
+                let encoded = base64::engine::general_purpose::STANDARD.encode(signature);
+                Box::pin(async move { Ok(format!("vault:v1:{encoded}")) })
+            });
+
+        let signer = VaultTransitSigner::new_for_testing(
+            "transit-key".to_string(),
+            create_test_pubkey_base64(),
+            mock_vault_service,
+        );
+
+        let result = signer
+            .sign_xdr_transaction(&unsigned_xdr, "Test SDF Network ; September 2015")
+            .await
+            .unwrap();
+
+        assert!(!result.signed_xdr.is_empty());
+        assert_eq!(result.signature.hint.0.len(), 4);
+        assert_eq!(result.signature.signature.0.len(), 64);
+
+        let signed_envelope =
+            TransactionEnvelope::from_xdr_base64(&result.signed_xdr, Limits::none()).unwrap();
+        match signed_envelope {
+            TransactionEnvelope::TxV0(v0_env) => assert_eq!(v0_env.signatures.len(), 1),
+            _ => panic!("Expected V0 envelope"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_sign_transaction_invalid_signature_length() {
+        let mut mock_vault_service = MockVaultServiceTrait::new();
+        mock_vault_service.expect_sign().times(1).returning(|_, _| {
+            let encoded = base64::engine::general_purpose::STANDARD.encode(vec![2u8; 32]);
+            Box::pin(async move { Ok(format!("vault:v1:{encoded}")) })
+        });
+
+        let signer = VaultTransitSigner::new_for_testing(
+            "transit-key".to_string(),
+            create_test_pubkey_base64(),
+            mock_vault_service,
+        );
+
+        let tx_data = StellarTransactionData {
+            source_account: create_test_address(),
+            fee: Some(100),
+            sequence_number: Some(1),
+            transaction_input: TransactionInput::Operations(vec![]),
+            memo: None,
+            valid_until: None,
+            network_passphrase: "Test SDF Network ; September 2015".to_string(),
+            signatures: Vec::new(),
+            hash: None,
+            simulation_transaction_data: None,
+            signed_envelope_xdr: None,
+            transaction_result_xdr: None,
+        };
+
+        let result = signer
+            .sign_transaction(NetworkTransactionData::Stellar(tx_data))
+            .await;
+
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            SignerError::SigningError(msg) => {
+                assert!(msg.contains("invalid Ed25519 signature length"));
+                assert!(msg.contains("expected 64 bytes, got 32"));
+            }
+            other => panic!("Expected SigningError, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_sign_propagates_vault_error() {
+        let mut mock_vault_service = MockVaultServiceTrait::new();
+        mock_vault_service.expect_sign().times(1).returning(|_, _| {
+            Box::pin(async move { Err(VaultError::SigningError("vault unavailable".into())) })
+        });
+
+        let signer = VaultTransitSigner::new_for_testing(
+            "transit-key".to_string(),
+            create_test_pubkey_base64(),
+            mock_vault_service,
+        );
+
+        let tx_data = StellarTransactionData {
+            source_account: create_test_address(),
+            fee: Some(100),
+            sequence_number: Some(1),
+            transaction_input: TransactionInput::Operations(vec![]),
+            memo: None,
+            valid_until: None,
+            network_passphrase: "Test SDF Network ; September 2015".to_string(),
+            signatures: Vec::new(),
+            hash: None,
+            simulation_transaction_data: None,
+            signed_envelope_xdr: None,
+            transaction_result_xdr: None,
+        };
+
+        let result = signer
+            .sign_transaction(NetworkTransactionData::Stellar(tx_data))
+            .await;
+
+        assert!(result.is_err());
+    }
+}

--- a/src/services/signer/stellar/vault_transit_signer.rs
+++ b/src/services/signer/stellar/vault_transit_signer.rs
@@ -38,37 +38,46 @@ where
 }
 
 impl VaultTransitSigner<DefaultVaultService> {
-    pub fn new(signer_model: &SignerDomainModel, vault_service: DefaultVaultService) -> Self {
+    /// Builds a Stellar Vault Transit signer from a validated signer model.
+    pub fn new(
+        signer_model: &SignerDomainModel,
+        vault_service: DefaultVaultService,
+    ) -> Result<Self, SignerError> {
         let config = signer_model
             .config
             .get_vault_transit()
-            .expect("vault transit config not found");
+            .ok_or_else(|| SignerError::Configuration("vault transit config not found".into()))?;
 
-        Self {
+        Ok(Self {
             vault_service,
             pubkey: config.pubkey.clone(),
             key_name: config.key_name.clone(),
             cached_hint: OnceCell::new(),
-        }
+        })
     }
 }
 
 #[cfg(test)]
 impl<T: VaultServiceTrait> VaultTransitSigner<T> {
-    pub fn new_with_service(signer_model: &SignerDomainModel, vault_service: T) -> Self {
+    /// Builds a test signer from a signer model and injected Vault service.
+    pub fn new_with_service(
+        signer_model: &SignerDomainModel,
+        vault_service: T,
+    ) -> Result<Self, SignerError> {
         let config = signer_model
             .config
             .get_vault_transit()
-            .expect("vault transit config not found");
+            .ok_or_else(|| SignerError::Configuration("vault transit config not found".into()))?;
 
-        Self {
+        Ok(Self {
             vault_service,
             pubkey: config.pubkey.clone(),
             key_name: config.key_name.clone(),
             cached_hint: OnceCell::new(),
-        }
+        })
     }
 
+    /// Builds a test signer directly from raw constructor inputs.
     pub fn new_for_testing(key_name: String, pubkey: String, vault_service: T) -> Self {
         Self {
             vault_service,
@@ -80,6 +89,7 @@ impl<T: VaultServiceTrait> VaultTransitSigner<T> {
 }
 
 impl<T: VaultServiceTrait> VaultTransitSigner<T> {
+    /// Converts the configured Vault Transit public key into a Stellar address.
     fn stellar_address_from_pubkey(&self) -> Result<Address, SignerError> {
         let raw_pubkey =
             base64_decode(&self.pubkey).map_err(|e| SignerError::KeyError(e.to_string()))?;
@@ -94,6 +104,7 @@ impl<T: VaultServiceTrait> VaultTransitSigner<T> {
         Ok(Address::Stellar(stellar_address))
     }
 
+    /// Requests a signature from Vault Transit and validates the Ed25519 length.
     async fn sign_hash(&self, hash: &[u8]) -> Result<Vec<u8>, SignerError> {
         let vault_signature_str = self.vault_service.sign(&self.key_name, hash).await?;
 
@@ -116,6 +127,7 @@ impl<T: VaultServiceTrait> VaultTransitSigner<T> {
         Ok(signature_bytes)
     }
 
+    /// Signs a parsed Stellar envelope using Vault Transit.
     async fn sign_envelope(
         &self,
         envelope: &TransactionEnvelope,
@@ -134,6 +146,7 @@ impl<T: VaultServiceTrait> VaultTransitSigner<T> {
         self.create_decorated_signature(signature_bytes).await
     }
 
+    /// Signs an operations-based Stellar transaction by constructing its signature payload.
     async fn sign_transaction_directly(
         &self,
         transaction: &Transaction,
@@ -151,6 +164,7 @@ impl<T: VaultServiceTrait> VaultTransitSigner<T> {
         self.create_decorated_signature(signature_bytes).await
     }
 
+    /// Wraps raw signature bytes with the cached Stellar signature hint.
     async fn create_decorated_signature(
         &self,
         signature_bytes: Vec<u8>,
@@ -169,6 +183,7 @@ impl<T: VaultServiceTrait> VaultTransitSigner<T> {
         })
     }
 
+    /// Computes and caches the Stellar signature hint derived from the configured public key.
     async fn get_signature_hint(&self) -> Result<SignatureHint, SignerError> {
         self.cached_hint
             .get_or_try_init(|| async {
@@ -182,10 +197,12 @@ impl<T: VaultServiceTrait> VaultTransitSigner<T> {
 
 #[async_trait]
 impl<T: VaultServiceTrait> Signer for VaultTransitSigner<T> {
+    /// Returns the Stellar address derived from the configured Vault Transit public key.
     async fn address(&self) -> Result<Address, SignerError> {
         self.stellar_address_from_pubkey()
     }
 
+    /// Signs Stellar transaction data using Vault Transit for either operations or XDR inputs.
     async fn sign_transaction(
         &self,
         tx: NetworkTransactionData,
@@ -233,6 +250,7 @@ impl<T: VaultServiceTrait> Signer for VaultTransitSigner<T> {
 
 #[async_trait]
 impl<T: VaultServiceTrait> StellarSignTrait for VaultTransitSigner<T> {
+    /// Signs an unsigned Stellar XDR envelope and returns the signed XDR plus decorated signature.
     async fn sign_xdr_transaction(
         &self,
         unsigned_xdr: &str,
@@ -267,27 +285,32 @@ mod tests {
     use super::*;
     use crate::{
         models::{
-            SecretString, SignerConfig, StellarTransactionData, TransactionInput,
-            VaultTransitSignerConfig,
+            LocalSignerConfig, SecretString, SignerConfig, StellarTransactionData,
+            TransactionInput, VaultTransitSignerConfig,
         },
         services::{vault::VaultError, MockVaultServiceTrait},
     };
     use base64::Engine;
     use mockall::predicate::*;
+    use secrets::SecretVec;
     use soroban_rs::xdr::{SequenceNumber, TransactionV0, TransactionV0Envelope, Uint256};
 
+    /// Returns deterministic public key bytes for Vault Transit unit tests.
     fn create_test_public_key_bytes() -> [u8; 32] {
         [7u8; 32]
     }
 
+    /// Encodes the deterministic test public key as base64, matching Vault output format.
     fn create_test_pubkey_base64() -> String {
         base64::engine::general_purpose::STANDARD.encode(create_test_public_key_bytes())
     }
 
+    /// Converts the deterministic test public key into a Stellar account address.
     fn create_test_address() -> String {
         stellar_strkey::ed25519::PublicKey(create_test_public_key_bytes()).to_string()
     }
 
+    /// Builds a valid Vault Transit signer model for Stellar unit tests.
     fn create_test_signer_model() -> SignerDomainModel {
         SignerDomainModel {
             id: "test-vault-transit-signer".to_string(),
@@ -303,6 +326,7 @@ mod tests {
         }
     }
 
+    /// Creates a minimal unsigned Stellar XDR envelope for signing tests.
     fn create_unsigned_xdr(source_address: &str) -> String {
         let source_pk = stellar_strkey::ed25519::PublicKey::from_string(source_address).unwrap();
         let tx = TransactionV0 {
@@ -324,17 +348,38 @@ mod tests {
     }
 
     #[test]
+    /// Verifies that constructor state is copied from Vault Transit config.
     fn test_new_with_service() {
         let model = create_test_signer_model();
         let mock_vault_service = MockVaultServiceTrait::new();
 
-        let signer = VaultTransitSigner::new_with_service(&model, mock_vault_service);
+        let signer = VaultTransitSigner::new_with_service(&model, mock_vault_service).unwrap();
 
         assert_eq!(signer.key_name, "transit-key");
         assert_eq!(signer.pubkey, create_test_pubkey_base64());
     }
 
+    #[test]
+    /// Verifies that missing Vault Transit config surfaces as a configuration error.
+    fn test_new_with_service_missing_config_returns_error() {
+        let model = SignerDomainModel {
+            id: "test-vault-transit-signer".to_string(),
+            config: SignerConfig::Local(LocalSignerConfig {
+                raw_key: SecretVec::new(32, |v| v.copy_from_slice(&[1u8; 32])),
+            }),
+        };
+        let mock_vault_service = MockVaultServiceTrait::new();
+
+        let result = VaultTransitSigner::new_with_service(&model, mock_vault_service);
+
+        assert!(matches!(
+            result,
+            Err(SignerError::Configuration(ref msg)) if msg == "vault transit config not found"
+        ));
+    }
+
     #[tokio::test]
+    /// Verifies that address resolution returns the expected Stellar StrKey.
     async fn test_address_returns_stellar_strkey() {
         let mock_vault_service = MockVaultServiceTrait::new();
         let signer = VaultTransitSigner::new_for_testing(
@@ -348,6 +393,7 @@ mod tests {
     }
 
     #[tokio::test]
+    /// Verifies that a signed XDR response contains a decorated signature and signed envelope.
     async fn test_sign_xdr_transaction_success() {
         let test_address = create_test_address();
         let unsigned_xdr = create_unsigned_xdr(&test_address);
@@ -387,6 +433,7 @@ mod tests {
     }
 
     #[tokio::test]
+    /// Verifies that invalid signature sizes returned by Vault Transit are rejected.
     async fn test_sign_transaction_invalid_signature_length() {
         let mut mock_vault_service = MockVaultServiceTrait::new();
         mock_vault_service.expect_sign().times(1).returning(|_, _| {
@@ -430,6 +477,7 @@ mod tests {
     }
 
     #[tokio::test]
+    /// Verifies that Vault signing failures propagate through transaction signing.
     async fn test_sign_propagates_vault_error() {
         let mut mock_vault_service = MockVaultServiceTrait::new();
         mock_vault_service.expect_sign().times(1).returning(|_, _| {

--- a/src/services/signer/stellar/vault_transit_signer.rs
+++ b/src/services/signer/stellar/vault_transit_signer.rs
@@ -111,7 +111,8 @@ impl<T: VaultServiceTrait> VaultTransitSigner<T> {
         debug!(vault_signature_str = %vault_signature_str, "vault signature string");
 
         let base64_sig = vault_signature_str
-            .strip_prefix("vault:v1:")
+            .rsplit_once(':')
+            .map(|(_, sig)| sig)
             .unwrap_or(&vault_signature_str);
 
         let signature_bytes = base64_decode(base64_sig)
@@ -430,6 +431,37 @@ mod tests {
             TransactionEnvelope::TxV0(v0_env) => assert_eq!(v0_env.signatures.len(), 1),
             _ => panic!("Expected V0 envelope"),
         }
+    }
+
+    #[tokio::test]
+    /// Verifies that Vault v2 signature responses are accepted when signing XDR transactions.
+    async fn test_sign_xdr_transaction_with_v2_vault_response() {
+        let test_address = create_test_address();
+        let unsigned_xdr = create_unsigned_xdr(&test_address);
+
+        let mut mock_vault_service = MockVaultServiceTrait::new();
+        mock_vault_service
+            .expect_sign()
+            .times(1)
+            .with(eq("transit-key"), always())
+            .returning(|_, _| {
+                let signature = vec![1u8; 64];
+                let encoded = base64::engine::general_purpose::STANDARD.encode(signature);
+                Box::pin(async move { Ok(format!("vault:v2:{encoded}")) })
+            });
+
+        let signer = VaultTransitSigner::new_for_testing(
+            "transit-key".to_string(),
+            create_test_pubkey_base64(),
+            mock_vault_service,
+        );
+
+        let result = signer
+            .sign_xdr_transaction(&unsigned_xdr, "Test SDF Network ; September 2015")
+            .await
+            .unwrap();
+
+        assert_eq!(result.signature.signature.0.len(), 64);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Add HashiCorp Vault Transit Support for Stellar Signing (#800)

### Summary

This proposal adds HashiCorp Vault Transit support to Stellar relayers in OpenZeppelin Relayer.

* Vault Transit-backed signer integration for Stellar transaction signing
* Support for Stellar account derivation and validation from Vault-managed Ed25519 public keys
* An end-to-end example demonstrating deployment and usage of Vault Transit-backed Stellar signing

### Implementation

* Vault Transit signer implementation for Stellar transaction signing
* Stellar account derivation from Vault Transit Ed25519 public keys
* Integration with existing relayer signer abstractions
* Reuse of existing Vault Transit authentication and key management flows
* Relayer configuration support for:
    * Vault address
    * AppRole credentials
    * Transit key name
    * Stellar public key
    * vault_transit signer selection

### Documentation & Examples

* Vault Transit setup and configuration
* Ed25519 Transit key creation
* Policy configuration
* AppRole authentication
* Relayer configuration examples
* Docker Compose deployment with Vault, Redis, and Relayer
* Stellar Testnet transaction submission walkthrough

### Notes

The implementation is designed to align with the existing Vault Transit integration already available for Solana, minimising integration complexity while extending support for Stellar’s Ed25519 signing requirements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Vault Transit signer support for Stellar using Ed25519 keys.
  * New ready-to-use example configuration for Vault Transit-based Stellar transaction signing.

* **Documentation**
  * Updated signer support documentation to include Vault Transit compatibility.
  * Added comprehensive setup guide and troubleshooting section for Vault Transit Stellar signing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->