### PR TITLE
fix: run queue metadata cleanup regardless of repository storage type

### DIFF
--- a/src/jobs/handlers/system_cleanup_handler.rs
+++ b/src/jobs/handlers/system_cleanup_handler.rs
@@ -139,7 +139,7 @@ async fn handle_cleanup_request(
     {
         Some(connections) => connections,
         None => {
-            debug!("redis queue connections unavailable, skipping system cleanup");
+            warn!("queue backend reports Redis but no Redis connections available; skipping system cleanup");
             return Ok(());
         }
     };

--- a/src/jobs/handlers/system_cleanup_handler.rs
+++ b/src/jobs/handlers/system_cleanup_handler.rs
@@ -110,8 +110,10 @@ pub async fn system_cleanup_handler(
 /// one instance processes cleanup at a time. If the lock is already held by
 /// another instance, this returns early without doing any work.
 ///
-/// Note: Queue metadata cleanup only runs when using Redis queue backend.
-/// SQS backend and in-memory mode skip cleanup since they don't use Redis queues.
+/// Note: Queue metadata cleanup runs whenever the queue backend is Redis, using
+/// the queue backend's own connection pool. It is independent of
+/// `REPOSITORY_STORAGE_TYPE`, so it also runs with an in-memory repository. SQS
+/// and Pub/Sub backends skip cleanup since they do not use Redis queues.
 async fn handle_cleanup_request(
     _job: SystemCleanupCronReminder,
     data: &ThinData<DefaultAppState>,
@@ -126,21 +128,27 @@ async fn handle_cleanup_request(
         return Ok(());
     }
 
-    let transaction_repo = data.transaction_repository();
-    let (redis_connections, key_prefix) =
-        match crate::repositories::TransactionRepository::connection_info(transaction_repo.as_ref())
-        {
-            Some((connections, prefix)) => (connections, prefix),
-            None => {
-                debug!("in-memory repository detected, skipping system cleanup");
-                return Ok(());
-            }
-        };
+    // Obtain the Redis pool from the queue backend rather than the transaction
+    // repository, so cleanup runs whenever the queue lives in Redis regardless
+    // of REPOSITORY_STORAGE_TYPE. Previously an in-memory repository caused this
+    // to return early, letting Redis queue metadata grow unbounded (issue #815).
+    let redis_connections = match data
+        .job_producer()
+        .get_queue_backend()
+        .and_then(|backend| backend.redis_connections())
+    {
+        Some(connections) => connections,
+        None => {
+            debug!("redis queue connections unavailable, skipping system cleanup");
+            return Ok(());
+        }
+    };
     let pool = redis_connections.primary().clone();
 
     // In distributed mode, acquire a lock to prevent multiple instances from
     // running cleanup simultaneously. In single-instance mode, skip locking.
     let _lock_guard = if ServerConfig::get_distributed_mode() {
+        let key_prefix = ServerConfig::get_redis_key_prefix();
         let lock_key = format!("{key_prefix}:lock:{SYSTEM_CLEANUP_LOCK_NAME}");
         let lock = DistributedLock::new(
             pool.clone(),


### PR DESCRIPTION
# Summary

Fixes #815.

`system_cleanup` (the worker that prunes Redis job-queue metadata) obtains its Redis connection pool from the **transaction repository** via `TransactionRepository::connection_info()`, which returns `None` for an in-memory repository. As a result the worker skips cleanup whenever `REPOSITORY_STORAGE_TYPE` is in-memory (the default) — even though the queue backend itself is Redis. The apalis queue metadata (`<queue>:{done,failed,dead}` sorted sets and their `:data`/`:result` hashes) then accumulates with no TTL and Redis grows without bound.

This restores the behavior that existed before #625 ("queues always use Redis regardless of repository storage type").

# Change

Source the pool from the **queue backend** instead of the repository:

```rust
let redis_connections = match data
    .job_producer()
    .get_queue_backend()
    .and_then(|backend| backend.redis_connections())
{
    Some(connections) => connections,
    None => { /* skip */ }
};
```

- The `backend_type() != Redis` guard is unchanged, so SQS/Pub-Sub backends still skip cleanup.
- The distributed-lock key prefix is now derived from `ServerConfig::get_redis_key_prefix()` (previously it came from the repository's `connection_info()` prefix, which resolves to the same value), so lock naming is unchanged.

# Why this is safe

`initialize_app_state` builds a single `RedisConnections` from `REDIS_URL` and hands the **same** `Arc` to both the queue backend and (when `REPOSITORY_STORAGE_TYPE=redis`) the repository. So:

- When the repository is Redis, the queue backend's pool is the *same object* the repository's `connection_info()` returned — this change is behavior-preserving.
- When the repository is in-memory, cleanup now runs against the queue backend's Redis pool (the correct one — it is where the queue metadata lives) instead of skipping.
- Cleanup uses `.primary()` (the write pool) in both the old and new code; `REDIS_READER_URL` is unaffected.

# Testing

- `cargo test --lib system_cleanup` — all existing tests pass.
- `cargo build` — clean.
- Verified manually that with an in-memory repository + Redis queue backend, the worker now runs and prunes `<queue>:{done,failed,dead}` metadata instead of logging "in-memory repository detected, skipping system cleanup".

# Checklist

- [x] Add a reference to related issues in the PR description (#815).
- [x] Add unit tests if applicable (existing `system_cleanup` unit tests cover key/prefix formatting; the change is exercised by them and by manual verification).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup handling for Redis-backed queues.
  * Cleanup now runs independently of repository storage settings.
  * Cleanup is skipped safely when Redis connections are unavailable or when using unsupported queue backends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->