### PR TITLE
fix: Hide cancelled txs and fix cancel tracking

### DIFF
--- a/src/api/controllers/relayer.rs
+++ b/src/api/controllers/relayer.rs
@@ -13,8 +13,9 @@ use crate::{
     domain::{
         get_network_relayer, get_network_relayer_by_model, get_relayer_by_id,
         get_relayer_transaction_by_model, get_transaction_by_id as get_tx_by_id,
-        GasAbstractionTrait, Relayer, RelayerFactory, RelayerFactoryTrait, SignDataRequest,
-        SignDataResponse, SignTransactionRequest, SignTypedDataRequest, Transaction,
+        transaction::is_final_state, GasAbstractionTrait, Relayer, RelayerFactory,
+        RelayerFactoryTrait, SignDataRequest, SignDataResponse, SignTransactionRequest,
+        SignTypedDataRequest, Transaction,
     },
     jobs::JobProducerTrait,
     models::{
@@ -26,7 +27,8 @@ use crate::{
         NetworkTransactionRequest, NetworkType, NotificationRepoModel, PaginationMeta,
         PaginationQuery, Relayer as RelayerDomainModel, RelayerRepoModel, RelayerRepoUpdater,
         RelayerResponse, Signer as SignerDomainModel, SignerRepoModel, ThinDataAppState,
-        TransactionRepoModel, TransactionResponse, TransactionStatus, UpdateRelayerRequestRaw,
+        TransactionListQuery, TransactionRepoModel, TransactionResponse, TransactionStatus,
+        UpdateRelayerRequestRaw,
     },
     repositories::{
         ApiKeyRepositoryTrait, NetworkRepository, PluginRepositoryTrait, RelayerRepository,
@@ -540,7 +542,7 @@ where
 /// A paginated list of transactions
 pub async fn list_transactions<J, RR, TR, NR, NFR, SR, TCR, PR, AKR>(
     relayer_id: String,
-    query: PaginationQuery,
+    query: TransactionListQuery,
     state: ThinDataAppState<J, RR, TR, NR, NFR, SR, TCR, PR, AKR>,
 ) -> Result<HttpResponse, ApiError>
 where
@@ -556,10 +558,39 @@ where
 {
     get_relayer_by_id(relayer_id.clone(), &state).await?;
 
-    let transactions = state
-        .transaction_repository
-        .find_by_relayer_id(&relayer_id, query)
-        .await?;
+    let pagination = PaginationQuery::from(query.clone());
+    let mut transactions = match &query.status {
+        Some(status) => {
+            state
+                .transaction_repository
+                .find_by_status_paginated(
+                    &relayer_id,
+                    std::slice::from_ref(status),
+                    pagination,
+                    false,
+                )
+                .await?
+        }
+        None => {
+            state
+                .transaction_repository
+                .find_by_relayer_id(&relayer_id, pagination)
+                .await?
+        }
+    };
+
+    // Hide cancelled-in-progress transactions from active-status listings. A cancelled
+    // transaction keeps its non-terminal status with is_canceled=true until its
+    // replacement NOOP mines (at which point it becomes Canceled), so without this it
+    // would still appear under e.g. ?status=Submitted. This filters the already-paginated
+    // page, so `total` may briefly overcount during the cancel->mine window; the drift is
+    // transient and self-healing. Terminal-status queries (e.g. ?status=Canceled) are
+    // unaffected, so the settled transaction remains visible there.
+    if let Some(status) = &query.status {
+        if !is_final_state(status) {
+            transactions.items.retain(|t| t.is_canceled != Some(true));
+        }
+    }
 
     let transaction_response_list: Vec<TransactionResponse> =
         transactions.items.into_iter().map(|t| t.into()).collect();
@@ -1551,6 +1582,99 @@ mod tests {
         assert!(api_response.success);
         let data = api_response.data.unwrap();
         assert_eq!(data.len(), 0);
+    }
+
+    // LIST TRANSACTIONS TESTS
+
+    /// Builds a transaction for `test-relayer` with a specific id, status and cancel flag.
+    fn tx_for_listing(
+        id: &str,
+        status: TransactionStatus,
+        is_canceled: Option<bool>,
+    ) -> TransactionRepoModel {
+        let mut tx = create_mock_transaction();
+        tx.id = id.to_string();
+        tx.relayer_id = "test-relayer".to_string();
+        tx.status = status;
+        tx.is_canceled = is_canceled;
+        tx
+    }
+
+    fn returned_ids(body: &[u8]) -> Vec<String> {
+        let api_response: ApiResponse<Vec<serde_json::Value>> =
+            serde_json::from_slice(body).unwrap();
+        assert!(api_response.success);
+        api_response
+            .data
+            .unwrap()
+            .iter()
+            .map(|t| t["id"].as_str().unwrap().to_string())
+            .collect()
+    }
+
+    /// A cancelled-in-progress transaction (non-terminal status + is_canceled=true) must be
+    /// hidden from active-status listings such as ?status=Submitted.
+    #[actix_web::test]
+    async fn test_list_transactions_excludes_canceled_from_active_status() {
+        let relayer = create_mock_relayer("test-relayer".to_string(), false);
+        let txs = vec![
+            tx_for_listing("tx-submitted-1", TransactionStatus::Submitted, None),
+            tx_for_listing("tx-submitted-2", TransactionStatus::Submitted, Some(false)),
+            tx_for_listing(
+                "tx-cancel-inflight",
+                TransactionStatus::Submitted,
+                Some(true),
+            ),
+        ];
+        let app_state =
+            create_mock_app_state(None, Some(vec![relayer]), None, None, None, Some(txs)).await;
+
+        let query = TransactionListQuery {
+            page: 1,
+            per_page: 10,
+            status: Some(TransactionStatus::Submitted),
+        };
+
+        let result =
+            list_transactions("test-relayer".to_string(), query, web::ThinData(app_state)).await;
+
+        let response = result.unwrap();
+        assert_eq!(response.status(), 200);
+        let ids = returned_ids(&to_bytes(response.into_body()).await.unwrap());
+
+        assert!(
+            !ids.contains(&"tx-cancel-inflight".to_string()),
+            "cancelled-in-progress tx must not appear under ?status=Submitted, got {ids:?}"
+        );
+        assert_eq!(ids.len(), 2, "only the two non-cancelled txs should remain");
+    }
+
+    /// Once the cancellation NOOP mines, the transaction becomes terminal Canceled and must
+    /// remain visible under ?status=Canceled (the exclusion only applies to active statuses).
+    #[actix_web::test]
+    async fn test_list_transactions_includes_canceled_under_canceled_status() {
+        let relayer = create_mock_relayer("test-relayer".to_string(), false);
+        let txs = vec![
+            tx_for_listing("tx-submitted-1", TransactionStatus::Submitted, None),
+            tx_for_listing("tx-canceled-done", TransactionStatus::Canceled, Some(true)),
+        ];
+        let app_state =
+            create_mock_app_state(None, Some(vec![relayer]), None, None, None, Some(txs)).await;
+
+        let query = TransactionListQuery {
+            page: 1,
+            per_page: 10,
+            status: Some(TransactionStatus::Canceled),
+        };
+
+        let result =
+            list_transactions("test-relayer".to_string(), query, web::ThinData(app_state)).await;
+
+        let response = result.unwrap();
+        assert_eq!(response.status(), 200);
+        let ids = returned_ids(&to_bytes(response.into_body()).await.unwrap());
+
+        assert_eq!(ids, vec!["tx-canceled-done".to_string()]);
     }
 
     // GET RELAYER TESTS

--- a/src/api/controllers/relayer.rs
+++ b/src/api/controllers/relayer.rs
@@ -559,15 +559,24 @@ where
     get_relayer_by_id(relayer_id.clone(), &state).await?;
 
     let pagination = PaginationQuery::from(query.clone());
-    let mut transactions = match &query.status {
+    let transactions = match &query.status {
         Some(status) => {
+            // Hide cancelled-in-progress transactions from active-status listings: a
+            // cancelled tx keeps its non-terminal status with is_canceled=true until its
+            // replacement NOOP mines (then it becomes Canceled), so without this it would
+            // still appear under e.g. ?status=Submitted. We only exclude for non-terminal
+            // statuses, so ?status=Canceled still returns settled cancellations. The
+            // exclusion is applied in the repository (before pagination) so the page and
+            // total stay consistent.
+            let exclude_canceled = !is_final_state(status);
             state
                 .transaction_repository
-                .find_by_status_paginated(
+                .find_by_status_paginated_filtered(
                     &relayer_id,
                     std::slice::from_ref(status),
                     pagination,
                     false,
+                    exclude_canceled,
                 )
                 .await?
         }
@@ -578,19 +587,6 @@ where
                 .await?
         }
     };
-
-    // Hide cancelled-in-progress transactions from active-status listings. A cancelled
-    // transaction keeps its non-terminal status with is_canceled=true until its
-    // replacement NOOP mines (at which point it becomes Canceled), so without this it
-    // would still appear under e.g. ?status=Submitted. This filters the already-paginated
-    // page, so `total` may briefly overcount during the cancel->mine window; the drift is
-    // transient and self-healing. Terminal-status queries (e.g. ?status=Canceled) are
-    // unaffected, so the settled transaction remains visible there.
-    if let Some(status) = &query.status {
-        if !is_final_state(status) {
-            transactions.items.retain(|t| t.is_canceled != Some(true));
-        }
-    }
 
     let transaction_response_list: Vec<TransactionResponse> =
         transactions.items.into_iter().map(|t| t.into()).collect();

--- a/src/api/routes/docs/relayer_docs.rs
+++ b/src/api/routes/docs/relayer_docs.rs
@@ -24,7 +24,8 @@ use crate::{
         },
         ApiResponse, CreateRelayerRequest, DeletePendingTransactionsResponse, JsonRpcRequest,
         JsonRpcResponse, NetworkRpcRequest, NetworkRpcResult, NetworkTransactionRequest,
-        RelayerResponse, RelayerStatus, TransactionResponse, UpdateRelayerRequest,
+        RelayerResponse, RelayerStatus, TransactionResponse, TransactionStatus,
+        UpdateRelayerRequest,
     },
 };
 
@@ -723,7 +724,8 @@ fn doc_get_transaction_by_nonce() {}
     params(
         ("relayer_id" = String, Path, description = "The unique identifier of the relayer"),
         ("page" = Option<usize>, Query, description = "Page number for pagination (starts at 1)"),
-        ("per_page" = Option<usize>, Query, description = "Number of items per page (default: 10)")
+        ("per_page" = Option<usize>, Query, description = "Number of items per page (default: 10)"),
+        ("status" = Option<TransactionStatus>, Query, description = "Optional status filter, accepted case-insensitively (e.g. pending, submitted, confirmed, canceled). Cancelled-in-progress transactions are excluded from active-status results until their replacement mines.")
     ),
     responses(
         (status = 200, description = "Relayer transactions retrieved successfully", body = ApiResponse<Vec<TransactionResponse>>),

--- a/src/api/routes/relayer.rs
+++ b/src/api/routes/relayer.rs
@@ -8,7 +8,7 @@ use crate::{
         transaction::request::{
             SponsoredTransactionBuildRequest, SponsoredTransactionQuoteRequest,
         },
-        CreateRelayerRequest, DefaultAppState, PaginationQuery,
+        CreateRelayerRequest, DefaultAppState, PaginationQuery, TransactionListQuery,
     },
 };
 use actix_web::{delete, get, patch, post, put, web, Responder};
@@ -115,11 +115,11 @@ async fn get_transaction_by_nonce(
     relayer::get_transaction_by_nonce(params.0, params.1, data).await
 }
 
-/// Lists all transactions for a specific relayer with pagination.
+/// Lists all transactions for a specific relayer with pagination and optional status filter.
 #[get("/relayers/{relayer_id}/transactions")]
 async fn list_transactions(
     relayer_id: web::Path<String>,
-    query: web::Query<PaginationQuery>,
+    query: web::Query<TransactionListQuery>,
     data: web::ThinData<DefaultAppState>,
 ) -> impl Responder {
     relayer::list_transactions(relayer_id.into_inner(), query.into_inner(), data).await

--- a/src/domain/transaction/evm/evm_transaction.rs
+++ b/src/domain/transaction/evm/evm_transaction.rs
@@ -1260,6 +1260,11 @@ where
                 .await;
         }
 
+        // Build the NOOP replacement. The transaction keeps its active status
+        // (Sent/Submitted) and is marked is_canceled=true, so it is still tracked,
+        // resubmitted, and recovered by the normal status machinery until the NOOP
+        // actually mines — at which point it transitions to Canceled (see status.rs).
+        // The is_canceled flag excludes it from active-status API views immediately.
         let update = self
             .prepare_noop_update_request(
                 &tx,
@@ -1267,6 +1272,7 @@ where
                 Some("Transaction canceled by user, replacing with NOOP".to_string()),
             )
             .await?;
+
         let updated_tx = self
             .transaction_repository()
             .partial_update(tx.id.clone(), update)
@@ -2162,6 +2168,7 @@ mod tests {
                     updated_tx.status = update.status.unwrap_or(updated_tx.status);
                     updated_tx.network_data =
                         update.network_data.unwrap_or(updated_tx.network_data);
+                    updated_tx.is_canceled = update.is_canceled.or(updated_tx.is_canceled);
                     if let Some(hashes) = update.hashes {
                         updated_tx.hashes = hashes;
                     }
@@ -2231,7 +2238,10 @@ mod tests {
 
             // Verify the cancellation transaction was properly created
             assert_eq!(cancelled_tx.id, "test-tx-id");
+            // The tx keeps its active status until the NOOP mines; is_canceled excludes
+            // it from active-status API views in the meantime.
             assert_eq!(cancelled_tx.status, TransactionStatus::Submitted);
+            assert_eq!(cancelled_tx.is_canceled, Some(true));
 
             // Verify the network data was properly updated
             if let NetworkTransactionData::Evm(evm_data) = &cancelled_tx.network_data {

--- a/src/domain/transaction/evm/status.rs
+++ b/src/domain/transaction/evm/status.rs
@@ -115,18 +115,30 @@ where
                 );
                 return Ok(TransactionStatus::Mined);
             }
-            // A confirmed NOOP that replaced a user-cancelled transaction is terminal
-            // as Canceled, not Confirmed: the relayer kept tracking and resubmitting it
-            // until it mined (consuming the nonce so the original could never execute),
-            // but from the user's perspective the transaction was cancelled.
-            if tx.is_canceled == Some(true) && is_noop(&evm_data) {
+            // For a user-cancelled transaction, attribute the terminal status by what
+            // ACTUALLY mined. Cancellation replaces the tx with a self-send NOOP
+            // (to == from). If that NOOP is what confirmed, the transaction was truly
+            // cancelled. If the original mined instead (the cancellation lost the nonce
+            // race), it executed for real and must be reported Confirmed, not Canceled.
+            // We key off the mined receipt rather than the locally-stored network_data,
+            // which may still describe the NOOP even while the original hash is what
+            // confirmed (e.g. before the replacement has been broadcast).
+            if tx.is_canceled == Some(true) {
+                if receipt.to == Some(receipt.from) {
+                    debug!(
+                        tx_id = %tx.id,
+                        relayer_id = %tx.relayer_id,
+                        tx_hash = %tx_hash,
+                        "cancellation NOOP confirmed on-chain; marking transaction as Canceled"
+                    );
+                    return Ok(TransactionStatus::Canceled);
+                }
                 debug!(
                     tx_id = %tx.id,
                     relayer_id = %tx.relayer_id,
                     tx_hash = %tx_hash,
-                    "cancellation NOOP confirmed on-chain; marking transaction as Canceled"
+                    "cancelled transaction's original mined before the NOOP could replace it; reporting Confirmed"
                 );
-                return Ok(TransactionStatus::Canceled);
             }
             Ok(TransactionStatus::Confirmed)
         } else {
@@ -1537,6 +1549,23 @@ mod tests {
         }
     }
 
+    /// The fixed `from` address used by [`make_mock_receipt`].
+    fn mock_receipt_from() -> Address {
+        Address::from([0x11; 20])
+    }
+
+    /// Like [`make_mock_receipt`] but sets the receipt's `to`, so cancellation
+    /// attribution (a NOOP is a self-send: `to == from`) can be exercised.
+    fn make_mock_receipt_with_to(
+        status: bool,
+        block_number: Option<u64>,
+        to: Option<Address>,
+    ) -> TransactionReceipt {
+        let mut receipt = make_mock_receipt(status, block_number);
+        receipt.inner.to = to;
+        receipt
+    }
+
     // Tests for `check_transaction_status`
     mod check_transaction_status_tests {
         use super::*;
@@ -1632,9 +1661,8 @@ mod tests {
             assert_eq!(status, TransactionStatus::Confirmed);
         }
 
-        /// A confirmed NOOP that replaced a user-cancelled transaction must terminate
-        /// as Canceled rather than Confirmed, so the user sees the cancellation reflected
-        /// once the nonce-consuming NOOP actually mines.
+        /// When a user-cancelled tx confirms and the mined tx is the NOOP (a self-send,
+        /// receipt.to == receipt.from), it must terminate as Canceled.
         #[tokio::test]
         async fn test_cancellation_noop_confirmed_becomes_canceled() {
             let mut mocks = default_test_mocks();
@@ -1642,18 +1670,20 @@ mod tests {
             let mut tx = make_test_transaction(TransactionStatus::Submitted);
             tx.is_canceled = Some(true);
 
-            // Shape the network data as a cancellation NOOP (value 0, data "0x", to == from).
             if let NetworkTransactionData::Evm(ref mut evm_data) = tx.network_data {
                 evm_data.hash = Some("0xNoopHash".to_string());
-                evm_data.value = U256::from(0);
-                evm_data.data = Some("0x".to_string());
-                evm_data.to = Some(evm_data.from.clone());
             }
 
+            // Mined receipt for a NOOP: to == from.
+            let noop_to = Some(mock_receipt_from());
             mocks
                 .provider
                 .expect_get_transaction_receipt()
-                .returning(|_| Box::pin(async { Ok(Some(make_mock_receipt(true, Some(100)))) }));
+                .returning(move |_| {
+                    Box::pin(async move {
+                        Ok(Some(make_mock_receipt_with_to(true, Some(100), noop_to)))
+                    })
+                });
             mocks
                 .provider
                 .expect_get_block_number()
@@ -1669,8 +1699,51 @@ mod tests {
             assert_eq!(status, TransactionStatus::Canceled);
         }
 
-        /// A confirmed NOOP that is NOT a user cancellation (is_canceled=false) — e.g. a
-        /// nonce-clearing NOOP from timeout handling — must still confirm normally.
+        /// If a user-cancelled tx confirms but the ORIGINAL transaction is what mined
+        /// (cancellation lost the nonce race: receipt.to != receipt.from), it actually
+        /// executed and must be reported Confirmed, not Canceled.
+        #[tokio::test]
+        async fn test_cancellation_original_mined_stays_confirmed() {
+            let mut mocks = default_test_mocks();
+            let relayer = create_test_relayer();
+            let mut tx = make_test_transaction(TransactionStatus::Submitted);
+            tx.is_canceled = Some(true);
+
+            if let NetworkTransactionData::Evm(ref mut evm_data) = tx.network_data {
+                evm_data.hash = Some("0xOriginalHash".to_string());
+            }
+
+            // Mined receipt for the ORIGINAL transfer: to is a different address than from.
+            let original_to = Some(Address::from([0x22; 20]));
+            mocks
+                .provider
+                .expect_get_transaction_receipt()
+                .returning(move |_| {
+                    Box::pin(async move {
+                        Ok(Some(make_mock_receipt_with_to(
+                            true,
+                            Some(100),
+                            original_to,
+                        )))
+                    })
+                });
+            mocks
+                .provider
+                .expect_get_block_number()
+                .return_once(|| Box::pin(async { Ok(113) }));
+            mocks
+                .network_repo
+                .expect_get_by_chain_id()
+                .returning(|_, _| Ok(Some(create_test_network_model())));
+
+            let evm_transaction = make_test_evm_relayer_transaction(relayer, mocks);
+
+            let status = evm_transaction.check_transaction_status(&tx).await.unwrap();
+            assert_eq!(status, TransactionStatus::Confirmed);
+        }
+
+        /// A confirmed self-send that is NOT a user cancellation (is_canceled=false) — e.g.
+        /// a nonce-clearing NOOP from timeout handling — must still confirm normally.
         #[tokio::test]
         async fn test_non_cancellation_noop_confirmed_stays_confirmed() {
             let mut mocks = default_test_mocks();
@@ -1680,15 +1753,18 @@ mod tests {
 
             if let NetworkTransactionData::Evm(ref mut evm_data) = tx.network_data {
                 evm_data.hash = Some("0xNoopHash".to_string());
-                evm_data.value = U256::from(0);
-                evm_data.data = Some("0x".to_string());
-                evm_data.to = Some(evm_data.from.clone());
             }
 
+            // Even with a self-send receipt (to == from), a non-cancelled tx stays Confirmed.
+            let noop_to = Some(mock_receipt_from());
             mocks
                 .provider
                 .expect_get_transaction_receipt()
-                .returning(|_| Box::pin(async { Ok(Some(make_mock_receipt(true, Some(100)))) }));
+                .returning(move |_| {
+                    Box::pin(async move {
+                        Ok(Some(make_mock_receipt_with_to(true, Some(100), noop_to)))
+                    })
+                });
             mocks
                 .provider
                 .expect_get_block_number()

--- a/src/domain/transaction/evm/status.rs
+++ b/src/domain/transaction/evm/status.rs
@@ -115,6 +115,19 @@ where
                 );
                 return Ok(TransactionStatus::Mined);
             }
+            // A confirmed NOOP that replaced a user-cancelled transaction is terminal
+            // as Canceled, not Confirmed: the relayer kept tracking and resubmitting it
+            // until it mined (consuming the nonce so the original could never execute),
+            // but from the user's perspective the transaction was cancelled.
+            if tx.is_canceled == Some(true) && is_noop(&evm_data) {
+                debug!(
+                    tx_id = %tx.id,
+                    relayer_id = %tx.relayer_id,
+                    tx_hash = %tx_hash,
+                    "cancellation NOOP confirmed on-chain; marking transaction as Canceled"
+                );
+                return Ok(TransactionStatus::Canceled);
+            }
             Ok(TransactionStatus::Confirmed)
         } else {
             debug!(
@@ -1608,6 +1621,78 @@ mod tests {
                 .return_once(|| Box::pin(async { Ok(113) }));
 
             // Mock network repository to return a test network model
+            mocks
+                .network_repo
+                .expect_get_by_chain_id()
+                .returning(|_, _| Ok(Some(create_test_network_model())));
+
+            let evm_transaction = make_test_evm_relayer_transaction(relayer, mocks);
+
+            let status = evm_transaction.check_transaction_status(&tx).await.unwrap();
+            assert_eq!(status, TransactionStatus::Confirmed);
+        }
+
+        /// A confirmed NOOP that replaced a user-cancelled transaction must terminate
+        /// as Canceled rather than Confirmed, so the user sees the cancellation reflected
+        /// once the nonce-consuming NOOP actually mines.
+        #[tokio::test]
+        async fn test_cancellation_noop_confirmed_becomes_canceled() {
+            let mut mocks = default_test_mocks();
+            let relayer = create_test_relayer();
+            let mut tx = make_test_transaction(TransactionStatus::Submitted);
+            tx.is_canceled = Some(true);
+
+            // Shape the network data as a cancellation NOOP (value 0, data "0x", to == from).
+            if let NetworkTransactionData::Evm(ref mut evm_data) = tx.network_data {
+                evm_data.hash = Some("0xNoopHash".to_string());
+                evm_data.value = U256::from(0);
+                evm_data.data = Some("0x".to_string());
+                evm_data.to = Some(evm_data.from.clone());
+            }
+
+            mocks
+                .provider
+                .expect_get_transaction_receipt()
+                .returning(|_| Box::pin(async { Ok(Some(make_mock_receipt(true, Some(100)))) }));
+            mocks
+                .provider
+                .expect_get_block_number()
+                .return_once(|| Box::pin(async { Ok(113) }));
+            mocks
+                .network_repo
+                .expect_get_by_chain_id()
+                .returning(|_, _| Ok(Some(create_test_network_model())));
+
+            let evm_transaction = make_test_evm_relayer_transaction(relayer, mocks);
+
+            let status = evm_transaction.check_transaction_status(&tx).await.unwrap();
+            assert_eq!(status, TransactionStatus::Canceled);
+        }
+
+        /// A confirmed NOOP that is NOT a user cancellation (is_canceled=false) — e.g. a
+        /// nonce-clearing NOOP from timeout handling — must still confirm normally.
+        #[tokio::test]
+        async fn test_non_cancellation_noop_confirmed_stays_confirmed() {
+            let mut mocks = default_test_mocks();
+            let relayer = create_test_relayer();
+            let mut tx = make_test_transaction(TransactionStatus::Submitted);
+            // is_canceled stays Some(false) from the helper.
+
+            if let NetworkTransactionData::Evm(ref mut evm_data) = tx.network_data {
+                evm_data.hash = Some("0xNoopHash".to_string());
+                evm_data.value = U256::from(0);
+                evm_data.data = Some("0x".to_string());
+                evm_data.to = Some(evm_data.from.clone());
+            }
+
+            mocks
+                .provider
+                .expect_get_transaction_receipt()
+                .returning(|_| Box::pin(async { Ok(Some(make_mock_receipt(true, Some(100)))) }));
+            mocks
+                .provider
+                .expect_get_block_number()
+                .return_once(|| Box::pin(async { Ok(113) }));
             mocks
                 .network_repo
                 .expect_get_by_chain_id()

--- a/src/jobs/handlers/notification_handler.rs
+++ b/src/jobs/handlers/notification_handler.rs
@@ -122,6 +122,7 @@ mod tests {
                 max_priority_fee_per_gas: None,
                 signature: None,
                 speed: None,
+                is_canceled: None,
             },
         )));
 
@@ -163,6 +164,7 @@ mod tests {
                 max_priority_fee_per_gas: None,
                 signature: None,
                 speed: None,
+                is_canceled: None,
             },
         )));
 

--- a/src/jobs/job.rs
+++ b/src/jobs/job.rs
@@ -486,6 +486,7 @@ mod tests {
                     sig: "0x123".to_string(),
                 }),
                 speed: Some(Speed::Fast),
+                is_canceled: None,
             },
         )));
 
@@ -528,6 +529,7 @@ mod tests {
                 max_priority_fee_per_gas: None,
                 signature: None,
                 speed: None,
+                is_canceled: None,
             },
         )));
 

--- a/src/jobs/job_producer.rs
+++ b/src/jobs/job_producer.rs
@@ -650,6 +650,7 @@ mod tests {
                     max_priority_fee_per_gas: None,
                     signature: None,
                     speed: None,
+                    is_canceled: None,
                 },
             ))),
         );
@@ -959,6 +960,7 @@ mod tests {
                     max_priority_fee_per_gas: None,
                     signature: None,
                     speed: None,
+                    is_canceled: None,
                 },
             ))),
         );

--- a/src/models/pagination.rs
+++ b/src/models/pagination.rs
@@ -1,3 +1,4 @@
+use crate::models::TransactionStatus;
 use serde::Deserialize;
 use utoipa::ToSchema;
 
@@ -7,6 +8,25 @@ pub struct PaginationQuery {
     pub page: u32,
     #[serde(default = "default_per_page")]
     pub per_page: u32,
+}
+
+/// Pagination + optional status filter for listing transactions.
+#[derive(Debug, Deserialize, Clone, ToSchema)]
+pub struct TransactionListQuery {
+    #[serde(default = "default_page")]
+    pub page: u32,
+    #[serde(default = "default_per_page")]
+    pub per_page: u32,
+    pub status: Option<TransactionStatus>,
+}
+
+impl From<TransactionListQuery> for PaginationQuery {
+    fn from(q: TransactionListQuery) -> Self {
+        PaginationQuery {
+            page: q.page,
+            per_page: q.per_page,
+        }
+    }
 }
 
 fn default_page() -> u32 {

--- a/src/models/pagination.rs
+++ b/src/models/pagination.rs
@@ -1,5 +1,6 @@
 use crate::models::TransactionStatus;
-use serde::Deserialize;
+use serde::de::IntoDeserializer;
+use serde::{Deserialize, Deserializer};
 use utoipa::ToSchema;
 
 #[derive(Debug, Deserialize, Clone, ToSchema)]
@@ -17,7 +18,30 @@ pub struct TransactionListQuery {
     pub page: u32,
     #[serde(default = "default_per_page")]
     pub per_page: u32,
+    /// Optional status filter. Accepted case-insensitively (e.g. `submitted`,
+    /// `Submitted`, and `SUBMITTED` all match), though the canonical form is
+    /// lowercase.
+    #[serde(default, deserialize_with = "deserialize_optional_status_ci")]
     pub status: Option<TransactionStatus>,
+}
+
+/// Deserializes an optional [`TransactionStatus`] from a query string
+/// case-insensitively. `TransactionStatus` serializes as lowercase, so we lower
+/// the incoming value before matching — this means `?status=Submitted` works as
+/// well as `?status=submitted` rather than returning a 400.
+fn deserialize_optional_status_ci<'de, D>(
+    deserializer: D,
+) -> Result<Option<TransactionStatus>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let raw = String::deserialize(deserializer)?;
+    let lowered = raw.to_ascii_lowercase();
+    TransactionStatus::deserialize(lowered.as_str().into_deserializer())
+        .map(Some)
+        .map_err(|_: serde::de::value::Error| {
+            serde::de::Error::custom(format!("unknown transaction status: {raw}"))
+        })
 }
 
 impl From<TransactionListQuery> for PaginationQuery {
@@ -34,4 +58,44 @@ fn default_page() -> u32 {
 }
 fn default_per_page() -> u32 {
     10
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // `web::Query` is exactly how the `?status=` param is decoded at the route layer,
+    // so parsing through it mirrors real request handling.
+    fn parse(qs: &str) -> Result<TransactionListQuery, actix_web::error::QueryPayloadError> {
+        actix_web::web::Query::<TransactionListQuery>::from_query(qs).map(|q| q.into_inner())
+    }
+
+    #[test]
+    fn status_is_parsed_case_insensitively() {
+        for qs in ["status=submitted", "status=Submitted", "status=SUBMITTED"] {
+            let q = parse(qs).unwrap_or_else(|e| panic!("{qs} should parse: {e}"));
+            assert_eq!(q.status, Some(TransactionStatus::Submitted), "for {qs}");
+        }
+    }
+
+    #[test]
+    fn status_absent_is_none_with_defaults() {
+        let q = parse("").unwrap();
+        assert_eq!(q.status, None);
+        assert_eq!(q.page, 1);
+        assert_eq!(q.per_page, 10);
+    }
+
+    #[test]
+    fn other_statuses_and_pagination_round_trip() {
+        let q = parse("page=2&per_page=5&status=CANCELED").unwrap();
+        assert_eq!(q.status, Some(TransactionStatus::Canceled));
+        assert_eq!(q.page, 2);
+        assert_eq!(q.per_page, 5);
+    }
+
+    #[test]
+    fn invalid_status_is_rejected() {
+        assert!(parse("status=bogus").is_err());
+    }
 }

--- a/src/models/transaction/response.rs
+++ b/src/models/transaction/response.rs
@@ -71,6 +71,11 @@ pub struct EvmTransactionResponse {
     pub max_priority_fee_per_gas: Option<u128>,
     pub signature: Option<EvmTransactionDataSignature>,
     pub speed: Option<Speed>,
+    /// Whether this transaction was cancelled by the user. While true and still in a
+    /// non-terminal status, it is being replaced on-chain by a NOOP that consumes its
+    /// nonce; it terminates as `canceled` once that NOOP mines.
+    #[schema(nullable = false)]
+    pub is_canceled: Option<bool>,
 }
 
 #[derive(Debug, Serialize, Clone, PartialEq, Deserialize, ToSchema)]
@@ -144,6 +149,7 @@ impl From<TransactionRepoModel> for TransactionResponse {
                     max_priority_fee_per_gas: evm_data.max_priority_fee_per_gas,
                     signature: evm_data.signature,
                     speed: evm_data.speed,
+                    is_canceled: model.is_canceled,
                 }))
             }
             NetworkTransactionData::Solana(solana_data) => {

--- a/src/repositories/transaction/mod.rs
+++ b/src/repositories/transaction/mod.rs
@@ -81,6 +81,22 @@ pub trait TransactionRepository: Repository<TransactionRepoModel, String> {
         oldest_first: bool,
     ) -> Result<PaginatedResult<TransactionRepoModel>, RepositoryError>;
 
+    /// Like [`find_by_status_paginated`], but when `exclude_canceled` is true,
+    /// transactions flagged `is_canceled` are removed BEFORE counting and pagination,
+    /// so the returned page and `total` stay consistent (no short/empty pages).
+    ///
+    /// Used by the listing API to hide cancelled-in-progress transactions from
+    /// active-status queries; internal callers use the unfiltered variant so they
+    /// still see the still-active replacement NOOP.
+    async fn find_by_status_paginated_filtered(
+        &self,
+        relayer_id: &str,
+        statuses: &[TransactionStatus],
+        query: PaginationQuery,
+        oldest_first: bool,
+        exclude_canceled: bool,
+    ) -> Result<PaginatedResult<TransactionRepoModel>, RepositoryError>;
+
     /// Find a transaction by relayer ID and nonce
     async fn find_by_nonce(
         &self,
@@ -225,6 +241,7 @@ mockall::mock! {
       async fn find_by_relayer_id(&self, relayer_id: &str, query: PaginationQuery) -> Result<PaginatedResult<TransactionRepoModel>, RepositoryError>;
       async fn find_by_status(&self, relayer_id: &str, statuses: &[TransactionStatus]) -> Result<Vec<TransactionRepoModel>, RepositoryError>;
       async fn find_by_status_paginated(&self, relayer_id: &str, statuses: &[TransactionStatus], query: PaginationQuery, oldest_first: bool) -> Result<PaginatedResult<TransactionRepoModel>, RepositoryError>;
+      async fn find_by_status_paginated_filtered(&self, relayer_id: &str, statuses: &[TransactionStatus], query: PaginationQuery, oldest_first: bool, exclude_canceled: bool) -> Result<PaginatedResult<TransactionRepoModel>, RepositoryError>;
       async fn find_by_nonce(&self, relayer_id: &str, nonce: u64) -> Result<Option<TransactionRepoModel>, RepositoryError>;
       async fn get_nonce_occupancy(&self, relayer_id: &str, from_nonce: u64, to_nonce: u64) -> Result<Vec<(u64, Option<TransactionStatus>)>, RepositoryError>;
       async fn update_status(&self, tx_id: String, status: TransactionStatus) -> Result<TransactionRepoModel, RepositoryError>;
@@ -341,6 +358,38 @@ impl TransactionRepository for TransactionRepositoryStorage {
             TransactionRepositoryStorage::Redis(repo) => {
                 repo.find_by_status_paginated(relayer_id, statuses, query, oldest_first)
                     .await
+            }
+        }
+    }
+
+    async fn find_by_status_paginated_filtered(
+        &self,
+        relayer_id: &str,
+        statuses: &[TransactionStatus],
+        query: PaginationQuery,
+        oldest_first: bool,
+        exclude_canceled: bool,
+    ) -> Result<PaginatedResult<TransactionRepoModel>, RepositoryError> {
+        match self {
+            TransactionRepositoryStorage::InMemory(repo) => {
+                repo.find_by_status_paginated_filtered(
+                    relayer_id,
+                    statuses,
+                    query,
+                    oldest_first,
+                    exclude_canceled,
+                )
+                .await
+            }
+            TransactionRepositoryStorage::Redis(repo) => {
+                repo.find_by_status_paginated_filtered(
+                    relayer_id,
+                    statuses,
+                    query,
+                    oldest_first,
+                    exclude_canceled,
+                )
+                .await
             }
         }
     }

--- a/src/repositories/transaction/transaction_in_memory.rs
+++ b/src/repositories/transaction/transaction_in_memory.rs
@@ -299,6 +299,65 @@ impl TransactionRepository for InMemoryTransactionRepository {
         })
     }
 
+    async fn find_by_status_paginated_filtered(
+        &self,
+        relayer_id: &str,
+        statuses: &[TransactionStatus],
+        query: PaginationQuery,
+        oldest_first: bool,
+        exclude_canceled: bool,
+    ) -> Result<PaginatedResult<TransactionRepoModel>, RepositoryError> {
+        if !exclude_canceled {
+            return self
+                .find_by_status_paginated(relayer_id, statuses, query, oldest_first)
+                .await;
+        }
+
+        let store = Self::acquire_lock(&self.store).await?;
+
+        // Drop cancelled-in-progress transactions BEFORE counting/paginating so the
+        // page and total stay consistent.
+        let filtered: Vec<TransactionRepoModel> = store
+            .values()
+            .filter(|tx| {
+                tx.relayer_id == relayer_id
+                    && statuses.contains(&tx.status)
+                    && tx.is_canceled != Some(true)
+            })
+            .cloned()
+            .collect();
+
+        let total = filtered.len() as u64;
+        let start = ((query.page.saturating_sub(1)) * query.per_page) as usize;
+
+        let items: Vec<TransactionRepoModel> = if oldest_first {
+            filtered
+                .into_iter()
+                .sorted_by(|a, b| {
+                    let (a_key, _) = Self::get_sort_key(a);
+                    let (b_key, _) = Self::get_sort_key(b);
+                    a_key.cmp(b_key).then_with(|| a.id.cmp(&b.id))
+                })
+                .skip(start)
+                .take(query.per_page as usize)
+                .collect()
+        } else {
+            filtered
+                .into_iter()
+                .sorted_by(Self::compare_for_sort)
+                .skip(start)
+                .take(query.per_page as usize)
+                .collect()
+        };
+
+        Ok(PaginatedResult {
+            items,
+            total,
+            page: query.page,
+            per_page: query.per_page,
+        })
+    }
+
     async fn find_by_nonce(
         &self,
         relayer_id: &str,
@@ -1395,6 +1454,94 @@ mod tests {
 
         assert_eq!(result.total, 0);
         assert_eq!(result.items.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_find_by_status_paginated_filtered_excludes_canceled() {
+        let repo = InMemoryTransactionRepository::new();
+
+        let make = |id: &str, ts: &str, is_canceled: Option<bool>| -> TransactionRepoModel {
+            let mut tx = create_test_transaction_pending_state(id);
+            tx.created_at = ts.to_string();
+            tx.status = TransactionStatus::Submitted;
+            tx.is_canceled = is_canceled;
+            tx
+        };
+
+        // 3 normal Submitted txs and 1 cancelled-in-progress (still Submitted) in the middle.
+        repo.create(make("tx1", "2025-01-27T11:00:00.000000+00:00", None))
+            .await
+            .unwrap();
+        repo.create(make("tx2", "2025-01-27T12:00:00.000000+00:00", Some(true)))
+            .await
+            .unwrap();
+        repo.create(make("tx3", "2025-01-27T13:00:00.000000+00:00", Some(false)))
+            .await
+            .unwrap();
+        repo.create(make("tx4", "2025-01-27T14:00:00.000000+00:00", None))
+            .await
+            .unwrap();
+
+        let statuses = [TransactionStatus::Submitted];
+        let query = PaginationQuery {
+            page: 1,
+            per_page: 10,
+        };
+
+        // exclude_canceled = false → all 4 returned (unchanged behaviour).
+        let all = repo
+            .find_by_status_paginated_filtered("relayer-1", &statuses, query.clone(), false, false)
+            .await
+            .unwrap();
+        assert_eq!(all.total, 4);
+        assert_eq!(all.items.len(), 4);
+
+        // exclude_canceled = true → the cancelled tx is dropped BEFORE counting, so total
+        // and items are both consistent (no short/empty page, no over-counted total).
+        let filtered = repo
+            .find_by_status_paginated_filtered("relayer-1", &statuses, query, false, true)
+            .await
+            .unwrap();
+        assert_eq!(filtered.total, 3, "total must reflect the filtered set");
+        assert_eq!(filtered.items.len(), 3);
+        let ids: Vec<&str> = filtered.items.iter().map(|t| t.id.as_str()).collect();
+        assert!(
+            !ids.contains(&"tx2"),
+            "cancelled tx must be excluded, got {ids:?}"
+        );
+
+        // Pagination stays consistent across pages: 2 per page → page 1 has 2, page 2 has 1,
+        // and tx2 never appears, with no empty intermediate page.
+        let p1 = repo
+            .find_by_status_paginated_filtered(
+                "relayer-1",
+                &statuses,
+                PaginationQuery {
+                    page: 1,
+                    per_page: 2,
+                },
+                false,
+                true,
+            )
+            .await
+            .unwrap();
+        assert_eq!(p1.total, 3);
+        assert_eq!(p1.items.len(), 2);
+        let p2 = repo
+            .find_by_status_paginated_filtered(
+                "relayer-1",
+                &statuses,
+                PaginationQuery {
+                    page: 2,
+                    per_page: 2,
+                },
+                false,
+                true,
+            )
+            .await
+            .unwrap();
+        assert_eq!(p2.total, 3);
+        assert_eq!(p2.items.len(), 1);
     }
 
     #[tokio::test]

--- a/src/repositories/transaction/transaction_redis.rs
+++ b/src/repositories/transaction/transaction_redis.rs
@@ -1578,6 +1578,108 @@ impl TransactionRepository for RedisTransactionRepository {
         })
     }
 
+    async fn find_by_status_paginated_filtered(
+        &self,
+        relayer_id: &str,
+        statuses: &[TransactionStatus],
+        query: PaginationQuery,
+        oldest_first: bool,
+        exclude_canceled: bool,
+    ) -> Result<PaginatedResult<TransactionRepoModel>, RepositoryError> {
+        if !exclude_canceled {
+            return self
+                .find_by_status_paginated(relayer_id, statuses, query, oldest_first)
+                .await;
+        }
+
+        // Excluding cancelled-in-progress transactions means removing them BEFORE
+        // counting and paginating, which the per-status sorted-set fast path (zcard +
+        // ZRANGE) cannot do. So for this listing-only path we load all matching
+        // transactions, drop the cancelled ones, then sort/paginate in memory. The hot
+        // internal callers use the unfiltered fast method above.
+        for status in statuses {
+            self.ensure_status_sorted_set(relayer_id, status).await?;
+        }
+
+        let mut conn = self
+            .get_connection(
+                self.connections.reader(),
+                "find_by_status_paginated_filtered",
+            )
+            .await?;
+
+        // Collect all ids (with scores) across the requested statuses.
+        let mut all_ids: Vec<(String, f64)> = Vec::new();
+        for status in statuses {
+            let sorted_key = self.relayer_status_sorted_key(relayer_id, status);
+            let ids_with_scores: Vec<(String, f64)> = redis::cmd("ZRANGE")
+                .arg(&sorted_key)
+                .arg(0)
+                .arg(-1)
+                .arg("WITHSCORES")
+                .query_async(&mut conn)
+                .await
+                .map_err(|e| self.map_redis_error(e, "find_by_status_paginated_filtered"))?;
+            all_ids.extend(ids_with_scores);
+        }
+
+        drop(conn);
+
+        // Dedup across statuses, keeping the extreme score for the sort direction.
+        let mut id_map: std::collections::HashMap<String, f64> = std::collections::HashMap::new();
+        for (id, score) in all_ids {
+            id_map
+                .entry(id)
+                .and_modify(|s| {
+                    if oldest_first {
+                        if score < *s {
+                            *s = score
+                        }
+                    } else if score > *s {
+                        *s = score
+                    }
+                })
+                .or_insert(score);
+        }
+
+        let mut sorted_ids: Vec<(String, f64)> = id_map.into_iter().collect();
+        if oldest_first {
+            sorted_ids.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal));
+        } else {
+            sorted_ids.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+        }
+        let ordered_ids: Vec<String> = sorted_ids.into_iter().map(|(id, _)| id).collect();
+
+        // Load all matching transactions, then filter + paginate, preserving sort order.
+        let fetched = self.get_transactions_by_ids(&ordered_ids).await?;
+        let mut by_id: std::collections::HashMap<String, TransactionRepoModel> = fetched
+            .results
+            .into_iter()
+            .map(|t| (t.id.clone(), t))
+            .collect();
+
+        let filtered: Vec<TransactionRepoModel> = ordered_ids
+            .iter()
+            .filter_map(|id| by_id.remove(id))
+            .filter(|t| t.is_canceled != Some(true))
+            .collect();
+
+        let total = filtered.len() as u64;
+        let start = ((query.page.saturating_sub(1)) * query.per_page) as usize;
+        let items: Vec<TransactionRepoModel> = filtered
+            .into_iter()
+            .skip(start)
+            .take(query.per_page as usize)
+            .collect();
+
+        Ok(PaginatedResult {
+            items,
+            total,
+            page: query.page,
+            per_page: query.per_page,
+        })
+    }
+
     async fn find_by_nonce(
         &self,
         relayer_id: &str,

--- a/src/services/notification/mod.rs
+++ b/src/services/notification/mod.rs
@@ -157,6 +157,7 @@ mod tests {
             max_priority_fee_per_gas: None,
             signature: None,
             speed: None,
+            is_canceled: None,
         }))
     }
 


### PR DESCRIPTION
## Summary

Taking over and combining #792 and #793 (both by @shaunwackerly, who asked us to carry them forward) into a single, robust feature:

**A cancelled transaction disappears from active-status listings immediately and ends up `Canceled` — without losing on-chain tracking, and without ever mislabelling a transaction that actually executed.**

The two original PRs are interdependent (the listing filter only makes sense alongside the cancel-flow's `is_canceled` semantics), so they're cleaner as one change. Thanks @shaunwackerly for the original work and approach.

## What changed

**1. Filter the transaction list by status** (was #792)
- `GET /relayers/{id}/transactions?status=…` now filters by status via a new `TransactionListQuery`.
- The `status` value is accepted **case-insensitively** (`submitted`, `Submitted`, `SUBMITTED` all match), and the param is documented in the OpenAPI spec.

**2. Rework the cancellation flow** (reworked from #793)
- `cancel_transaction` no longer forces `status=Canceled` before enqueueing the resubmit job. That earlier approach made the resubmit handler **skip the NOOP** (its guard only allows `Sent`/`Submitted`), so the nonce was never freed and the original tx could still mine — and it disabled all follow-up tracking, since `handle_status_impl` short-circuits on final states.
- Instead the tx keeps its active status with `is_canceled=true` and stays under the normal status machinery (resubmit, nonce recovery, hash recovery) until the NOOP actually mines.
- **Terminal status is attributed by what actually mined.** A cancellation NOOP is a self-send (`to == from`). When a cancelled tx confirms, `check_transaction_status` returns `Canceled` only if the mined receipt is that NOOP (`receipt.to == receipt.from`). If the **original** mined instead (the cancellation lost the nonce race), it genuinely executed and is reported `Confirmed` — never falsely `Canceled`. This keys off the mined receipt rather than locally-stored data, which can still describe the NOOP while the original hash is what confirmed. (Mirrors how OZ Defender reconstructs terminal state from on-chain truth.)

**3. Hide cancelled-in-progress txs from active-status listings**
- The list endpoint excludes `is_canceled` transactions when the queried status is **non-terminal**, so a cancelled tx no longer appears under e.g. `?status=Submitted`. Terminal queries (`?status=Canceled`) are unaffected, so the settled tx remains visible there.
- The exclusion is applied in the repository via `find_by_status_paginated_filtered(.., exclude_canceled)`, **before** counting and pagination — so `total` and the returned page stay consistent (no short/empty pages). The existing `find_by_status_paginated` and its internal nonce/cleanup callers are untouched, so they still see the active NOOP.

**4. Expose `is_canceled`**
- Added to `EvmTransactionResponse` so clients can see a cancelled-in-progress transaction directly.

## Review-driven refinements

This PR incorporates fixes from a `codex` review and the CodeRabbit thread:
- **Correctness (was a mislabel risk):** terminal status is now attributed by the mined receipt, so a lost-race original is reported `Confirmed`, not `Canceled`.
- **Pagination (was a page-selection bug):** the exclusion moved from a post-pagination filter to a repository-level pre-pagination filter, keeping counts/pages consistent.
- **Ergonomics:** `?status=` is case-insensitive; `is_canceled` is exposed.

## Relationship to #792 / #793

Supersedes both — they are now closed in favour of this PR (credit to @shaunwackerly).

## Test plan

- [x] `cargo test --lib` green (pre-existing flaky `services::provider::*` / `stellar::lane_gate` concurrency tests aside; they pass in isolation).
- New unit tests:
  - `check_transaction_status`: cancellation NOOP confirmed (`to == from`) → `Canceled`; **original mined** (`to != from`) → `Confirmed`; non-cancellation self-send → `Confirmed`.
  - `find_by_status_paginated_filtered`: excludes `is_canceled` before pagination, with correct `total` and consistent pages across requests.
  - `list_transactions`: excludes cancelled-in-progress from `?status=Submitted`; still returns them under `?status=Canceled`.
  - `TransactionListQuery`: `?status=` parsed case-insensitively (and absent/invalid handled), decoded through `web::Query`.
  - `cancel_transaction`: keeps status `Submitted` with `is_canceled=true`.
- [x] Live end-to-end against a local `anvil` (`--no-mining`) + Redis + the relayer built from this branch: submit → cancel → excluded from `?status=submitted` (with `is_canceled=true` exposed) → mine → terminates `canceled` → appears under `?status=canceled`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Transaction lists can now be filtered by status, in addition to standard paging.

* **Bug Fixes**
  * Active transaction lists now hide cancelled-in-progress items, while completed cancelled transactions still appear where expected.
  * Cancelled transactions now display correctly after being finalized on-chain.
  * Improved cancellation handling so user-cancelled transactions stay visible as cancelled rather than appearing confirmed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
