### PR TITLE
chore: Fix queue processing for not found

### DIFF
--- a/src/jobs/handlers/mod.rs
+++ b/src/jobs/handlers/mod.rs
@@ -2,6 +2,7 @@ use eyre::Report;
 use tracing::{debug, error, warn};
 
 use crate::{
+    models::{ApiError, RepositoryError},
     observability::request_id::get_request_id,
     queues::{HandlerError, WorkerContext},
 };
@@ -38,6 +39,29 @@ pub use system_cleanup_handler::*;
 mod relayer_health_check_handler;
 pub use relayer_health_check_handler::*;
 
+/// Returns `true` when retrying the job can never succeed, so it should be
+/// aborted immediately instead of consuming the retry budget.
+///
+/// A `NotFound` for the entity a job operates on (e.g. a transaction that was
+/// deleted or expired from the repository) will never reappear by re-running
+/// the same job. On standard SQS queues this is critical: each retry
+/// re-enqueues a fresh message with `ApproximateReceiveCount` reset to 1, so
+/// the attempt counter never advances and the job would otherwise loop
+/// forever, also bypassing the SQS dead-letter redrive policy.
+fn is_terminal_error(err: &Report) -> bool {
+    if let Some(api_err) = err.downcast_ref::<ApiError>() {
+        if matches!(api_err, ApiError::NotFound(_)) {
+            return true;
+        }
+    }
+    if let Some(repo_err) = err.downcast_ref::<RepositoryError>() {
+        if matches!(repo_err, RepositoryError::NotFound(_)) {
+            return true;
+        }
+    }
+    false
+}
+
 pub fn handle_result(
     result: Result<(), Report>,
     ctx: &WorkerContext,
@@ -62,6 +86,18 @@ pub fn handle_result(
         max_attempts = %max_attempts,
         "request failed"
     );
+
+    if is_terminal_error(err) {
+        error!(
+            job_type = %job_type,
+            request_id = ?get_request_id(),
+            error = %err,
+            "terminal error (entity not found), aborting job without retry"
+        );
+        return Err(HandlerError::Abort(
+            "Terminal error: target entity not found, not retryable".into(),
+        ));
+    }
 
     if ctx.attempt >= max_attempts {
         error!(
@@ -122,5 +158,45 @@ mod tests {
 
         assert!(handled.is_err());
         assert!(matches!(handled, Err(HandlerError::Abort(_))));
+    }
+
+    #[test]
+    fn test_handle_result_terminal_api_not_found_aborts_at_first_attempt() {
+        // A missing entity will never appear by retrying the same job, so a
+        // NotFound must abort immediately instead of burning the whole retry
+        // budget (or looping forever on standard SQS queues where attempt stays 0).
+        let result: Result<(), Report> = Err(Report::new(crate::models::ApiError::NotFound(
+            "Transaction with ID 4af0a83b not found".into(),
+        )));
+        let ctx = WorkerContext::new(0, "test-task".into());
+
+        let handled = handle_result(result, &ctx, "Transaction Request", 5);
+
+        assert!(matches!(handled, Err(HandlerError::Abort(_))));
+    }
+
+    #[test]
+    fn test_handle_result_terminal_repository_not_found_aborts_at_first_attempt() {
+        let result: Result<(), Report> = Err(Report::new(
+            crate::models::RepositoryError::NotFound("relayer xyz not found".into()),
+        ));
+        let ctx = WorkerContext::new(0, "test-task".into());
+
+        let handled = handle_result(result, &ctx, "Transaction Request", 5);
+
+        assert!(matches!(handled, Err(HandlerError::Abort(_))));
+    }
+
+    #[test]
+    fn test_handle_result_non_terminal_error_still_retries() {
+        // Regression guard: transient errors must keep retrying below max.
+        let result: Result<(), Report> = Err(Report::new(
+            crate::models::RepositoryError::ConnectionError("redis timeout".into()),
+        ));
+        let ctx = WorkerContext::new(0, "test-task".into());
+
+        let handled = handle_result(result, &ctx, "Transaction Request", 5);
+
+        assert!(matches!(handled, Err(HandlerError::Retry(_))));
     }
 }

--- a/src/queues/sqs/worker.rs
+++ b/src/queues/sqs/worker.rs
@@ -514,9 +514,14 @@ async fn process_message(
         .unwrap_or(1);
     // SQS receive count starts at 1; Apalis Attempt starts at 0.
     let attempt_number = receive_count.saturating_sub(1);
-    // Persisted retry attempt for self-reenqueued status checks. Falls back to receive_count-based
-    // attempt when attribute is missing.
-    let logical_retry_attempt = parse_retry_attempt(&message).unwrap_or(attempt_number);
+    // Attempt count handed to the handler for its max_attempts decision.
+    // Prefers the persisted `retry_attempt` attribute (set on standard-queue
+    // re-enqueues, where receive_count resets to 1 every retry) and falls back
+    // to receive_count-1 for FIFO (same physical message redelivered).
+    // Using receive_count alone would peg standard-queue retries at attempt 0
+    // forever, so max_attempts would never trigger and the job would loop.
+    let logical_retry_attempt =
+        effective_handler_attempt(receive_count, parse_retry_attempt(&message));
 
     // Use SQS MessageId as the worker task_id for log correlation.
     let sqs_message_id = message.message_id().unwrap_or("unknown").to_string();
@@ -536,7 +541,7 @@ async fn process_message(
             process_job::<TransactionRequest, _, _>(
                 body,
                 app_state,
-                attempt_number,
+                logical_retry_attempt,
                 sqs_message_id,
                 "TransactionRequest",
                 transaction_request_handler,
@@ -547,7 +552,7 @@ async fn process_message(
             process_job::<TransactionSend, _, _>(
                 body,
                 app_state,
-                attempt_number,
+                logical_retry_attempt,
                 sqs_message_id,
                 "TransactionSend",
                 transaction_submission_handler,
@@ -558,7 +563,7 @@ async fn process_message(
             process_job::<TransactionStatusCheck, _, _>(
                 body,
                 app_state,
-                attempt_number,
+                logical_retry_attempt,
                 sqs_message_id,
                 "TransactionStatusCheck",
                 transaction_status_handler,
@@ -569,7 +574,7 @@ async fn process_message(
             process_job::<NotificationSend, _, _>(
                 body,
                 app_state,
-                attempt_number,
+                logical_retry_attempt,
                 sqs_message_id,
                 "NotificationSend",
                 notification_handler,
@@ -580,7 +585,7 @@ async fn process_message(
             process_job::<TokenSwapRequest, _, _>(
                 body,
                 app_state,
-                attempt_number,
+                logical_retry_attempt,
                 sqs_message_id,
                 "TokenSwapRequest",
                 token_swap_request_handler,
@@ -591,7 +596,7 @@ async fn process_message(
             process_job::<RelayerHealthCheck, _, _>(
                 body,
                 app_state,
-                attempt_number,
+                logical_retry_attempt,
                 sqs_message_id,
                 "RelayerHealthCheck",
                 relayer_health_check_handler,
@@ -776,6 +781,22 @@ fn parse_retry_attempt(message: &Message) -> Option<usize> {
         .and_then(|attrs| attrs.get("retry_attempt"))
         .and_then(|value| value.string_value())
         .and_then(|value| value.parse::<usize>().ok())
+}
+
+/// The attempt number handed to a job handler for its `max_attempts` decision.
+///
+/// Standard-queue retries re-enqueue a brand-new message, so the SQS
+/// `ApproximateReceiveCount` resets to 1 on every retry; the true retry count
+/// is carried instead in the persisted `retry_attempt` message attribute.
+/// FIFO retries reuse the same physical message via `change_message_visibility`,
+/// so `receive_count` climbs and no `retry_attempt` attribute is set.
+///
+/// Preferring the persisted `retry_attempt` (falling back to `receive_count - 1`)
+/// yields a monotonically increasing attempt count on BOTH queue types, so the
+/// handler's `max_attempts` ceiling is actually enforced and a permanently
+/// failing job cannot loop forever on a standard queue.
+fn effective_handler_attempt(receive_count: usize, retry_attempt: Option<usize>) -> usize {
+    retry_attempt.unwrap_or_else(|| receive_count.saturating_sub(1))
 }
 
 /// Compute pickup latency in seconds, clamping negative deltas to 0 so a
@@ -1636,6 +1657,27 @@ mod tests {
             .build();
 
         assert_eq!(queue_pickup_baseline_ms(&message), Some(777_000));
+    }
+
+    #[test]
+    fn test_effective_handler_attempt_prefers_persisted_retry_attempt() {
+        // Standard-queue retry: re-enqueued as a NEW message (receive_count=1)
+        // but carrying retry_attempt=3. The handler must see attempt 3, not 0,
+        // otherwise max_attempts is never reached and the job loops forever.
+        assert_eq!(effective_handler_attempt(1, Some(3)), 3);
+    }
+
+    #[test]
+    fn test_effective_handler_attempt_falls_back_to_receive_count_for_fifo() {
+        // FIFO retry: same physical message redelivered, receive_count climbs,
+        // and there is no retry_attempt attribute to read.
+        assert_eq!(effective_handler_attempt(4, None), 3);
+    }
+
+    #[test]
+    fn test_effective_handler_attempt_first_delivery_is_zero() {
+        assert_eq!(effective_handler_attempt(1, None), 0);
+        assert_eq!(effective_handler_attempt(1, Some(0)), 0);
     }
 
     #[test]


### PR DESCRIPTION
# Summary

This PR will improve processing of messages that are not in the repo anymore for some reason.

## Testing Process

## Checklist

- [ ] Add a reference to related issues in the PR description.
- [ ] Add unit tests if applicable.

> [!NOTE]
> If you are using Relayer in your stack, consider adding your team or organization to our list of [Relayer Users in the Wild](../INTHEWILD.md)!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Job processing now immediately terminates when encountering not-found errors instead of retrying, enabling faster failure resolution and reducing wasted processing.
  * Improved retry attempt tracking to provide more accurate and consistent retry behavior across different queue types and message delivery mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->