### PR TITLE
feat(signer): support hex-encoded messages in the sign endpoint

### DIFF
--- a/src/domain/relayer/mod.rs
+++ b/src/domain/relayer/mod.rs
@@ -629,9 +629,23 @@ impl<
     }
 }
 
+/// How the `message` field of a [`SignDataRequest`] is interpreted.
+#[derive(Serialize, Deserialize, ToSchema, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum SignDataRequestEncoding {
+    /// Interpreted as UTF-8 text. (default)
+    #[default]
+    Text,
+    /// Interpreted as a hex-encoded byte string (optional `0x` prefix), decoded to raw bytes.
+    Hex,
+}
+
 #[derive(Serialize, Deserialize, ToSchema)]
 pub struct SignDataRequest {
     pub message: String,
+    /// Encoding of `message`; defaults to `text`.
+    #[serde(default)]
+    pub encoding: SignDataRequestEncoding,
 }
 
 #[derive(Serialize, Deserialize, ToSchema)]

--- a/src/services/signer/evm/aws_kms_signer.rs
+++ b/src/services/signer/evm/aws_kms_signer.rs
@@ -15,7 +15,9 @@ use crate::{
     },
     services::{
         signer::{
-            evm::{construct_eip712_message_hash, validate_and_format_signature},
+            evm::{
+                construct_eip712_message_hash, resolve_message_bytes, validate_and_format_signature,
+            },
             DataSignerTrait, Signer,
         },
         AwsKmsClient, AwsKmsEvmService, AwsKmsService,
@@ -124,7 +126,7 @@ impl<T: AwsKmsEvmService> Signer for AwsKmsSigner<T> {
 #[async_trait]
 impl<T: AwsKmsEvmService> DataSignerTrait for AwsKmsSigner<T> {
     async fn sign_data(&self, request: SignDataRequest) -> Result<SignDataResponse, SignerError> {
-        let eip191_message = eip191_message(&request.message);
+        let eip191_message = eip191_message(&resolve_message_bytes(&request)?);
 
         let signature_bytes = self
             .aws_kms_service
@@ -216,6 +218,7 @@ mod tests {
         let signer = setup_mock_aws_signer();
         let request = SignDataRequest {
             message: "Test message".to_string(),
+            encoding: Default::default(),
         };
 
         let result = signer.sign_data(request).await.unwrap();
@@ -236,6 +239,7 @@ mod tests {
         let signer = setup_mock_aws_signer();
         let request = SignDataRequest {
             message: "".to_string(),
+            encoding: Default::default(),
         };
 
         let result = signer.sign_data(request).await;

--- a/src/services/signer/evm/azure_key_vault_signer.rs
+++ b/src/services/signer/evm/azure_key_vault_signer.rs
@@ -17,7 +17,9 @@ use crate::{
     },
     services::{
         signer::{
-            evm::{construct_eip712_message_hash, validate_and_format_signature},
+            evm::{
+                construct_eip712_message_hash, resolve_message_bytes, validate_and_format_signature,
+            },
             DataSignerTrait, Signer,
         },
         AzureKeyVaultEvmService, AzureKeyVaultService,
@@ -123,7 +125,7 @@ impl Signer for AzureKeyVaultSigner {
 #[async_trait]
 impl DataSignerTrait for AzureKeyVaultSigner {
     async fn sign_data(&self, request: SignDataRequest) -> Result<SignDataResponse, SignerError> {
-        let eip191_message = eip191_message(&request.message);
+        let eip191_message = eip191_message(&resolve_message_bytes(&request)?);
         let signature_bytes = self
             .azure_key_vault_service
             .sign_payload_evm(&eip191_message)

--- a/src/services/signer/evm/cdp_signer.rs
+++ b/src/services/signer/evm/cdp_signer.rs
@@ -24,8 +24,8 @@ use tracing::{debug, info};
 
 use crate::{
     domain::{
-        SignDataRequest, SignDataResponse, SignDataResponseEvm, SignTransactionResponse,
-        SignTransactionResponseEvm, SignTypedDataRequest,
+        SignDataRequest, SignDataRequestEncoding, SignDataResponse, SignDataResponseEvm,
+        SignTransactionResponse, SignTransactionResponseEvm, SignTypedDataRequest,
     },
     models::{
         Address, CdpSignerConfig, EvmTransactionDataSignature, EvmTransactionDataTrait,
@@ -145,6 +145,11 @@ impl<T: CdpServiceTrait> Signer for CdpSigner<T> {
 #[async_trait]
 impl<T: CdpServiceTrait> DataSignerTrait for CdpSigner<T> {
     async fn sign_data(&self, request: SignDataRequest) -> Result<SignDataResponse, SignerError> {
+        if matches!(request.encoding, SignDataRequestEncoding::Hex) {
+            return Err(SignerError::NotImplemented(
+                "hex encoding is not supported by the CDP signer".to_string(),
+            ));
+        }
         let message_string = request.message.to_string();
         let signature_bytes = self
             .cdp_service
@@ -254,6 +259,7 @@ mod tests {
         let signer = CdpSigner::new_for_testing(mock_service);
         let request = SignDataRequest {
             message: test_message.to_string(),
+            encoding: Default::default(),
         };
 
         let result = signer.sign_data(request).await.unwrap();
@@ -341,6 +347,7 @@ mod tests {
         let signer = CdpSigner::new_for_testing(mock_service);
         let request = SignDataRequest {
             message: test_message.to_string(),
+            encoding: Default::default(),
         };
 
         let result = signer.sign_data(request).await;
@@ -370,6 +377,7 @@ mod tests {
         let signer = CdpSigner::new_for_testing(mock_service);
         let request = SignDataRequest {
             message: test_message.to_string(),
+            encoding: Default::default(),
         };
 
         // Verify that we get the expected error about signature length

--- a/src/services/signer/evm/google_cloud_kms_signer.rs
+++ b/src/services/signer/evm/google_cloud_kms_signer.rs
@@ -23,7 +23,9 @@ use crate::{
     },
     services::{
         signer::{
-            evm::{construct_eip712_message_hash, validate_and_format_signature},
+            evm::{
+                construct_eip712_message_hash, resolve_message_bytes, validate_and_format_signature,
+            },
             DataSignerTrait, Signer,
         },
         GoogleCloudKmsEvmService, GoogleCloudKmsService,
@@ -120,7 +122,7 @@ impl Signer for GoogleCloudKmsSigner {
 #[async_trait]
 impl DataSignerTrait for GoogleCloudKmsSigner {
     async fn sign_data(&self, request: SignDataRequest) -> Result<SignDataResponse, SignerError> {
-        let eip191_message = eip191_message(&request.message);
+        let eip191_message = eip191_message(&resolve_message_bytes(&request)?);
         let signature_bytes = self
             .gcp_kms_service
             .sign_payload_evm(&eip191_message)
@@ -295,6 +297,7 @@ mod tests {
         let signer = setup_mock_gcp_signer(&mock_server).await;
         let request = SignDataRequest {
             message: test_message.to_string(),
+            encoding: Default::default(),
         };
 
         let result = signer.sign_data(request).await;

--- a/src/services/signer/evm/local_signer.rs
+++ b/src/services/signer/evm/local_signer.rs
@@ -40,7 +40,7 @@ use crate::{
     services::signer::{evm::construct_eip712_message_hash, Signer},
 };
 
-use super::{validate_and_format_signature, DataSignerTrait};
+use super::{resolve_message_bytes, validate_and_format_signature, DataSignerTrait};
 
 use alloy::rpc::types::TransactionRequest;
 
@@ -146,11 +146,11 @@ impl Signer for LocalSigner {
 #[async_trait]
 impl DataSignerTrait for LocalSigner {
     async fn sign_data(&self, request: SignDataRequest) -> Result<SignDataResponse, SignerError> {
-        let message = request.message.as_bytes();
+        let message = resolve_message_bytes(&request)?;
 
         let signature = self
             .local_signer_client
-            .sign_message(message)
+            .sign_message(&message)
             .await
             .map_err(|e| SignerError::SigningError(format!("Failed to sign message: {e}")))?;
 
@@ -242,6 +242,7 @@ mod tests {
         let signer = LocalSigner::new(&create_test_signer_model()).unwrap();
         let request = SignDataRequest {
             message: "Test message".to_string(),
+            encoding: Default::default(),
         };
 
         let result = signer.sign_data(request).await.unwrap();
@@ -262,6 +263,7 @@ mod tests {
         let signer = LocalSigner::new(&create_test_signer_model()).unwrap();
         let request = SignDataRequest {
             message: "".to_string(),
+            encoding: Default::default(),
         };
 
         let result = signer.sign_data(request).await;

--- a/src/services/signer/evm/mod.rs
+++ b/src/services/signer/evm/mod.rs
@@ -52,8 +52,8 @@ use std::sync::Arc;
 
 use crate::{
     domain::{
-        SignDataRequest, SignDataResponse, SignDataResponseEvm, SignTransactionResponse,
-        SignTypedDataRequest,
+        SignDataRequest, SignDataRequestEncoding, SignDataResponse, SignDataResponseEvm,
+        SignTransactionResponse, SignTypedDataRequest,
     },
     models::{
         Address, NetworkTransactionData, Signer as SignerDomainModel, SignerConfig,
@@ -267,6 +267,21 @@ pub(crate) fn validate_and_format_signature(
     }))
 }
 
+/// Resolves the message bytes to sign, honoring the request encoding.
+pub(crate) fn resolve_message_bytes(request: &SignDataRequest) -> Result<Vec<u8>, SignerError> {
+    match request.encoding {
+        SignDataRequestEncoding::Text => Ok(request.message.as_bytes().to_vec()),
+        SignDataRequestEncoding::Hex => {
+            let hex_str = request
+                .message
+                .strip_prefix("0x")
+                .unwrap_or(&request.message);
+            hex::decode(hex_str)
+                .map_err(|e| SignerError::ParseError(format!("invalid hex message: {e}")))
+        }
+    }
+}
+
 #[async_trait]
 pub trait DataSignerTrait: Send + Sync {
     /// Signs arbitrary message data
@@ -434,6 +449,35 @@ mod tests {
     use secrets::SecretVec;
     use std::str::FromStr;
     use std::sync::Arc;
+
+    #[test]
+    fn resolve_message_bytes_text_uses_utf8_bytes() {
+        let req = SignDataRequest {
+            message: "hello".to_string(),
+            encoding: SignDataRequestEncoding::Text,
+        };
+        assert_eq!(resolve_message_bytes(&req).unwrap(), b"hello".to_vec());
+    }
+
+    #[test]
+    fn resolve_message_bytes_hex_decodes_with_or_without_prefix() {
+        for m in ["0x48656c6c6f", "48656c6c6f"] {
+            let req = SignDataRequest {
+                message: m.to_string(),
+                encoding: SignDataRequestEncoding::Hex,
+            };
+            assert_eq!(resolve_message_bytes(&req).unwrap(), b"Hello".to_vec());
+        }
+    }
+
+    #[test]
+    fn resolve_message_bytes_invalid_hex_errors() {
+        let req = SignDataRequest {
+            message: "0xnothex".to_string(),
+            encoding: SignDataRequestEncoding::Hex,
+        };
+        assert!(resolve_message_bytes(&req).is_err());
+    }
 
     fn test_key_bytes() -> SecretVec<u8> {
         let key_bytes =
@@ -679,6 +723,7 @@ mod tests {
             .unwrap();
         let request = SignDataRequest {
             message: "Test message".to_string(),
+            encoding: Default::default(),
         };
 
         let result = signer.sign_data(request).await;
@@ -799,6 +844,7 @@ mod tests {
         for (name, message) in test_cases {
             let request = SignDataRequest {
                 message: message.to_string(),
+                encoding: Default::default(),
             };
 
             let result = signer.sign_data(request).await;

--- a/src/services/signer/evm/turnkey_signer.rs
+++ b/src/services/signer/evm/turnkey_signer.rs
@@ -33,7 +33,9 @@ use crate::{
     },
     services::{
         signer::{
-            evm::{construct_eip712_message_hash, validate_and_format_signature},
+            evm::{
+                construct_eip712_message_hash, resolve_message_bytes, validate_and_format_signature,
+            },
             Signer,
         },
         TurnkeyService, TurnkeyServiceTrait,
@@ -141,8 +143,8 @@ impl<T: TurnkeyServiceTrait> Signer for TurnkeySigner<T> {
 #[async_trait]
 impl<T: TurnkeyServiceTrait> DataSignerTrait for TurnkeySigner<T> {
     async fn sign_data(&self, request: SignDataRequest) -> Result<SignDataResponse, SignerError> {
-        let message_bytes = request.message.as_bytes();
-        let message_hash = eip191_hash_message(message_bytes);
+        let message_bytes = resolve_message_bytes(&request)?;
+        let message_hash = eip191_hash_message(&message_bytes);
         let signature_bytes = self.turnkey_service.sign_evm(message_hash.as_ref()).await?;
 
         if signature_bytes.len() != 65 {
@@ -266,6 +268,7 @@ mod tests {
         let signer = TurnkeySigner::new_for_testing(mock_service);
         let request = SignDataRequest {
             message: test_message.to_string(),
+            encoding: Default::default(),
         };
 
         let result = signer.sign_data(request).await.unwrap();
@@ -350,6 +353,7 @@ mod tests {
         let signer = TurnkeySigner::new_for_testing(mock_service);
         let request = SignDataRequest {
             message: test_message.to_string(),
+            encoding: Default::default(),
         };
 
         let result = signer.sign_data(request).await;
@@ -376,6 +380,7 @@ mod tests {
         let signer = TurnkeySigner::new_for_testing(mock_service);
         let request = SignDataRequest {
             message: test_message.to_string(),
+            encoding: Default::default(),
         };
 
         // Verify that we get the expected error about signature length


### PR DESCRIPTION
## Summary

Adds an optional `encoding` field (`text | hex` defaults to `text`) to `SignDataRequest`. With `hex`, the `message` is decoded from a hex string to raw bytes before EIP-191 signing, so arbitrary binary payloads can be signed instead of only text. The default preserves the existing behavior (i.e. this change is fully backward-compatible).

## Motivation

The `/sign` endpoint currently signs the message as text (`eip191_message(message.as_bytes())`). A caller that wants to sign a precomputed hash or other binary payload can't (i.e. passing a hex string like `0x…` signs the literal characters (wrong length prefix and content), not the decoded bytes. The `hex` encoding lets callers opt into decoding the message first.

## Changes

- New `SignDataRequestEncoding` enum; `encoding` defaults to `text` via `#[serde(default)]` (existing requests are unaffected).
- Shared `resolve_message_bytes` helper, wired into all EVM signers (Local, GCP KMS, AWS KMS, Azure Key Vault, Turnkey). The Vault signer inherits it via delegation to the local signer. The CDP signer returns `NotImplemented` for `hex`, since it signs via a string-based API.
- Invalid hex → `SignerError::ParseError`.
