### PR TITLE
feat: Bounded Redis connection lifetime for endpoint/DNS-change recovery

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,10 @@ REDIS_URL=redis://localhost:6379
 # Optional reader endpoint for read-heavy Redis deployments
 # REDIS_READER_URL=redis://localhost:6380
 REDIS_CONNECTION_TIMEOUT_MS=10000
+# Max Redis connection age (ms) before recycling; fresh connections re-resolve
+# DNS so the relayer follows endpoint changes (e.g. ElastiCache failover).
+# 0 disables age-based recycling. Default: 60000
+REDIS_CONNECTION_MAX_AGE_MS=60000
 REDIS_KEY_PREFIX=oz-relayer
 
 # Queue backend selection

--- a/src/config/server_config.rs
+++ b/src/config/server_config.rs
@@ -444,6 +444,10 @@ impl ServerConfig {
     ///
     /// See the `redis_connection_max_age_ms` field docs. Defaults to 60000ms
     /// (also on parse failure); `0` disables age-based recycling.
+    ///
+    /// Note: the pool recycler sweeps at half this value clamped to
+    /// `[1s, 30s]`, so values under ~2000ms are effectively bounded by the 1s
+    /// sweep floor rather than the configured age.
     pub fn get_redis_connection_max_age_ms() -> u64 {
         env::var("REDIS_CONNECTION_MAX_AGE_MS")
             .unwrap_or_else(|_| "60000".to_string())

--- a/src/config/server_config.rs
+++ b/src/config/server_config.rs
@@ -440,14 +440,10 @@ impl ServerConfig {
             .unwrap_or(10000)
     }
 
-    /// Gets the Redis connection max age from environment variable or default
+    /// Gets the Redis connection max age from environment variable or default.
     ///
-    /// Controls how long a Redis connection may live before it is proactively
-    /// dropped and reopened so a fresh connect re-resolves the endpoint DNS
-    /// (needed to follow endpoint changes such as failover, scaling, or node
-    /// replacement, e.g. an ElastiCache failover onto a new node). Defaults to
-    /// 60000ms. A value of `0` disables age-based recycling. Falls back to the
-    /// default on parse failure.
+    /// See the `redis_connection_max_age_ms` field docs. Defaults to 60000ms
+    /// (also on parse failure); `0` disables age-based recycling.
     pub fn get_redis_connection_max_age_ms() -> u64 {
         env::var("REDIS_CONNECTION_MAX_AGE_MS")
             .unwrap_or_else(|_| "60000".to_string())

--- a/src/config/server_config.rs
+++ b/src/config/server_config.rs
@@ -74,6 +74,13 @@ pub struct ServerConfig {
     pub redis_reader_pool_max_size: usize,
     /// Timeout in milliseconds waiting to get a connection from the pool.
     pub redis_pool_timeout_ms: u64,
+    /// Maximum lifetime in milliseconds for a Redis connection before it is
+    /// proactively dropped and reopened. Reopening re-resolves the endpoint's
+    /// DNS, which lets connections follow endpoint changes such as failover,
+    /// scaling, node replacement, or maintenance (e.g. after an ElastiCache
+    /// failover repoints the endpoint to a new node). A value of `0` disables
+    /// age-based recycling.
+    pub redis_connection_max_age_ms: u64,
     /// The number of milliseconds to wait for an RPC response.
     pub rpc_timeout_ms: u64,
     /// Maximum number of retry attempts for provider operations.
@@ -174,6 +181,7 @@ impl ServerConfig {
             redis_key_prefix: Self::get_redis_key_prefix(),
             redis_pool_max_size: Self::get_redis_pool_max_size(),
             redis_pool_timeout_ms: Self::get_redis_pool_timeout_ms(),
+            redis_connection_max_age_ms: Self::get_redis_connection_max_age_ms(),
             rpc_timeout_ms: Self::get_rpc_timeout_ms(),
             provider_max_retries: Self::get_provider_max_retries(),
             provider_retry_base_delay_ms: Self::get_provider_retry_base_delay_ms(),
@@ -430,6 +438,21 @@ impl ServerConfig {
             .ok()
             .filter(|&v| v > 0)
             .unwrap_or(10000)
+    }
+
+    /// Gets the Redis connection max age from environment variable or default
+    ///
+    /// Controls how long a Redis connection may live before it is proactively
+    /// dropped and reopened so a fresh connect re-resolves the endpoint DNS
+    /// (needed to follow endpoint changes such as failover, scaling, or node
+    /// replacement, e.g. an ElastiCache failover onto a new node). Defaults to
+    /// 60000ms. A value of `0` disables age-based recycling. Falls back to the
+    /// default on parse failure.
+    pub fn get_redis_connection_max_age_ms() -> u64 {
+        env::var("REDIS_CONNECTION_MAX_AGE_MS")
+            .unwrap_or_else(|_| "60000".to_string())
+            .parse()
+            .unwrap_or(60000)
     }
 
     /// Gets the RPC timeout from environment variable or default
@@ -2132,6 +2155,46 @@ mod tests {
 
             env::remove_var("REDIS_URL");
             env::remove_var("API_KEY");
+        }
+    }
+
+    mod get_redis_connection_max_age_ms_tests {
+        use super::*;
+        use serial_test::serial;
+
+        #[test]
+        #[serial]
+        fn test_returns_default_when_env_not_set() {
+            env::remove_var("REDIS_CONNECTION_MAX_AGE_MS");
+            let result = ServerConfig::get_redis_connection_max_age_ms();
+            assert_eq!(result, 60000, "Should return default value of 60000");
+        }
+
+        #[test]
+        #[serial]
+        fn test_returns_env_value_when_set() {
+            env::set_var("REDIS_CONNECTION_MAX_AGE_MS", "120000");
+            let result = ServerConfig::get_redis_connection_max_age_ms();
+            assert_eq!(result, 120000, "Should return env var value");
+            env::remove_var("REDIS_CONNECTION_MAX_AGE_MS");
+        }
+
+        #[test]
+        #[serial]
+        fn test_returns_default_when_env_invalid() {
+            env::set_var("REDIS_CONNECTION_MAX_AGE_MS", "not_a_number");
+            let result = ServerConfig::get_redis_connection_max_age_ms();
+            assert_eq!(result, 60000, "Should return default value when invalid");
+            env::remove_var("REDIS_CONNECTION_MAX_AGE_MS");
+        }
+
+        #[test]
+        #[serial]
+        fn test_zero_disables_recycling() {
+            env::set_var("REDIS_CONNECTION_MAX_AGE_MS", "0");
+            let result = ServerConfig::get_redis_connection_max_age_ms();
+            assert_eq!(result, 0, "Should accept zero to disable recycling");
+            env::remove_var("REDIS_CONNECTION_MAX_AGE_MS");
         }
     }
 

--- a/src/queues/redis/mod.rs
+++ b/src/queues/redis/mod.rs
@@ -6,6 +6,7 @@ pub use crate::queues::{
 
 pub mod backend;
 pub mod queue;
+pub mod refreshing_connection;
 pub mod worker;
 
 pub use worker as redis_worker;

--- a/src/queues/redis/queue.rs
+++ b/src/queues/redis/queue.rs
@@ -16,6 +16,7 @@ use serde::{Deserialize, Serialize};
 use tokio::time::Duration;
 use tracing::info;
 
+use crate::queues::redis::refreshing_connection::RefreshingConnection;
 use crate::{config::ServerConfig, utils::RedisConnections};
 
 use crate::jobs::{
@@ -23,19 +24,27 @@ use crate::jobs::{
     TransactionSend, TransactionStatusCheck,
 };
 
+/// Storage type for all queues.
+///
+/// Uses [`RefreshingConnection`] instead of a bare `ConnectionManager` so that
+/// connections are dropped/reopened on a bounded lifetime, letting them follow
+/// the endpoint's DNS whenever it changes (e.g. after an ElastiCache failover
+/// repoints the endpoint to a new node).
+type QueueStorage<T> = RedisStorage<T, RefreshingConnection<ConnectionManager>>;
+
 #[derive(Clone)]
 pub struct Queue {
-    pub transaction_request_queue: RedisStorage<Job<TransactionRequest>>,
-    pub transaction_submission_queue: RedisStorage<Job<TransactionSend>>,
+    pub transaction_request_queue: QueueStorage<Job<TransactionRequest>>,
+    pub transaction_submission_queue: QueueStorage<Job<TransactionSend>>,
     /// Default/fallback status queue for backward compatibility, Solana, and future networks
-    pub transaction_status_queue: RedisStorage<Job<TransactionStatusCheck>>,
+    pub transaction_status_queue: QueueStorage<Job<TransactionStatusCheck>>,
     /// EVM-specific status queue with slower retries
-    pub transaction_status_queue_evm: RedisStorage<Job<TransactionStatusCheck>>,
+    pub transaction_status_queue_evm: QueueStorage<Job<TransactionStatusCheck>>,
     /// Stellar-specific status queue with fast retries
-    pub transaction_status_queue_stellar: RedisStorage<Job<TransactionStatusCheck>>,
-    pub notification_queue: RedisStorage<Job<NotificationSend>>,
-    pub token_swap_request_queue: RedisStorage<Job<TokenSwapRequest>>,
-    pub relayer_health_check_queue: RedisStorage<Job<RelayerHealthCheck>>,
+    pub transaction_status_queue_stellar: QueueStorage<Job<TransactionStatusCheck>>,
+    pub notification_queue: QueueStorage<Job<NotificationSend>>,
+    pub token_swap_request_queue: QueueStorage<Job<TokenSwapRequest>>,
+    pub relayer_health_check_queue: QueueStorage<Job<RelayerHealthCheck>>,
     /// Redis connection pools for handlers that need pool-based access.
     /// Provides both primary (write) and reader (read) pools for:
     /// - Distributed locking
@@ -105,9 +114,9 @@ impl Queue {
     /// ensuring queue processing continues even if the Redis connection drops temporarily.
     fn storage<T: Serialize + for<'de> Deserialize<'de>>(
         namespace: &str,
-        conn: ConnectionManager,
+        conn: RefreshingConnection<ConnectionManager>,
         queue_config: QueueConfig,
-    ) -> RedisStorage<T> {
+    ) -> QueueStorage<T> {
         let config = Config::default()
             .set_namespace(namespace)
             .set_enqueue_scheduled(queue_config.enqueue_scheduled);
@@ -115,23 +124,37 @@ impl Queue {
         RedisStorage::new_with_config(conn, config)
     }
 
-    /// Creates a ConnectionManager with the standard queue configuration.
+    /// Creates a `RefreshingConnection` wrapping a `ConnectionManager` with the
+    /// standard queue configuration.
     ///
     /// Each ConnectionManager represents a single Redis connection with auto-reconnect.
     /// Creating separate managers for different queue types enables parallel Redis operations.
+    ///
+    /// The connection is wrapped in a [`RefreshingConnection`] so it is dropped
+    /// and reopened once it exceeds `max_age_ms`, re-resolving DNS to follow
+    /// the endpoint wherever it currently points (e.g. after an ElastiCache
+    /// failover repoints the endpoint to a new node).
     async fn create_connection_manager(
         client: &redis::Client,
         queue_timeout: Duration,
-    ) -> Result<ConnectionManager> {
+        max_age_ms: u64,
+    ) -> Result<RefreshingConnection<ConnectionManager>> {
         let conn_config = ConnectionManagerConfig::new()
             .set_connection_timeout(queue_timeout)
             .set_response_timeout(queue_timeout)
             .set_number_of_retries(2)
             .set_max_delay(1000);
 
-        ConnectionManager::new_with_config(client.clone(), conn_config)
+        let conn = ConnectionManager::new_with_config(client.clone(), conn_config.clone())
             .await
-            .map_err(|e| eyre::eyre!("Failed to create Redis connection manager: {}", e))
+            .map_err(|e| eyre::eyre!("Failed to create Redis connection manager: {}", e))?;
+
+        Ok(RefreshingConnection::new(
+            client.clone(),
+            conn_config,
+            conn,
+            max_age_ms,
+        ))
     }
 
     /// Sets up all job queues with properly configured Redis connections.
@@ -163,16 +186,30 @@ impl Queue {
         // Worst case calculation: 3 attempts × 5s timeout + ~0.3s backoff = ~15.3s
         let queue_timeout = Duration::from_secs(5);
 
+        // Bounded connection lifetime: each queue connection is dropped and
+        // reopened once it exceeds this age so a fresh connect re-resolves the
+        // endpoint's DNS, letting it follow endpoint changes such as failover,
+        // scaling, or node replacement (e.g. an ElastiCache failover repointing
+        // the endpoint to a new node). `0` disables age-based recycling.
+        let max_age_ms = server_config.redis_connection_max_age_ms;
+
         // Create one ConnectionManager per queue to prevent connection contention.
         // Each ConnectionManager is a single Redis connection with auto-reconnect.
-        let conn_tx_request = Self::create_connection_manager(&client, queue_timeout).await?;
-        let conn_tx_submit = Self::create_connection_manager(&client, queue_timeout).await?;
-        let conn_status = Self::create_connection_manager(&client, queue_timeout).await?;
-        let conn_status_evm = Self::create_connection_manager(&client, queue_timeout).await?;
-        let conn_status_stellar = Self::create_connection_manager(&client, queue_timeout).await?;
-        let conn_notification = Self::create_connection_manager(&client, queue_timeout).await?;
-        let conn_swap = Self::create_connection_manager(&client, queue_timeout).await?;
-        let conn_health = Self::create_connection_manager(&client, queue_timeout).await?;
+        let conn_tx_request =
+            Self::create_connection_manager(&client, queue_timeout, max_age_ms).await?;
+        let conn_tx_submit =
+            Self::create_connection_manager(&client, queue_timeout, max_age_ms).await?;
+        let conn_status =
+            Self::create_connection_manager(&client, queue_timeout, max_age_ms).await?;
+        let conn_status_evm =
+            Self::create_connection_manager(&client, queue_timeout, max_age_ms).await?;
+        let conn_status_stellar =
+            Self::create_connection_manager(&client, queue_timeout, max_age_ms).await?;
+        let conn_notification =
+            Self::create_connection_manager(&client, queue_timeout, max_age_ms).await?;
+        let conn_swap = Self::create_connection_manager(&client, queue_timeout, max_age_ms).await?;
+        let conn_health =
+            Self::create_connection_manager(&client, queue_timeout, max_age_ms).await?;
 
         info!(
             redis_url = %redis_url,

--- a/src/queues/redis/queue.rs
+++ b/src/queues/redis/queue.rs
@@ -29,7 +29,10 @@ use crate::jobs::{
 /// Uses [`RefreshingConnection`] instead of a bare `ConnectionManager` so that
 /// connections are dropped/reopened on a bounded lifetime, letting them follow
 /// the endpoint's DNS whenever it changes (e.g. after an ElastiCache failover
-/// repoints the endpoint to a new node).
+/// repoints the endpoint to a new node). Connections are ALSO rebuilt
+/// reactively when a reply indicates the connection is pinned to a read-only
+/// node, which accelerates recovery; the bounded lifetime remains the
+/// guaranteed backstop.
 type QueueStorage<T> = RedisStorage<T, RefreshingConnection<ConnectionManager>>;
 
 #[derive(Clone)]
@@ -130,10 +133,8 @@ impl Queue {
     /// Each ConnectionManager represents a single Redis connection with auto-reconnect.
     /// Creating separate managers for different queue types enables parallel Redis operations.
     ///
-    /// The connection is wrapped in a [`RefreshingConnection`] so it is dropped
-    /// and reopened once it exceeds `max_age_ms`, re-resolving DNS to follow
-    /// the endpoint wherever it currently points (e.g. after an ElastiCache
-    /// failover repoints the endpoint to a new node).
+    /// The connection is wrapped in a [`RefreshingConnection`] so it is
+    /// recycled on age and on read-only replies (see [`QueueStorage`]).
     async fn create_connection_manager(
         client: &redis::Client,
         queue_timeout: Duration,
@@ -186,11 +187,8 @@ impl Queue {
         // Worst case calculation: 3 attempts × 5s timeout + ~0.3s backoff = ~15.3s
         let queue_timeout = Duration::from_secs(5);
 
-        // Bounded connection lifetime: each queue connection is dropped and
-        // reopened once it exceeds this age so a fresh connect re-resolves the
-        // endpoint's DNS, letting it follow endpoint changes such as failover,
-        // scaling, or node replacement (e.g. an ElastiCache failover repointing
-        // the endpoint to a new node). `0` disables age-based recycling.
+        // Bounded connection lifetime (see `QueueStorage`). `0` disables only
+        // the age backstop, not reactive read-only healing.
         let max_age_ms = server_config.redis_connection_max_age_ms;
 
         // Create one ConnectionManager per queue to prevent connection contention.

--- a/src/queues/redis/queue.rs
+++ b/src/queues/redis/queue.rs
@@ -33,7 +33,7 @@ use crate::jobs::{
 /// reactively when a reply indicates the connection is pinned to a read-only
 /// node, which accelerates recovery; the bounded lifetime remains the
 /// guaranteed backstop.
-type QueueStorage<T> = RedisStorage<T, RefreshingConnection<ConnectionManager>>;
+pub type QueueStorage<T> = RedisStorage<T, RefreshingConnection<ConnectionManager>>;
 
 #[derive(Clone)]
 pub struct Queue {

--- a/src/queues/redis/refreshing_connection.rs
+++ b/src/queues/redis/refreshing_connection.rs
@@ -1,0 +1,400 @@
+//! A `ConnectionLike` wrapper that gives Redis connections a bounded lifetime,
+//! so they are periodically dropped and reopened.
+//!
+//! # Why this exists
+//!
+//! A long-lived Redis connection resolves the endpoint's DNS once, at connect
+//! time, and then keeps talking to whatever address it first resolved. If the
+//! DNS behind the endpoint later changes — due to failover, scaling, node
+//! replacement, blue/green cutover, or maintenance — the connection stays
+//! pinned to the OLD, now-stale node instead of following the endpoint to its
+//! new target (e.g. after an ElastiCache failover repoints the endpoint to a
+//! new node). A stale connection pinned to a demoted node keeps failing writes
+//! as one symptom, but the underlying problem is the stale DNS resolution, not
+//! any particular error. `ConnectionManager` only re-resolves DNS when it
+//! reconnects, and it reconnects on a broken socket — NOT on a valid error
+//! reply over a healthy socket, so it never notices the endpoint moved.
+//!
+//! `RefreshingConnection` fixes this by giving each connection a bounded
+//! lifetime: once a connection exceeds a jittered max age it is dropped and
+//! reopened before the next command, and a fresh connect re-resolves the
+//! endpoint's DNS onto whatever node it currently points to. Recovery from any
+//! DNS change is therefore bounded by the configured max age.
+//!
+//! # Shared healing state
+//!
+//! `RedisStorage` is cloned into every worker AND cloned per enqueue on the
+//! producer path. All clones of a given queue's connection therefore share ONE
+//! healing connection and ONE age clock via `Arc<Mutex<ConnState>>`. A rebuild
+//! performed by any clone is immediately visible to all other clones. This is
+//! what makes the fix correct in steady state: without shared state, the
+//! template living in the `Queue` struct would have a `created_at` fixed at
+//! setup that never advances, so every producer clone would be born
+//! already-expired once uptime exceeds `max_age`, opening a brand-new connection
+//! per enqueue forever.
+//!
+//! ## Locking discipline
+//!
+//! The `std::sync::Mutex` guard is NEVER held across an `.await`; it guards only
+//! tiny synchronous critical sections (read/clone the current conn, swap in a
+//! rebuilt conn). The actual command is delegated with no lock held, and the
+//! inner `ConnectionManager` is a multiplexed connection, so concurrent
+//! commands from different clones stay concurrent. Cloning `C` is cheap and
+//! shares the underlying multiplexed pipe.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use redis::aio::{ConnectionLike, ConnectionManager, ConnectionManagerConfig};
+use redis::{Client, Cmd, Pipeline, RedisFuture, RedisResult, Value};
+use tracing::warn;
+
+/// Per-connection jitter fraction applied to the base max age (±20%).
+///
+/// Spreads reconnects across connections and instances so they do not reconnect
+/// in lockstep, which would otherwise cause synchronized load spikes on Redis.
+const JITTER_FRACTION: f64 = 0.20;
+
+/// Boxed future returned by the connection builder closure.
+type BuildFuture<C> = Pin<Box<dyn Future<Output = RedisResult<C>> + Send>>;
+
+/// Builds a fresh inner connection on demand. Cloneable so the wrapper can
+/// rebuild repeatedly and so the whole wrapper can be `Clone`.
+type Builder<C> = Arc<dyn Fn() -> BuildFuture<C> + Send + Sync>;
+
+/// Shared, interior-mutable healing state for a `RefreshingConnection`.
+///
+/// One instance is shared (behind `Arc<Mutex<..>>`) by all clones of a given
+/// queue's connection.
+struct ConnState<C: ConnectionLike + Clone + Send> {
+    /// The current inner connection all commands delegate to.
+    conn: C,
+    /// When the current `conn` was created.
+    created_at: Instant,
+    /// The un-jittered base max age. `None` disables age-based recycling.
+    base_max_age: Option<Duration>,
+    /// Effective max age for the current connection (`base_max_age` ± jitter).
+    /// `None` disables age-based recycling. Re-drawn on each rebuild.
+    max_age: Option<Duration>,
+}
+
+impl<C: ConnectionLike + Clone + Send> ConnState<C> {
+    /// Whether the current connection has exceeded its (jittered) max age.
+    fn is_expired(&self) -> bool {
+        matches!(self.max_age, Some(age) if self.created_at.elapsed() >= age)
+    }
+
+    /// Installs a freshly built connection: swaps it in, resets the age clock,
+    /// and re-draws the jittered max age around the fixed base.
+    fn install(&mut self, new_conn: C) {
+        self.conn = new_conn;
+        self.created_at = Instant::now();
+        self.max_age = self.base_max_age.map(jittered_max_age);
+    }
+}
+
+/// A `ConnectionLike` wrapper that periodically rebuilds its inner connection
+/// (bounded lifetime), sharing healing state across all clones.
+///
+/// Generic over the inner connection type so it can be unit-tested against a
+/// fake `ConnectionLike`; in production `C = ConnectionManager`.
+#[derive(Clone)]
+pub struct RefreshingConnection<C: ConnectionLike + Clone + Send> {
+    /// Builds a fresh inner connection (re-resolves DNS in production). Shared.
+    builder: Builder<C>,
+    /// Shared interior-mutable healing state. Cloning the wrapper clones this
+    /// `Arc`, so all clones share one connection and one age clock.
+    state: Arc<Mutex<ConnState<C>>>,
+}
+
+/// Returns a deterministic, per-instance jitter multiplier in
+/// `[1 - JITTER_FRACTION, 1 + JITTER_FRACTION]`.
+///
+/// Each rebuild draws a fresh value so connections/instances do not reconnect
+/// in lockstep.
+fn jitter_multiplier() -> f64 {
+    let r: f64 = rand::random::<f64>(); // [0, 1)
+    1.0 - JITTER_FRACTION + r * (2.0 * JITTER_FRACTION)
+}
+
+/// Applies the jitter multiplier to a base max age.
+fn jittered_max_age(base: Duration) -> Duration {
+    base.mul_f64(jitter_multiplier())
+}
+
+impl<C: ConnectionLike + Clone + Send> RefreshingConnection<C> {
+    /// Creates a wrapper from an already-built inner connection and a builder
+    /// used to rebuild it later.
+    ///
+    /// `max_age_ms == 0` disables the age-based rebuild entirely. A non-zero
+    /// value is jittered per rebuild.
+    fn from_parts(builder: Builder<C>, conn: C, max_age_ms: u64) -> Self {
+        let base_max_age = if max_age_ms == 0 {
+            None
+        } else {
+            Some(Duration::from_millis(max_age_ms))
+        };
+        let max_age = base_max_age.map(jittered_max_age);
+        let state = ConnState {
+            conn,
+            created_at: Instant::now(),
+            base_max_age,
+            max_age,
+        };
+        Self {
+            builder,
+            state: Arc::new(Mutex::new(state)),
+        }
+    }
+
+    /// Locks the state guard, recovering from poisoning (a panic while healing
+    /// must not wedge the connection forever).
+    fn lock(&self) -> std::sync::MutexGuard<'_, ConnState<C>> {
+        self.state.lock().unwrap_or_else(|p| p.into_inner())
+    }
+
+    /// Resolves the connection to delegate to, performing a proactive age
+    /// rebuild first if needed.
+    ///
+    /// Locking discipline: reads/swaps happen under brief synchronous locks;
+    /// the `builder().await` runs with NO lock held.
+    async fn conn_for_command(&self) -> C {
+        // Brief lock: check expiry and clone out the current conn.
+        let (expired, conn) = {
+            let guard = self.lock();
+            (guard.is_expired(), guard.conn.clone())
+        };
+
+        if !expired {
+            return conn;
+        }
+
+        // Build a replacement OUTSIDE the lock.
+        match (self.builder)().await {
+            Ok(new_conn) => {
+                let mut guard = self.lock();
+                // Only install if still expired — another clone may have
+                // rebuilt while we were building; if so, drop ours.
+                if guard.is_expired() {
+                    guard.install(new_conn);
+                }
+                guard.conn.clone()
+            }
+            Err(e) => {
+                warn!(error = %e, "failed to rebuild Redis connection (age); keeping existing connection");
+                // Keep whatever is current now.
+                self.lock().conn.clone()
+            }
+        }
+    }
+}
+
+impl RefreshingConnection<ConnectionManager> {
+    /// Creates a `RefreshingConnection` wrapping a `ConnectionManager`.
+    ///
+    /// The builder recreates a `ConnectionManager` from `client` and
+    /// `cm_config`; a fresh `ConnectionManager` re-resolves the host via DNS,
+    /// which is how recreating a connection follows the CNAME onto the new
+    /// writer after failover.
+    pub fn new(
+        client: Client,
+        cm_config: ConnectionManagerConfig,
+        inner: ConnectionManager,
+        max_age_ms: u64,
+    ) -> Self {
+        let builder: Builder<ConnectionManager> = Arc::new(move || {
+            let client = client.clone();
+            let cm_config = cm_config.clone();
+            Box::pin(async move { ConnectionManager::new_with_config(client, cm_config).await })
+        });
+        Self::from_parts(builder, inner, max_age_ms)
+    }
+}
+
+impl<C: ConnectionLike + Clone + Send> ConnectionLike for RefreshingConnection<C> {
+    fn req_packed_command<'a>(&'a mut self, cmd: &'a Cmd) -> RedisFuture<'a, Value> {
+        Box::pin(async move {
+            let mut conn = self.conn_for_command().await;
+            // Delegate with NO lock held (preserves multiplexing/concurrency).
+            conn.req_packed_command(cmd).await
+        })
+    }
+
+    fn req_packed_commands<'a>(
+        &'a mut self,
+        cmd: &'a Pipeline,
+        offset: usize,
+        count: usize,
+    ) -> RedisFuture<'a, Vec<Value>> {
+        Box::pin(async move {
+            let mut conn = self.conn_for_command().await;
+            // Delegate with NO lock held (preserves multiplexing/concurrency).
+            conn.req_packed_commands(cmd, offset, count).await
+        })
+    }
+
+    fn get_db(&self) -> i64 {
+        // Brief lock to read the current connection's db.
+        self.lock().conn.get_db()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+
+    /// A fake `ConnectionLike` we fully control: every command succeeds and
+    /// records how many commands this instance served.
+    #[derive(Clone)]
+    struct FakeConn {
+        /// Unique id so tests can tell rebuilt connections apart.
+        id: u64,
+        /// Count of commands served by THIS connection instance.
+        calls: Arc<AtomicUsize>,
+    }
+
+    impl FakeConn {
+        fn new(id: u64) -> Self {
+            Self {
+                id,
+                calls: Arc::new(AtomicUsize::new(0)),
+            }
+        }
+    }
+
+    impl ConnectionLike for FakeConn {
+        fn req_packed_command<'a>(&'a mut self, _cmd: &'a Cmd) -> RedisFuture<'a, Value> {
+            Box::pin(async move {
+                self.calls.fetch_add(1, Ordering::SeqCst);
+                Ok(Value::Okay)
+            })
+        }
+
+        fn req_packed_commands<'a>(
+            &'a mut self,
+            _cmd: &'a Pipeline,
+            _offset: usize,
+            _count: usize,
+        ) -> RedisFuture<'a, Vec<Value>> {
+            Box::pin(async move {
+                self.calls.fetch_add(1, Ordering::SeqCst);
+                Ok(vec![Value::Okay])
+            })
+        }
+
+        fn get_db(&self) -> i64 {
+            self.id as i64
+        }
+    }
+
+    /// Builds a `RefreshingConnection<FakeConn>` whose builder hands out a new
+    /// `FakeConn` (incrementing id) on each rebuild, and counts rebuilds.
+    fn make_conn(max_age_ms: u64) -> (RefreshingConnection<FakeConn>, Arc<AtomicU64>) {
+        let rebuild_count = Arc::new(AtomicU64::new(0));
+        let next_id = Arc::new(AtomicU64::new(1));
+        let rc = rebuild_count.clone();
+        let ni = next_id.clone();
+
+        let builder: Builder<FakeConn> = Arc::new(move || {
+            let rc = rc.clone();
+            let ni = ni.clone();
+            Box::pin(async move {
+                rc.fetch_add(1, Ordering::SeqCst);
+                let id = ni.fetch_add(1, Ordering::SeqCst);
+                Ok(FakeConn::new(id))
+            })
+        });
+
+        let initial = FakeConn::new(next_id.fetch_add(1, Ordering::SeqCst));
+        let conn = RefreshingConnection::from_parts(builder, initial, max_age_ms);
+        (conn, rebuild_count)
+    }
+
+    /// Force the shared state to look expired regardless of jitter.
+    fn force_expire(conn: &RefreshingConnection<FakeConn>) {
+        let mut guard = conn.lock();
+        guard.created_at = Instant::now() - Duration::from_secs(3600);
+    }
+
+    #[tokio::test]
+    async fn test_age_triggered_rebuild() {
+        // Tiny max age so the connection is immediately expired.
+        let (mut conn, rebuilds) = make_conn(1);
+        force_expire(&conn);
+        assert!(conn.lock().is_expired(), "connection should be expired");
+
+        let _ = conn.req_packed_command(&Cmd::new()).await;
+
+        assert_eq!(
+            rebuilds.load(Ordering::SeqCst),
+            1,
+            "aged connection should rebuild once before delegating"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_age_rebuild_disabled_when_zero() {
+        // max_age_ms == 0 => age-based rebuild disabled.
+        let (mut conn, rebuilds) = make_conn(0);
+        assert!(
+            conn.lock().max_age.is_none(),
+            "max_age should be None when disabled"
+        );
+        // Even a very old created_at must not trigger a rebuild.
+        force_expire(&conn);
+        assert!(!conn.lock().is_expired());
+
+        let _ = conn.req_packed_command(&Cmd::new()).await;
+
+        assert_eq!(
+            rebuilds.load(Ordering::SeqCst),
+            0,
+            "age-based rebuild must be disabled when max_age_ms == 0"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_get_db_delegates_to_inner() {
+        let (conn, _) = make_conn(0);
+        // The initial FakeConn is assigned id 1 (before any builder rebuild).
+        assert_eq!(
+            conn.get_db(),
+            1,
+            "get_db must delegate to the inner connection"
+        );
+    }
+
+    /// Regression guard for the producer-path fix: cloning an already-expired
+    /// wrapper and driving several clones must NOT rebuild once per clone.
+    /// Because all clones share one `ConnState`, the proactive age rebuild
+    /// happens at most once across all of them.
+    #[tokio::test]
+    async fn test_shared_state_rebuilds_at_most_once_across_clones() {
+        let (base, rebuilds) = make_conn(60_000);
+        force_expire(&base);
+        assert!(base.lock().is_expired(), "base must start expired");
+
+        // Simulate the producer path: clone the template per enqueue.
+        let mut clone_a = base.clone();
+        let mut clone_b = base.clone();
+
+        let _ = clone_a.req_packed_command(&Cmd::new()).await;
+        let _ = clone_b.req_packed_command(&Cmd::new()).await;
+
+        // Shared state: the first command rebuilt and advanced the age clock;
+        // the second clone sees a fresh, non-expired connection and does NOT
+        // rebuild again.
+        assert_eq!(
+            rebuilds.load(Ordering::SeqCst),
+            1,
+            "shared state must rebuild at most once across clones, not once per clone"
+        );
+        assert!(
+            !base.lock().is_expired(),
+            "the age clock must have advanced (visible through all clones)"
+        );
+    }
+}

--- a/src/queues/redis/refreshing_connection.rs
+++ b/src/queues/redis/refreshing_connection.rs
@@ -21,6 +21,24 @@
 //! endpoint's DNS onto whatever node it currently points to. Recovery from any
 //! DNS change is therefore bounded by the configured max age.
 //!
+//! # Reactive rebuild (accelerator)
+//!
+//! Age-based recycling is the guaranteed backstop, but recovery is only as fast
+//! as the configured max age. On top of it, connections are ALSO rebuilt
+//! reactively when a command reply indicates the connection is pinned to a
+//! read-only node — the tell-tale symptom of talking to a stale/demoted node
+//! after an endpoint change. When such a reply is observed the wrapper rebuilds
+//! the connection immediately (rate-limited by [`MIN_RECONNECT_GAP`]), so the
+//! very next command re-resolves DNS onto the current node instead of waiting
+//! out the age window. This detection intentionally covers BOTH shapes Redis
+//! uses for a write-on-replica failure: a top-level `Err(ReadOnly)` (direct
+//! write commands) AND an inline `Value::ServerError` embedded in an otherwise
+//! `Ok(..)` reply (apalis runs queue ops as Lua `EVALSHA` scripts, and the
+//! read-only failure is returned inside the script reply, not as a top-level
+//! error). Reactive rebuild is an accelerator only; it does not replace the
+//! age-based backstop, and it is not keyed on any specific error string beyond
+//! the read-only marker.
+//!
 //! # Shared healing state
 //!
 //! `RedisStorage` is cloned into every worker AND cloned per enqueue on the
@@ -57,6 +75,13 @@ use tracing::warn;
 /// in lockstep, which would otherwise cause synchronized load spikes on Redis.
 const JITTER_FRACTION: f64 = 0.20;
 
+/// Minimum gap between two reactive (read-only-triggered) rebuilds.
+///
+/// Rate-limits the reactive path so a burst of read-only replies (which all
+/// arrive before a single rebuild can take effect) triggers at most one
+/// rebuild per window instead of a reconnect storm.
+const MIN_RECONNECT_GAP: Duration = Duration::from_secs(3);
+
 /// Boxed future returned by the connection builder closure.
 type BuildFuture<C> = Pin<Box<dyn Future<Output = RedisResult<C>> + Send>>;
 
@@ -69,15 +94,14 @@ type Builder<C> = Arc<dyn Fn() -> BuildFuture<C> + Send + Sync>;
 /// One instance is shared (behind `Arc<Mutex<..>>`) by all clones of a given
 /// queue's connection.
 struct ConnState<C: ConnectionLike + Clone + Send> {
-    /// The current inner connection all commands delegate to.
     conn: C,
-    /// When the current `conn` was created.
     created_at: Instant,
-    /// The un-jittered base max age. `None` disables age-based recycling.
+    /// Un-jittered base; `None` disables age-based recycling.
     base_max_age: Option<Duration>,
-    /// Effective max age for the current connection (`base_max_age` ± jitter).
-    /// `None` disables age-based recycling. Re-drawn on each rebuild.
+    /// `base_max_age` ± jitter, re-drawn on each rebuild.
     max_age: Option<Duration>,
+    /// Timestamp of the last reactive rebuild; gates the rate limit.
+    last_reconnect: Option<Instant>,
 }
 
 impl<C: ConnectionLike + Clone + Send> ConnState<C> {
@@ -86,12 +110,33 @@ impl<C: ConnectionLike + Clone + Send> ConnState<C> {
         matches!(self.max_age, Some(age) if self.created_at.elapsed() >= age)
     }
 
+    /// Whether a reactive rebuild is allowed right now under the rate limit:
+    /// true if none has happened yet or at least `min_gap` has elapsed since
+    /// the last one.
+    fn reconnect_allowed(&self, min_gap: Duration) -> bool {
+        match self.last_reconnect {
+            None => true,
+            Some(at) => at.elapsed() >= min_gap,
+        }
+    }
+
     /// Installs a freshly built connection: swaps it in, resets the age clock,
     /// and re-draws the jittered max age around the fixed base.
     fn install(&mut self, new_conn: C) {
         self.conn = new_conn;
         self.created_at = Instant::now();
         self.max_age = self.base_max_age.map(jittered_max_age);
+    }
+
+    /// Claims the age-rebuild window: pushes the age clock back so the
+    /// connection only re-expires after `gap`. Concurrent clones then see a
+    /// non-expired connection (one build in flight, no thundering herd), and a
+    /// failed build cannot retry faster than the gap. A successful build
+    /// resets the clock fully via `install`.
+    fn defer_expiry(&mut self, gap: Duration) {
+        if let Some(age) = self.max_age {
+            self.created_at = Instant::now() - age.saturating_sub(gap);
+        }
     }
 }
 
@@ -107,6 +152,7 @@ pub struct RefreshingConnection<C: ConnectionLike + Clone + Send> {
     /// Shared interior-mutable healing state. Cloning the wrapper clones this
     /// `Arc`, so all clones share one connection and one age clock.
     state: Arc<Mutex<ConnState<C>>>,
+    min_reconnect_gap: Duration,
 }
 
 /// Returns a deterministic, per-instance jitter multiplier in
@@ -142,10 +188,12 @@ impl<C: ConnectionLike + Clone + Send> RefreshingConnection<C> {
             created_at: Instant::now(),
             base_max_age,
             max_age,
+            last_reconnect: None,
         };
         Self {
             builder,
             state: Arc::new(Mutex::new(state)),
+            min_reconnect_gap: MIN_RECONNECT_GAP,
         }
     }
 
@@ -158,36 +206,76 @@ impl<C: ConnectionLike + Clone + Send> RefreshingConnection<C> {
     /// Resolves the connection to delegate to, performing a proactive age
     /// rebuild first if needed.
     ///
-    /// Locking discipline: reads/swaps happen under brief synchronous locks;
-    /// the `builder().await` runs with NO lock held.
+    /// The rebuild window is claimed under the first lock BEFORE building
+    /// (via `defer_expiry`) — success or failure — so only one clone builds at
+    /// a time and a failed build retries no faster than `min_reconnect_gap`.
+    /// The `builder().await` runs with NO lock held.
     async fn conn_for_command(&self) -> C {
-        // Brief lock: check expiry and clone out the current conn.
-        let (expired, conn) = {
-            let guard = self.lock();
-            (guard.is_expired(), guard.conn.clone())
+        let stale_conn = {
+            let mut guard = self.lock();
+            if !guard.is_expired() {
+                return guard.conn.clone();
+            }
+            guard.defer_expiry(self.min_reconnect_gap);
+            guard.conn.clone()
         };
 
-        if !expired {
-            return conn;
-        }
-
-        // Build a replacement OUTSIDE the lock.
         match (self.builder)().await {
             Ok(new_conn) => {
                 let mut guard = self.lock();
-                // Only install if still expired — another clone may have
-                // rebuilt while we were building; if so, drop ours.
-                if guard.is_expired() {
-                    guard.install(new_conn);
-                }
+                guard.install(new_conn);
                 guard.conn.clone()
             }
             Err(e) => {
                 warn!(error = %e, "failed to rebuild Redis connection (age); keeping existing connection");
-                // Keep whatever is current now.
-                self.lock().conn.clone()
+                stale_conn
             }
         }
+    }
+
+    /// Reactively rebuilds the inner connection in response to a read-only
+    /// reply, rate-limited by `min_reconnect_gap`.
+    ///
+    /// The rate-limit window is claimed under the first lock BEFORE building —
+    /// success or failure — so concurrent clones short-circuit at the gate
+    /// (one build in flight, no thundering herd) and a failed rebuild retries
+    /// no faster than the gap. The `builder().await` runs with NO lock held.
+    async fn handle_readonly(&self) {
+        {
+            let mut guard = self.lock();
+            if !guard.reconnect_allowed(self.min_reconnect_gap) {
+                return;
+            }
+            guard.last_reconnect = Some(Instant::now());
+        }
+
+        match (self.builder)().await {
+            Ok(new_conn) => self.lock().install(new_conn),
+            Err(e) => {
+                warn!(error = %e, "failed to rebuild Redis connection (read-only); keeping existing connection");
+            }
+        }
+    }
+}
+
+/// Returns true if a reply indicates the connection is pinned to a read-only
+/// node, recursing into aggregate replies so nested and pipeline replies
+/// (e.g. Lua `EVALSHA` script results) are covered.
+///
+/// Redis surfaces a write-on-replica failure as an inline `Value::ServerError`
+/// carrying the `READONLY` code, which can appear at the top level or nested
+/// inside an aggregate — redis-rs only lifts it to a top-level `Err` one layer
+/// above this wrapper, so we must inspect the `Value` shape directly.
+fn is_readonly_value(v: &Value) -> bool {
+    match v {
+        Value::ServerError(e) => e.code() == "READONLY",
+        Value::Array(items) | Value::Set(items) => items.iter().any(is_readonly_value),
+        Value::Map(pairs) => pairs
+            .iter()
+            .any(|(k, val)| is_readonly_value(k) || is_readonly_value(val)),
+        Value::Push { data, .. } => data.iter().any(is_readonly_value),
+        Value::Attribute { data, .. } => is_readonly_value(data),
+        _ => false,
     }
 }
 
@@ -217,8 +305,16 @@ impl<C: ConnectionLike + Clone + Send> ConnectionLike for RefreshingConnection<C
     fn req_packed_command<'a>(&'a mut self, cmd: &'a Cmd) -> RedisFuture<'a, Value> {
         Box::pin(async move {
             let mut conn = self.conn_for_command().await;
-            // Delegate with NO lock held (preserves multiplexing/concurrency).
-            conn.req_packed_command(cmd).await
+            let result = conn.req_packed_command(cmd).await;
+            // Reactive rebuild on a read-only reply, in either shape: a
+            // top-level `Err(ReadOnly)` (direct writes) or an inline
+            // `Value::ServerError` embedded in an `Ok(..)` reply (Lua scripts).
+            if matches!(&result, Err(e) if e.kind() == redis::ErrorKind::ReadOnly)
+                || matches!(&result, Ok(v) if is_readonly_value(v))
+            {
+                self.handle_readonly().await;
+            }
+            result
         })
     }
 
@@ -230,13 +326,20 @@ impl<C: ConnectionLike + Clone + Send> ConnectionLike for RefreshingConnection<C
     ) -> RedisFuture<'a, Vec<Value>> {
         Box::pin(async move {
             let mut conn = self.conn_for_command().await;
-            // Delegate with NO lock held (preserves multiplexing/concurrency).
-            conn.req_packed_commands(cmd, offset, count).await
+            let result = conn.req_packed_commands(cmd, offset, count).await;
+            // Reactive rebuild on a read-only reply, in either shape: a
+            // top-level `Err(ReadOnly)` or an inline `Value::ServerError`
+            // embedded in any element of the `Ok(..)` pipeline reply.
+            if matches!(&result, Err(e) if e.kind() == redis::ErrorKind::ReadOnly)
+                || matches!(&result, Ok(vs) if vs.iter().any(is_readonly_value))
+            {
+                self.handle_readonly().await;
+            }
+            result
         })
     }
 
     fn get_db(&self) -> i64 {
-        // Brief lock to read the current connection's db.
         self.lock().conn.get_db()
     }
 }
@@ -246,21 +349,60 @@ mod tests {
     use super::*;
     use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 
-    /// A fake `ConnectionLike` we fully control: every command succeeds and
-    /// records how many commands this instance served.
+    /// How a `FakeConn` should reply to commands, so tests can reproduce the
+    /// exact production shapes of a read-only failure.
+    #[derive(Clone, Copy)]
+    enum Reply {
+        /// Normal success (`Value::Okay` / `[Value::Okay]`).
+        Ok,
+        /// Inline read-only `ServerError` inside an otherwise-`Ok(..)` reply —
+        /// the apalis Lua-script shape that a naive top-level `Err` guard
+        /// missed. THE regression case.
+        InlineReadonly,
+        /// Inline read-only nested one aggregate level deeper
+        /// (`Ok(Array[Array[ServerError]])`) — exercises the recursion arm.
+        NestedInlineReadonly,
+        /// Top-level `Err(ReadOnly)` — the shape direct write commands take.
+        ErrReadonly,
+    }
+
+    /// Parses a RESP `-READONLY ...` error line into the `Value::ServerError`
+    /// that redis-rs produces in production, WITHOUT naming redis's private
+    /// `ServerError`/`ServerErrorKind` types. This is exactly the inline error
+    /// value that appears embedded in an otherwise-`Ok(..)` script reply.
+    fn readonly_value() -> Value {
+        redis::parse_redis_value(b"-READONLY You can't write against a read only replica.\r\n")
+            .expect("parse READONLY server error")
+    }
+
+    /// A top-level `Err` whose kind is `ReadOnly`, as a direct write would
+    /// surface it one layer above this wrapper.
+    fn readonly_err() -> redis::RedisError {
+        redis::RedisError::from((redis::ErrorKind::ReadOnly, "read only replica"))
+    }
+
+    /// A fake `ConnectionLike` we fully control: it replies according to its
+    /// `reply` mode and records how many commands this instance served.
     #[derive(Clone)]
     struct FakeConn {
         /// Unique id so tests can tell rebuilt connections apart.
         id: u64,
         /// Count of commands served by THIS connection instance.
         calls: Arc<AtomicUsize>,
+        /// How this connection replies to commands.
+        reply: Reply,
     }
 
     impl FakeConn {
         fn new(id: u64) -> Self {
+            Self::with_reply(id, Reply::Ok)
+        }
+
+        fn with_reply(id: u64, reply: Reply) -> Self {
             Self {
                 id,
                 calls: Arc::new(AtomicUsize::new(0)),
+                reply,
             }
         }
     }
@@ -269,7 +411,14 @@ mod tests {
         fn req_packed_command<'a>(&'a mut self, _cmd: &'a Cmd) -> RedisFuture<'a, Value> {
             Box::pin(async move {
                 self.calls.fetch_add(1, Ordering::SeqCst);
-                Ok(Value::Okay)
+                match self.reply {
+                    Reply::Ok => Ok(Value::Okay),
+                    Reply::InlineReadonly => Ok(readonly_value()),
+                    Reply::NestedInlineReadonly => {
+                        Ok(Value::Array(vec![Value::Array(vec![readonly_value()])]))
+                    }
+                    Reply::ErrReadonly => Err(readonly_err()),
+                }
             })
         }
 
@@ -281,7 +430,16 @@ mod tests {
         ) -> RedisFuture<'a, Vec<Value>> {
             Box::pin(async move {
                 self.calls.fetch_add(1, Ordering::SeqCst);
-                Ok(vec![Value::Okay])
+                match self.reply {
+                    Reply::Ok => Ok(vec![Value::Okay]),
+                    Reply::InlineReadonly => Ok(vec![readonly_value()]),
+                    Reply::NestedInlineReadonly => {
+                        Ok(vec![Value::Array(vec![Value::Array(vec![
+                            readonly_value(),
+                        ])])])
+                    }
+                    Reply::ErrReadonly => Err(readonly_err()),
+                }
             })
         }
 
@@ -291,8 +449,19 @@ mod tests {
     }
 
     /// Builds a `RefreshingConnection<FakeConn>` whose builder hands out a new
-    /// `FakeConn` (incrementing id) on each rebuild, and counts rebuilds.
+    /// (healthy, `Reply::Ok`) `FakeConn` with incrementing id on each rebuild,
+    /// and counts rebuilds. The initial connection is also healthy.
     fn make_conn(max_age_ms: u64) -> (RefreshingConnection<FakeConn>, Arc<AtomicU64>) {
+        make_conn_with_initial_reply(max_age_ms, Reply::Ok)
+    }
+
+    /// Like `make_conn`, but the INITIAL connection replies with `initial_reply`
+    /// (e.g. a read-only shape). Rebuilt connections are always healthy so that
+    /// a reactive rebuild resolves the condition after exactly one rebuild.
+    fn make_conn_with_initial_reply(
+        max_age_ms: u64,
+        initial_reply: Reply,
+    ) -> (RefreshingConnection<FakeConn>, Arc<AtomicU64>) {
         let rebuild_count = Arc::new(AtomicU64::new(0));
         let next_id = Arc::new(AtomicU64::new(1));
         let rc = rebuild_count.clone();
@@ -308,7 +477,7 @@ mod tests {
             })
         });
 
-        let initial = FakeConn::new(next_id.fetch_add(1, Ordering::SeqCst));
+        let initial = FakeConn::with_reply(next_id.fetch_add(1, Ordering::SeqCst), initial_reply);
         let conn = RefreshingConnection::from_parts(builder, initial, max_age_ms);
         (conn, rebuild_count)
     }
@@ -317,6 +486,13 @@ mod tests {
     fn force_expire(conn: &RefreshingConnection<FakeConn>) {
         let mut guard = conn.lock();
         guard.created_at = Instant::now() - Duration::from_secs(3600);
+    }
+
+    /// Push `last_reconnect` far enough into the past that the reactive rate
+    /// limit no longer blocks another rebuild.
+    fn elapse_reconnect_gap(conn: &RefreshingConnection<FakeConn>) {
+        let mut guard = conn.lock();
+        guard.last_reconnect = Some(Instant::now() - Duration::from_secs(3600));
     }
 
     #[tokio::test]
@@ -337,7 +513,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_age_rebuild_disabled_when_zero() {
-        // max_age_ms == 0 => age-based rebuild disabled.
+        // max_age_ms == 0 => AGE-based rebuild disabled. The reactive path is
+        // independent and stays active (see test_reactive_rebuild_*).
         let (mut conn, rebuilds) = make_conn(0);
         assert!(
             conn.lock().max_age.is_none(),
@@ -347,12 +524,114 @@ mod tests {
         force_expire(&conn);
         assert!(!conn.lock().is_expired());
 
+        // A healthy reply must not trigger the reactive path either.
         let _ = conn.req_packed_command(&Cmd::new()).await;
 
         assert_eq!(
             rebuilds.load(Ordering::SeqCst),
             0,
             "age-based rebuild must be disabled when max_age_ms == 0"
+        );
+    }
+
+    /// THE regression guard: an inline read-only `ServerError` embedded in an
+    /// otherwise-`Ok(..)` single-command reply (the apalis Lua-script shape a
+    /// naive top-level `Err` guard missed) must trigger exactly one reactive
+    /// rebuild. Age is disabled here so only the reactive path can fire.
+    #[tokio::test]
+    async fn test_reactive_rebuild_on_inline_readonly_command() {
+        let (mut conn, rebuilds) = make_conn_with_initial_reply(0, Reply::InlineReadonly);
+
+        let _ = conn.req_packed_command(&Cmd::new()).await;
+
+        assert_eq!(
+            rebuilds.load(Ordering::SeqCst),
+            1,
+            "inline Ok(Value::ServerError(READONLY)) must trigger exactly one reactive rebuild"
+        );
+    }
+
+    /// Same regression guard for the pipeline path: an inline read-only
+    /// `ServerError` nested in an `Ok(vec![..])` reply must trigger exactly one
+    /// reactive rebuild.
+    #[tokio::test]
+    async fn test_reactive_rebuild_on_inline_readonly_commands() {
+        let (mut conn, rebuilds) = make_conn_with_initial_reply(0, Reply::InlineReadonly);
+
+        let _ = conn.req_packed_commands(&Pipeline::new(), 0, 1).await;
+
+        assert_eq!(
+            rebuilds.load(Ordering::SeqCst),
+            1,
+            "inline Ok(vec![Value::ServerError(READONLY)]) must trigger exactly one reactive rebuild"
+        );
+    }
+
+    /// Direct-write shape: a top-level `Err(ReadOnly)` must also trigger a
+    /// reactive rebuild.
+    #[tokio::test]
+    async fn test_reactive_rebuild_on_err_readonly() {
+        let (mut conn, rebuilds) = make_conn_with_initial_reply(0, Reply::ErrReadonly);
+
+        let _ = conn.req_packed_command(&Cmd::new()).await;
+
+        assert_eq!(
+            rebuilds.load(Ordering::SeqCst),
+            1,
+            "top-level Err(ReadOnly) must trigger exactly one reactive rebuild"
+        );
+    }
+
+    /// The rate limit: repeated read-only replies within `min_reconnect_gap`
+    /// cause a single rebuild; once the gap has elapsed, another is allowed.
+    ///
+    /// Here the builder produces conns that STILL reply read-only, so the
+    /// condition never clears and every command re-enters the reactive path —
+    /// isolating the rate limit as the only thing that gates rebuild count.
+    #[tokio::test]
+    async fn test_reactive_rebuild_rate_limited() {
+        let rebuild_count = Arc::new(AtomicU64::new(0));
+        let next_id = Arc::new(AtomicU64::new(1));
+        let rc = rebuild_count.clone();
+        let ni = next_id.clone();
+
+        // Every built connection also replies read-only, so the reactive path
+        // fires on every command; only the rate limit caps the rebuild count.
+        let builder: Builder<FakeConn> = Arc::new(move || {
+            let rc = rc.clone();
+            let ni = ni.clone();
+            Box::pin(async move {
+                rc.fetch_add(1, Ordering::SeqCst);
+                let id = ni.fetch_add(1, Ordering::SeqCst);
+                Ok(FakeConn::with_reply(id, Reply::InlineReadonly))
+            })
+        });
+        let initial = FakeConn::with_reply(
+            next_id.fetch_add(1, Ordering::SeqCst),
+            Reply::InlineReadonly,
+        );
+        // Age disabled so only the reactive path can rebuild.
+        let mut conn = RefreshingConnection::from_parts(builder, initial, 0);
+
+        // First read-only reply: allowed (last_reconnect is None) -> 1 rebuild.
+        let _ = conn.req_packed_command(&Cmd::new()).await;
+        // Second read-only reply immediately after: within the gap -> no rebuild.
+        let _ = conn.req_packed_command(&Cmd::new()).await;
+
+        assert_eq!(
+            rebuild_count.load(Ordering::SeqCst),
+            1,
+            "repeated read-only within the gap must rebuild at most once"
+        );
+
+        // Simulate the gap elapsing: the next read-only reply is allowed again.
+        elapse_reconnect_gap(&conn);
+        let _ = conn.req_packed_command(&Cmd::new()).await;
+
+        assert_eq!(
+            rebuild_count.load(Ordering::SeqCst),
+            2,
+            "after the gap elapses, another reactive rebuild is allowed"
         );
     }
 
@@ -395,6 +674,103 @@ mod tests {
         assert!(
             !base.lock().is_expired(),
             "the age clock must have advanced (visible through all clones)"
+        );
+    }
+
+    /// Builds a wrapper whose builder ALWAYS fails, counting attempts — for
+    /// asserting that failed rebuilds are rate-limited instead of storming.
+    fn make_conn_with_failing_builder(
+        max_age_ms: u64,
+        initial_reply: Reply,
+    ) -> (RefreshingConnection<FakeConn>, Arc<AtomicU64>) {
+        let attempts = Arc::new(AtomicU64::new(0));
+        let at = attempts.clone();
+        let builder: Builder<FakeConn> = Arc::new(move || {
+            let at = at.clone();
+            Box::pin(async move {
+                at.fetch_add(1, Ordering::SeqCst);
+                Err(redis::RedisError::from((
+                    redis::ErrorKind::IoError,
+                    "connect failed",
+                )))
+            })
+        });
+        let initial = FakeConn::with_reply(1, initial_reply);
+        let conn = RefreshingConnection::from_parts(builder, initial, max_age_ms);
+        (conn, attempts)
+    }
+
+    /// A FAILED reactive rebuild must still consume the rate-limit window;
+    /// otherwise every read-only reply during an outage would hammer the
+    /// builder (reconnect storm).
+    #[tokio::test]
+    async fn test_reactive_failed_rebuild_is_rate_limited() {
+        let (mut conn, attempts) = make_conn_with_failing_builder(0, Reply::InlineReadonly);
+
+        // First read-only reply: one (failed) build attempt claims the window.
+        // Subsequent read-only replies within the gap must not retry.
+        let _ = conn.req_packed_command(&Cmd::new()).await;
+        let _ = conn.req_packed_command(&Cmd::new()).await;
+        let _ = conn.req_packed_command(&Cmd::new()).await;
+        assert_eq!(
+            attempts.load(Ordering::SeqCst),
+            1,
+            "failed reactive rebuilds within the gap must not retry the builder"
+        );
+        assert_eq!(conn.get_db(), 1, "existing connection must be preserved");
+
+        // Once the gap elapses, one more attempt is allowed.
+        elapse_reconnect_gap(&conn);
+        let _ = conn.req_packed_command(&Cmd::new()).await;
+        assert_eq!(
+            attempts.load(Ordering::SeqCst),
+            2,
+            "after the gap elapses, another rebuild attempt is allowed"
+        );
+    }
+
+    /// A FAILED age rebuild must defer the next attempt (via the claimed
+    /// window) instead of retrying the builder on every command.
+    #[tokio::test]
+    async fn test_age_failed_rebuild_is_rate_limited() {
+        let (mut conn, attempts) = make_conn_with_failing_builder(60_000, Reply::Ok);
+        force_expire(&conn);
+
+        // First command: one (failed) build attempt claims the window.
+        // Further commands within the gap reuse the stale connection.
+        let _ = conn.req_packed_command(&Cmd::new()).await;
+        let _ = conn.req_packed_command(&Cmd::new()).await;
+        let _ = conn.req_packed_command(&Cmd::new()).await;
+        assert_eq!(
+            attempts.load(Ordering::SeqCst),
+            1,
+            "a failed age rebuild must not retry the builder on every command"
+        );
+        assert_eq!(conn.get_db(), 1, "existing connection must be preserved");
+
+        // Once the claim expires, a retry is allowed.
+        force_expire(&conn);
+        let _ = conn.req_packed_command(&Cmd::new()).await;
+        assert_eq!(
+            attempts.load(Ordering::SeqCst),
+            2,
+            "after the claim expires, another rebuild attempt is allowed"
+        );
+    }
+
+    /// The aggregate recursion: a read-only `ServerError` nested one level
+    /// deeper (array-in-array, as a script reply can be shaped) must still
+    /// trigger the reactive rebuild.
+    #[tokio::test]
+    async fn test_reactive_rebuild_on_nested_readonly() {
+        let (mut conn, rebuilds) = make_conn_with_initial_reply(0, Reply::NestedInlineReadonly);
+
+        let _ = conn.req_packed_command(&Cmd::new()).await;
+
+        assert_eq!(
+            rebuilds.load(Ordering::SeqCst),
+            1,
+            "a READONLY nested inside aggregates must trigger a reactive rebuild"
         );
     }
 }

--- a/src/queues/redis/refreshing_connection.rs
+++ b/src/queues/redis/refreshing_connection.rs
@@ -133,9 +133,15 @@ impl<C: ConnectionLike + Clone + Send> ConnState<C> {
     /// non-expired connection (one build in flight, no thundering herd), and a
     /// failed build cannot retry faster than the gap. A successful build
     /// resets the clock fully via `install`.
+    ///
+    /// If the configured max age is shorter than `gap`, the effective retry
+    /// gap for failed builds is the max age itself. `checked_sub` guards
+    /// against `Instant` underflow on hosts whose monotonic clock started
+    /// recently; the fallback defers retry by one full age window instead.
     fn defer_expiry(&mut self, gap: Duration) {
         if let Some(age) = self.max_age {
-            self.created_at = Instant::now() - age.saturating_sub(gap);
+            let now = Instant::now();
+            self.created_at = now.checked_sub(age.saturating_sub(gap)).unwrap_or(now);
         }
     }
 }
@@ -482,17 +488,29 @@ mod tests {
         (conn, rebuild_count)
     }
 
+    /// An `Instant` far enough in the past to trip any age/gap check.
+    /// `checked_sub` with fallbacks: a bare `Instant - Duration` panics on
+    /// hosts whose monotonic clock started less than an hour ago (fresh
+    /// VMs/containers), which would make these tests flake.
+    fn distant_past() -> Instant {
+        let now = Instant::now();
+        [3600u64, 600, 60, 5]
+            .iter()
+            .find_map(|&secs| now.checked_sub(Duration::from_secs(secs)))
+            .unwrap_or(now)
+    }
+
     /// Force the shared state to look expired regardless of jitter.
     fn force_expire(conn: &RefreshingConnection<FakeConn>) {
         let mut guard = conn.lock();
-        guard.created_at = Instant::now() - Duration::from_secs(3600);
+        guard.created_at = distant_past();
     }
 
     /// Push `last_reconnect` far enough into the past that the reactive rate
     /// limit no longer blocks another rebuild.
     fn elapse_reconnect_gap(conn: &RefreshingConnection<FakeConn>) {
         let mut guard = conn.lock();
-        guard.last_reconnect = Some(Instant::now() - Duration::from_secs(3600));
+        guard.last_reconnect = Some(distant_past());
     }
 
     #[tokio::test]

--- a/src/utils/mocks.rs
+++ b/src/utils/mocks.rs
@@ -328,6 +328,7 @@ pub mod mockutils {
             redis_connection_timeout_ms: 5000,
             redis_pool_max_size: 10,
             redis_pool_timeout_ms: 5000,
+            redis_connection_max_age_ms: 60000,
             redis_key_prefix: "test-oz-relayer".to_string(),
             rpc_timeout_ms: 10000,
             provider_max_retries: 3,

--- a/src/utils/redis.rs
+++ b/src/utils/redis.rs
@@ -160,10 +160,16 @@ pub async fn initialize_redis_connections(config: &ServerConfig) -> Result<Arc<R
         }
     };
 
-    // Bound the PRIMARY (write) pool's connection lifetime so fresh connections
-    // periodically re-resolve the endpoint DNS and follow it to its current
-    // node. A separately configured reader pool is left untouched.
-    spawn_primary_pool_age_recycler(&primary_pool, config.redis_connection_max_age_ms);
+    // Bound pool connection lifetimes so fresh connections periodically
+    // re-resolve the endpoint DNS and follow it to its current node. A
+    // separately configured reader endpoint can repoint the same way (node
+    // replacement, scaling, blue/green), so a distinct reader pool gets its
+    // own recycler; without one, `reader_pool` aliases `primary_pool` and a
+    // single recycler covers both.
+    spawn_pool_age_recycler(&primary_pool, config.redis_connection_max_age_ms, "primary");
+    if !Arc::ptr_eq(&reader_pool, &primary_pool) {
+        spawn_pool_age_recycler(&reader_pool, config.redis_connection_max_age_ms, "reader");
+    }
 
     Ok(Arc::new(RedisConnections {
         primary_pool,
@@ -177,21 +183,29 @@ fn should_retain_connection(metrics: &Metrics, max_age: Duration) -> bool {
     metrics.created.elapsed() < max_age
 }
 
-/// Spawns a background task that evicts primary-pool connections older than
+/// Spawns a background task that evicts pool connections older than
 /// `max_age_ms` via `Pool::retain`; deadpool then lazily opens fresh
 /// connections on demand, which re-resolve DNS. `max_age_ms == 0` disables
 /// recycling and spawns nothing.
 ///
+/// The sweep runs at half the max age, clamped to `[1s, 30s]`, so a
+/// connection can outlive the bound by up to one sweep interval — and for
+/// `max_age_ms` under ~2000 the 1s floor means the effective lifetime bound
+/// is roughly one second, not the configured value.
+///
+/// The task holds only a `Weak` reference to the pool and exits once the
+/// owning `RedisConnections` (and any checked-out connections) are dropped.
+///
 /// (`Pool::retain` is used rather than a custom `Manager` because deadpool-redis
 /// 0.22 has no hook to swap the manager without changing the concrete `Pool`
 /// type that `RedisConnections` holds.)
-fn spawn_primary_pool_age_recycler(primary_pool: &Arc<Pool>, max_age_ms: u64) {
+fn spawn_pool_age_recycler(pool: &Arc<Pool>, max_age_ms: u64, pool_label: &'static str) {
     if max_age_ms == 0 {
         return;
     }
 
     let max_age = Duration::from_millis(max_age_ms);
-    let pool = primary_pool.clone();
+    let pool = Arc::downgrade(pool);
 
     // Sweep at roughly half the max age (bounded to a sane range) so an aged
     // connection is dropped well within one max-age window without hammering.
@@ -202,13 +216,17 @@ fn spawn_primary_pool_age_recycler(primary_pool: &Arc<Pool>, max_age_ms: u64) {
     tokio::spawn(async move {
         loop {
             tokio::time::sleep(interval).await;
+            let Some(pool) = pool.upgrade() else {
+                break;
+            };
             let result = pool.retain(|_, metrics| should_retain_connection(&metrics, max_age));
             if !result.removed.is_empty() {
                 debug!(
+                    pool = pool_label,
                     removed = result.removed.len(),
                     retained = result.retained,
                     max_age_ms = max_age_ms,
-                    "recycled aged primary Redis connections"
+                    "recycled aged Redis connections"
                 );
             }
         }
@@ -813,8 +831,13 @@ mod tests {
     #[test]
     fn test_should_retain_connection_drops_over_age_connection() {
         // Simulate a connection created well in the past → over max age → dropped.
+        // checked_sub: a bare `Instant - Duration` panics on hosts whose
+        // monotonic clock started less than 120s ago (fresh VMs/containers).
+        let Some(past) = std::time::Instant::now().checked_sub(Duration::from_secs(120)) else {
+            return;
+        };
         let mut metrics = Metrics::default();
-        metrics.created = std::time::Instant::now() - Duration::from_secs(120);
+        metrics.created = past;
         assert!(
             !should_retain_connection(&metrics, Duration::from_secs(60)),
             "over-age connection should be dropped"

--- a/src/utils/redis.rs
+++ b/src/utils/redis.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use color_eyre::Result;
-use deadpool_redis::{Config, Pool, Runtime};
+use deadpool_redis::{Config, Metrics, Pool, Runtime};
 use tracing::{debug, info, warn};
 
 use crate::config::ServerConfig;
@@ -160,10 +160,68 @@ pub async fn initialize_redis_connections(config: &ServerConfig) -> Result<Arc<R
         }
     };
 
+    // Bounded connection lifetime for the PRIMARY (write) pool: periodically
+    // evict connections older than `redis_connection_max_age_ms` so the next
+    // `get()` opens a fresh connection that re-resolves the endpoint DNS. This
+    // lets pooled writes follow endpoint changes such as failover, scaling, or
+    // node replacement (e.g. an ElastiCache failover repointing the endpoint to
+    // a new node) instead of staying pinned to a stale, potentially unusable
+    // node. Applied to the primary pool only; the reader pool is left untouched.
+    spawn_primary_pool_age_recycler(&primary_pool, config.redis_connection_max_age_ms);
+
     Ok(Arc::new(RedisConnections {
         primary_pool,
         reader_pool,
     }))
+}
+
+/// Spawns a background task that evicts primary-pool connections older than
+/// `max_age_ms`.
+///
+/// deadpool-redis 0.22 does not expose a hook to swap in a custom `Manager`
+/// without changing the concrete `Pool` type (which would ripple into
+/// `RedisConnections`), so age eviction is implemented with `Pool::retain`,
+/// which drops connections whose age exceeds the bound. Fresh connections are
+/// then created lazily by deadpool on demand, re-resolving DNS so the pool
+/// follows whatever node the endpoint currently points to.
+///
+/// Age-eviction predicate for `Pool::retain`.
+///
+/// Returns `true` to KEEP the connection and `false` to DROP it. A connection
+/// is dropped once its age (time since creation) reaches `max_age`.
+fn should_retain_connection(metrics: &Metrics, max_age: Duration) -> bool {
+    metrics.created.elapsed() < max_age
+}
+
+/// When `max_age_ms == 0`, recycling is disabled and no task is spawned.
+fn spawn_primary_pool_age_recycler(primary_pool: &Arc<Pool>, max_age_ms: u64) {
+    if max_age_ms == 0 {
+        return;
+    }
+
+    let max_age = Duration::from_millis(max_age_ms);
+    let pool = primary_pool.clone();
+
+    // Sweep at roughly half the max age (bounded to a sane range) so an aged
+    // connection is dropped well within one max-age window without hammering.
+    let interval = max_age
+        .div_f64(2.0)
+        .clamp(Duration::from_secs(1), Duration::from_secs(30));
+
+    tokio::spawn(async move {
+        loop {
+            tokio::time::sleep(interval).await;
+            let result = pool.retain(|_, metrics| should_retain_connection(&metrics, max_age));
+            if !result.removed.is_empty() {
+                debug!(
+                    removed = result.removed.len(),
+                    retained = result.retained,
+                    max_age_ms = max_age_ms,
+                    "recycled aged primary Redis connections"
+                );
+            }
+        }
+    });
 }
 
 /// A distributed lock implementation using Redis SET NX EX pattern.
@@ -749,6 +807,27 @@ mod tests {
 
         // First part should be parseable as u32 (process ID)
         assert!(parts[0].parse::<u32>().is_ok());
+    }
+
+    #[test]
+    fn test_should_retain_connection_keeps_young_connection() {
+        // A freshly created connection is younger than any positive max age.
+        let metrics = Metrics::default();
+        assert!(
+            should_retain_connection(&metrics, Duration::from_secs(60)),
+            "young connection should be retained"
+        );
+    }
+
+    #[test]
+    fn test_should_retain_connection_drops_over_age_connection() {
+        // Simulate a connection created well in the past → over max age → dropped.
+        let mut metrics = Metrics::default();
+        metrics.created = std::time::Instant::now() - Duration::from_secs(120);
+        assert!(
+            !should_retain_connection(&metrics, Duration::from_secs(60)),
+            "over-age connection should be dropped"
+        );
     }
 
     #[test]

--- a/src/utils/redis.rs
+++ b/src/utils/redis.rs
@@ -160,13 +160,9 @@ pub async fn initialize_redis_connections(config: &ServerConfig) -> Result<Arc<R
         }
     };
 
-    // Bounded connection lifetime for the PRIMARY (write) pool: periodically
-    // evict connections older than `redis_connection_max_age_ms` so the next
-    // `get()` opens a fresh connection that re-resolves the endpoint DNS. This
-    // lets pooled writes follow endpoint changes such as failover, scaling, or
-    // node replacement (e.g. an ElastiCache failover repointing the endpoint to
-    // a new node) instead of staying pinned to a stale, potentially unusable
-    // node. Applied to the primary pool only; the reader pool is left untouched.
+    // Bound the PRIMARY (write) pool's connection lifetime so fresh connections
+    // periodically re-resolve the endpoint DNS and follow it to its current
+    // node. A separately configured reader pool is left untouched.
     spawn_primary_pool_age_recycler(&primary_pool, config.redis_connection_max_age_ms);
 
     Ok(Arc::new(RedisConnections {
@@ -175,25 +171,20 @@ pub async fn initialize_redis_connections(config: &ServerConfig) -> Result<Arc<R
     }))
 }
 
-/// Spawns a background task that evicts primary-pool connections older than
-/// `max_age_ms`.
-///
-/// deadpool-redis 0.22 does not expose a hook to swap in a custom `Manager`
-/// without changing the concrete `Pool` type (which would ripple into
-/// `RedisConnections`), so age eviction is implemented with `Pool::retain`,
-/// which drops connections whose age exceeds the bound. Fresh connections are
-/// then created lazily by deadpool on demand, re-resolving DNS so the pool
-/// follows whatever node the endpoint currently points to.
-///
-/// Age-eviction predicate for `Pool::retain`.
-///
-/// Returns `true` to KEEP the connection and `false` to DROP it. A connection
-/// is dropped once its age (time since creation) reaches `max_age`.
+/// Age-eviction predicate for `Pool::retain`: keeps a connection while its age
+/// is under `max_age`, dropping it once it reaches the bound.
 fn should_retain_connection(metrics: &Metrics, max_age: Duration) -> bool {
     metrics.created.elapsed() < max_age
 }
 
-/// When `max_age_ms == 0`, recycling is disabled and no task is spawned.
+/// Spawns a background task that evicts primary-pool connections older than
+/// `max_age_ms` via `Pool::retain`; deadpool then lazily opens fresh
+/// connections on demand, which re-resolve DNS. `max_age_ms == 0` disables
+/// recycling and spawns nothing.
+///
+/// (`Pool::retain` is used rather than a custom `Manager` because deadpool-redis
+/// 0.22 has no hook to swap the manager without changing the concrete `Pool`
+/// type that `RedisConnections` holds.)
 fn spawn_primary_pool_age_recycler(primary_pool: &Arc<Pool>, max_age_ms: u64) {
     if max_age_ms == 0 {
         return;


### PR DESCRIPTION
## Problem

Long-lived Redis connections resolve DNS once and never again — `ConnectionManager` and deadpool connections only reconnect when the socket breaks. So when the DNS behind a Redis endpoint changes (failover, scaling, node replacement), existing connections stay pinned to the old node until the process restarts. Canonical case: an AWS ElastiCache writer failover repoints the endpoint to a new primary and the old node becomes a read-only replica — every write fails with `READONLY` indefinitely, and the queue workers spam:

```
WARN An error occurred during streaming jobs: ... ReadOnly: You can't write against a read only replica ...
```

## Fix

Two mechanisms; both recover because a fresh connection re-resolves DNS:

1. **Bounded connection lifetime (backstop).** Connections older than `REDIS_CONNECTION_MAX_AGE_MS` are dropped and reopened. Applied to the apalis queue connections via a new `RefreshingConnection` wrapper (`ConnectionLike`), and to the primary deadpool pool via `Pool::retain` age eviction. Recovery bounded by the max age.
2. **Reactive rebuild on READONLY (accelerator).** A read-only reply triggers an immediate rebuild (rate-limited, one attempt per 3s window; failed attempts consume the window so outages can't cause reconnect storms). Note: apalis runs queue ops as Lua scripts, and Redis returns the READONLY *inside* an otherwise-OK reply — so detection inspects the `Ok` payload too, not just top-level `Err(ReadOnly)`. Recovery in seconds; stays active even with `MAX_AGE_MS=0`.

Wrapper details: healing state is shared across clones (`Arc<Mutex<..>>`, never held across `.await`), so per-enqueue storage clones reuse one healed connection; rebuilds are jittered ±20% to avoid lockstep reconnects.

## Configuration

| Variable | Default | Notes |
|---|---|---|
| `REDIS_CONNECTION_MAX_AGE_MS` | `60000` | Max connection age before recycle. `0` disables age-based recycling (reactive stays on). Lower = faster recovery, more reconnect churn. |

Default-on, backward compatible.

## Validation

- Unit tests: age rebuild, shared-clone regression guard, reactive detection in the real reply shapes (inline `Ok(ServerError)` via `parse_redis_value`, pipeline/nested variants, top-level `Err`), failed-rebuild rate limiting, config parsing, pool eviction predicate.
- Live Docker reproduction (two Redis nodes behind a repointable proxy standing in for DNS): READONLY errors appear after failover, then the relayer recovers onto the new writer with **no restart** — including with `MAX_AGE_MS=0` to isolate the reactive path. A negative control built from `main` does **not** recover.
- Not yet exercised against real ElastiCache; a staging Global Datastore failover is recommended as the final DNS-TTL check.
