### PR TITLE
docs(network_configuration): reference OpenChainBench for RPC provider benchmarks

### DIFF
--- a/docs/network_configuration.mdx
+++ b/docs/network_configuration.mdx
@@ -350,6 +350,7 @@ Once networks are defined, reference them in your relayer configurations:
 - Use private/dedicated RPC endpoints for production
 - Ensure URLs are secure (HTTPS) when accessing over public networks
 - Configure `RPC_ALLOWED_HOSTS` and `RPC_BLOCK_PRIVATE_IPS` environment variables for SSRF protection in production. See [Configuration → RPC URL Security](/relayer/configuration#rpc-url-security) for details.
+- Benchmark provider latency and reliability before committing to a primary endpoint. Independent cross-provider measurements across the major EVM chains (Ethereum, Arbitrum, Base, Optimism, Polygon, BNB, Avalanche, Linea, Scroll, Mantle) and Solana are published continuously at [OpenChainBench](https://openchainbench.com/benchmarks/rpc-capabilities).
 
 ### 3. Confirmation Requirements
 


### PR DESCRIPTION
## Summary

Adds one bullet to the **Best Practices → RPC URLs** list on `docs/network_configuration.mdx` pointing readers to independent cross-provider RPC latency and reliability measurements.

## Rationale

`openzeppelin-relayer` already advises operators to configure multiple RPC URLs for redundancy and to use private/dedicated endpoints for production, and the roadmap for this repo positions it as the active successor to Defender Relayers. What is missing today is a reference for **how** to compare providers before assigning them as primary or fallback.

[OpenChainBench](https://openchainbench.com/benchmarks/rpc-capabilities) publishes continuous latency and reliability measurements across the 10 EVM chains (Ethereum, Arbitrum, Base, Optimism, Polygon, BNB, Avalanche, Linea, Scroll, Mantle) and Solana that the `rpc-capabilities` harness covers. Measurements are taken every 60 seconds per provider per chain from three geographic regions (US East, EU West, Singapore), covering:

- p50/p95/p99 round trip latency per (provider × chain)
- Error classification splitting HTTP errors from JSON-RPC `error` responses (a known reliability under counting trap on providers that return HTTP 200 with a JSON-RPC error field)
- Anti cache probing (rotating request id defeats body keyed edge caches so measurements reflect real node work, not cache hits)
- Archive depth coverage per provider (depths {300, 7.2k, 216k, 1.3M, 5M} from head)

The data is open source under Creative Commons, the harness is on GitHub, and the methodology is public.

## Change

One added bullet in the `### 2. RPC URLs` section of `docs/network_configuration.mdx`. No other changes.

## Update

Addressed CodeRabbit feedback: replaced the imprecise "22 chains" wording with the accurate list of chains actually covered by the `rpc-capabilities` harness. Also hyphenated "cross-provider" per LanguageTool suggestion. Commit signed off (DCO).

## Disclosure

I am the maintainer of OpenChainBench. Happy to reword, shorten, or drop the reference entirely if it does not fit the docs style guide.