### PR TITLE
fix: Rewind drifted EVM nonce counter and skip resubmits blocked by nonce gaps

### DIFF
--- a/.env.integration.example
+++ b/.env.integration.example
@@ -36,6 +36,16 @@ WEBHOOK_SIGNING_KEY=your-webhook-signing-key-here
 # Enable/disable networks by setting "enabled": true/false in registry.json
 
 # ==============================================================================
+# Storage Backend
+# ==============================================================================
+# The relayer defaults to in-memory storage. Set these to run integration tests
+# against Redis-backed storage (production parity). Required for tests that
+# manipulate persisted state directly, e.g. nonce_drift_recovery.
+# Generate a key with: openssl rand -base64 32
+# REPOSITORY_STORAGE_TYPE=redis
+# STORAGE_ENCRYPTION_KEY=your-generated-key-here
+
+# ==============================================================================
 # Optional Configuration
 # ==============================================================================
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,6 +147,7 @@ mockall = { version = "0.13" }
 mockito = "1.7.1"
 proptest = "1.6.0"
 rand = "0.9.0"
+redis = { version = "0.32", features = ["aio", "tokio-comp"] }
 tempfile = "3.2"
 serial_test = "3.2"
 zstd = "0.13"

--- a/docker-compose.integration.yml
+++ b/docker-compose.integration.yml
@@ -96,6 +96,8 @@ services:
       - .env.integration
     environment:
       - RELAYER_BASE_URL=http://relayer:8080
+      # Direct Redis access for tests that manipulate relayer state (e.g. nonce drift)
+      - REDIS_URL=redis://redis:6379
       # Test logging configuration
       # Default to INFO level for clean output, can be overridden with RUST_LOG
       - RUST_LOG=${RUST_LOG:-info}

--- a/src/domain/relayer/evm/evm_relayer.rs
+++ b/src/domain/relayer/evm/evm_relayer.rs
@@ -1150,12 +1150,9 @@ mod tests {
             .returning(|_| Box::pin(ready(Ok(42u64))));
 
         counter
-            .expect_set()
-            .returning(|_nonce| Box::pin(ready(Ok(()))));
-
-        counter
-            .expect_get()
-            .returning(|| Box::pin(ready(Ok(Some(42u64)))));
+            .expect_sync_floor()
+            .with(eq(42u64))
+            .returning(|floor| Box::pin(ready(Ok(floor))));
 
         let relayer = EvmRelayer::new(
             relayer_model,
@@ -1184,14 +1181,11 @@ mod tests {
             .expect_get_transaction_count()
             .returning(|_| Box::pin(ready(Ok(40u64))));
 
+        // Chain nonce (40) is below the counter; sync_floor(40) leaves it at 42.
         counter
-            .expect_set()
-            .with(eq(42u64))
-            .returning(|_nonce| Box::pin(ready(Ok(()))));
-
-        counter
-            .expect_get()
-            .returning(|| Box::pin(ready(Ok(Some(42u64)))));
+            .expect_sync_floor()
+            .with(eq(40u64))
+            .returning(|_| Box::pin(ready(Ok(42u64))));
 
         let relayer = EvmRelayer::new(
             relayer_model,
@@ -1220,14 +1214,11 @@ mod tests {
             .expect_get_transaction_count()
             .returning(|_| Box::pin(ready(Ok(42u64))));
 
+        // Chain nonce (42) is above the counter; sync_floor(42) raises it to 42.
         counter
-            .expect_set()
+            .expect_sync_floor()
             .with(eq(42u64))
-            .returning(|_nonce| Box::pin(ready(Ok(()))));
-
-        counter
-            .expect_get()
-            .returning(|| Box::pin(ready(Ok(Some(40u64)))));
+            .returning(|floor| Box::pin(ready(Ok(floor))));
 
         let relayer = EvmRelayer::new(
             relayer_model,
@@ -2842,11 +2833,9 @@ mod tests {
             .expect_get_transaction_count()
             .returning(|_| Box::pin(ready(Ok(42u64))));
 
-        counter.expect_set().returning(|_| Box::pin(ready(Ok(()))));
-
         counter
-            .expect_get()
-            .returning(|| Box::pin(ready(Ok(Some(42u64)))));
+            .expect_sync_floor()
+            .returning(|floor| Box::pin(ready(Ok(floor))));
 
         provider
             .expect_get_balance()
@@ -2893,11 +2882,9 @@ mod tests {
             .expect_get_transaction_count()
             .returning(|_| Box::pin(ready(Ok(42u64))));
 
-        counter.expect_set().returning(|_| Box::pin(ready(Ok(()))));
-
         counter
-            .expect_get()
-            .returning(|| Box::pin(ready(Ok(Some(42u64)))));
+            .expect_sync_floor()
+            .returning(|floor| Box::pin(ready(Ok(floor))));
 
         provider
             .expect_get_balance()
@@ -2946,11 +2933,9 @@ mod tests {
             .expect_get_transaction_count()
             .returning(|_| Box::pin(ready(Ok(42u64))));
 
-        counter.expect_set().returning(|_| Box::pin(ready(Ok(()))));
-
         counter
-            .expect_get()
-            .returning(|| Box::pin(ready(Ok(Some(42u64)))));
+            .expect_sync_floor()
+            .returning(|floor| Box::pin(ready(Ok(floor))));
 
         provider
             .expect_get_balance()
@@ -3017,11 +3002,9 @@ mod tests {
             .expect_get_transaction_count()
             .returning(|_| Box::pin(ready(Ok(42u64))));
 
-        counter.expect_set().returning(|_| Box::pin(ready(Ok(()))));
-
         counter
-            .expect_get()
-            .returning(|| Box::pin(ready(Ok(Some(42u64)))));
+            .expect_sync_floor()
+            .returning(|floor| Box::pin(ready(Ok(floor))));
 
         provider
             .expect_get_balance()

--- a/src/domain/relayer/evm/nonce.rs
+++ b/src/domain/relayer/evm/nonce.rs
@@ -5,8 +5,11 @@
 //! through the health check queue.
 
 use std::collections::HashMap;
+use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
+use dashmap::DashMap;
+use tokio::sync::Mutex;
 use tracing::{debug, error, info, instrument, warn};
 
 use crate::{
@@ -43,6 +46,16 @@ const MAX_REWIND_SCAN_RANGE: u64 = 100_000;
 /// Chunk size for the occupancy scan over the drift region (one `get_nonce_occupancy`
 /// range query per chunk).
 const REWIND_SCAN_CHUNK: u64 = 1000;
+
+/// Per-relayer in-process locks serializing nonce-health runs when no distributed
+/// lock is available (non-distributed mode, or missing connection info).
+///
+/// The rewind CAS alone is not enough there: concurrent health runs plus fresh
+/// allocations can reproduce the observed counter value (ABA), letting a stale
+/// rewind apply beneath live allocations. Serializing runs per relayer closes the
+/// health-vs-health interleaving; the prepare-persist race remains covered by the
+/// settle pause and the self-correcting collision class.
+static NONCE_HEALTH_LOCAL_LOCKS: OnceLock<DashMap<String, Arc<Mutex<()>>>> = OnceLock::new();
 
 // ── Nonce synchronization & gap detection ─────────────────────────────────────
 
@@ -212,9 +225,11 @@ where
     /// # Residual race
     /// A `prepare` that INCRed the counter before our `observed` read but persists its tx
     /// record slower than pause+scan is protected only up to the read: if it persists after
-    /// the scan, the rewind can move the counter past it. That collapses to the existing
-    /// self-correcting same-nonce collision class (see `detect_nonce_gaps` docs at the
-    /// "Self-correcting" note) — the persist precedes signing, so no funds are ever at risk.
+    /// the scan, the rewind can move the counter past it and the nonce is handed out again.
+    /// The slow `prepare` still persists, signs, and broadcasts, so the failure mode is two
+    /// relayer-signed transactions competing for one nonce — exactly one mines, and the
+    /// loser collapses to the existing self-correcting same-nonce collision class (see
+    /// `detect_nonce_gaps` docs at the "Self-correcting" note).
     ///
     /// # Returns
     /// Number of gaps filled, or error.
@@ -400,8 +415,12 @@ where
                 "rewound nonce counter over verified-empty region"
             );
         } else {
-            debug!(
+            // warn, not debug: repeated misses are the only visible signal that the
+            // rewind is being starved by concurrent counter movement.
+            warn!(
                 relayer_id = %self.relayer.id,
+                observed = observed,
+                target = target,
                 "counter moved concurrently; skipping rewind, next health run will retry"
             );
         }
@@ -604,6 +623,29 @@ where
                         }
                     } else {
                         None
+                    }
+                } else {
+                    None
+                };
+
+                // Without a distributed lock, serialize health runs in-process per
+                // relayer (see `NONCE_HEALTH_LOCAL_LOCKS`). Mirror the distributed
+                // behavior: if a run is already active, skip instead of queueing.
+                let _local_guard = if _lock_guard.is_none() {
+                    let locks = NONCE_HEALTH_LOCAL_LOCKS.get_or_init(DashMap::new);
+                    let lock = locks
+                        .entry(self.relayer.id.clone())
+                        .or_insert_with(|| Arc::new(Mutex::new(())))
+                        .clone();
+                    match lock.try_lock_owned() {
+                        Ok(guard) => Some(guard),
+                        Err(_) => {
+                            info!(
+                                relayer_id = %self.relayer.id,
+                                "nonce health already running in-process for this relayer, skipping"
+                            );
+                            return Ok(true);
+                        }
                     }
                 } else {
                     None

--- a/src/domain/relayer/evm/nonce.rs
+++ b/src/domain/relayer/evm/nonce.rs
@@ -19,7 +19,7 @@ use crate::{
     jobs::{JobProducerTrait, TransactionRequest, TransactionStatusCheck},
     models::{
         EvmNetwork, EvmTransactionData, NetworkRepoModel, NetworkType, RelayerRepoModel,
-        TransactionRepoModel, TransactionStatus,
+        TransactionRepoModel, TransactionStatus, TransactionUpdateRequest,
     },
     repositories::{NetworkRepository, RelayerRepository, Repository, TransactionRepository},
     services::{
@@ -34,6 +34,15 @@ use super::EvmRelayer;
 /// time to persist their reserved nonces to the repository. Best-effort mitigation
 /// for the counter-increment-before-persist race. See `detect_nonce_gaps` docs.
 const NONCE_GAP_SETTLE_DURATION: Duration = Duration::from_secs(2);
+
+/// Upper bound on the width of a drift region we are willing to scan for occupancy
+/// before rewinding the counter. A rewind is NEVER performed on a partial scan, so
+/// a region wider than this is skipped entirely rather than verified piecemeal.
+const MAX_REWIND_SCAN_RANGE: u64 = 100_000;
+
+/// Chunk size for the occupancy scan over the drift region (one `get_nonce_occupancy`
+/// range query per chunk).
+const REWIND_SCAN_CHUNK: u64 = 1000;
 
 // ── Nonce synchronization & gap detection ─────────────────────────────────────
 
@@ -59,26 +68,20 @@ where
     pub(crate) async fn sync_nonce(&self) -> Result<(), RelayerError> {
         let on_chain_nonce = self.get_on_chain_nonce().await?;
 
-        let transaction_counter_nonce = self
+        // Treat the chain nonce as a floor only: atomically raise the counter to it
+        // when the counter is behind, never lower it here. Concurrent allocations that
+        // have already advanced the counter past the chain nonce are preserved.
+        let effective = self
             .transaction_counter_service
-            .get()
-            .await
-            .ok()
-            .flatten()
-            .unwrap_or(0);
-
-        let nonce = std::cmp::max(on_chain_nonce, transaction_counter_nonce);
+            .sync_floor(on_chain_nonce)
+            .await?;
 
         debug!(
             relayer_id = %self.relayer.id,
             on_chain_nonce = %on_chain_nonce,
-            transaction_counter_nonce = %transaction_counter_nonce,
-            "syncing nonce"
+            effective_nonce = %effective,
+            "synced nonce counter to on-chain floor"
         );
-
-        debug!(nonce = %nonce, "setting nonce for relayer");
-
-        self.transaction_counter_service.set(nonce).await?;
 
         Ok(())
     }
@@ -187,13 +190,31 @@ where
         Ok(gaps)
     }
 
-    /// Detects and resolves nonce gaps by creating gap-filling NOOP transactions.
+    /// Detects and resolves nonce drift by trimming the empty head of the counter
+    /// and filling genuine gaps with NOOP transactions.
     ///
     /// # Algorithm
-    /// 1. Snapshot the counter + settle pause (allows in-flight `prepare_transaction` to persist)
-    /// 2. Run `sync_nonce()` — raises counter to max(on_chain, local)
-    /// 3. Run `detect_nonce_gaps()` with the snapshot — only scans nonces reserved before the pause
-    /// 4. For each gap: double-check, create NOOP, push through prepare/submit pipeline
+    /// 1. Read `observed` (the current counter) BEFORE the settle pause. Any increment
+    ///    that landed before this read is given the pause+scan window to persist its tx
+    ///    record; any increment after this read makes the rewind CAS fail (safe no-op).
+    /// 2. If a nonce hint is provided, `sync_floor(hint + 1)` so new txs don't collide
+    ///    with the NOOPs we may create (handles counter resets). Order relative to the
+    ///    `observed` read is immaterial — the hint path only raises, the rewind only lowers.
+    /// 3. Settle pause: let in-flight `prepare_transaction` calls persist their reserved
+    ///    nonces before we scan (best-effort, see `detect_nonce_gaps`).
+    /// 4. `get_on_chain_nonce()` + `sync_floor(on_chain_nonce)` — raise the counter to the
+    ///    chain floor.
+    /// 5. Rewind trim: `try_rewind_counter` verifies the region `[on_chain, observed)` is
+    ///    empty of any tx record and CAS-lowers the counter to the top of on-chain reality.
+    /// 6. `detect_nonce_gaps()` + double-check + NOOP fill for any real gaps below the
+    ///    highest known tx (runs in the same pass, regardless of the rewind outcome).
+    ///
+    /// # Residual race
+    /// A `prepare` that INCRed the counter before our `observed` read but persists its tx
+    /// record slower than pause+scan is protected only up to the read: if it persists after
+    /// the scan, the rewind can move the counter past it. That collapses to the existing
+    /// self-correcting same-nonce collision class (see `detect_nonce_gaps` docs at the
+    /// "Self-correcting" note) — the persist precedes signing, so no funds are ever at risk.
     ///
     /// # Returns
     /// Number of gaps filled, or error.
@@ -206,27 +227,26 @@ where
         )
     )]
     async fn resolve_nonce_gaps(&self, nonce_hint: Option<u64>) -> Result<usize, RelayerError> {
+        // Read the counter BEFORE the settle pause so it anchors the rewind CAS. A None
+        // counter → 0 means there is nothing above the chain nonce to rewind.
+        let observed = self.transaction_counter_service.get().await?.unwrap_or(0);
+
         // If a nonce hint is provided (e.g., from a tx stuck ahead of on-chain),
         // ensure the counter covers at least hint + 1 so new txs don't collide
         // with the NOOPs we're about to create. This handles counter resets.
         if let Some(hint) = nonce_hint {
             let required = hint + 1;
-            let current = self
+            let effective = self
                 .transaction_counter_service
-                .get()
-                .await
-                .ok()
-                .flatten()
-                .unwrap_or(0);
-            if current < required {
+                .sync_floor(required)
+                .await?;
+            if observed < required {
                 info!(
                     relayer_id = %self.relayer.id,
-                    counter = current,
                     nonce_hint = hint,
-                    new_counter = required,
-                    "raising counter to cover nonce hint"
+                    effective = effective,
+                    "raised counter to cover nonce hint"
                 );
-                self.transaction_counter_service.set(required).await?;
             }
         }
 
@@ -237,7 +257,21 @@ where
 
         let on_chain_nonce = self.get_on_chain_nonce().await?;
 
-        self.sync_nonce().await?;
+        // Raise the counter to the chain floor without a second on-chain nonce fetch.
+        let effective = self
+            .transaction_counter_service
+            .sync_floor(on_chain_nonce)
+            .await?;
+        debug!(
+            relayer_id = %self.relayer.id,
+            on_chain_nonce = %on_chain_nonce,
+            effective_nonce = %effective,
+            "synced nonce counter to on-chain floor"
+        );
+
+        // Trim the empty head: lower the counter back to on-chain reality over any
+        // region verified free of tx records. Best-effort — outcome does not gate the fill.
+        self.try_rewind_counter(on_chain_nonce, observed).await?;
 
         let gaps = self
             .detect_nonce_gaps(Some(on_chain_nonce), nonce_hint)
@@ -288,6 +322,91 @@ where
         );
 
         Ok(filled)
+    }
+
+    /// Trims the empty head of the nonce counter down to on-chain reality.
+    ///
+    /// Rewinds the counter from `observed` to `target`, where `target` is the highest
+    /// slot in `[on_chain_nonce, observed)` holding a tx record of ANY status (plus one),
+    /// or `on_chain_nonce` if the region is entirely empty. Records of any status bound
+    /// the rewind: a `Failed` record may be a reverted-on-chain tx whose nonce was still
+    /// consumed (a stale on-chain read), so it is never trimmed past.
+    ///
+    /// Invariants:
+    /// - Never rewinds on a partial scan: a region wider than `MAX_REWIND_SCAN_RANGE` is
+    ///   skipped entirely rather than verified in part.
+    /// - The write is a CAS against `observed`; if the counter moved since we read it, the
+    ///   write is a no-op and the next health run retries.
+    async fn try_rewind_counter(
+        &self,
+        on_chain_nonce: u64,
+        observed: u64,
+    ) -> Result<(), RelayerError> {
+        if observed <= on_chain_nonce {
+            return Ok(());
+        }
+
+        if observed - on_chain_nonce > MAX_REWIND_SCAN_RANGE {
+            error!(
+                relayer_id = %self.relayer.id,
+                on_chain_nonce = on_chain_nonce,
+                observed = observed,
+                "nonce drift region too large to verify; skipping rewind"
+            );
+            return Ok(());
+        }
+
+        // Scan chunks top-down from `observed` toward `on_chain_nonce`. The first chunk
+        // containing any tx record holds the region's highest-occupied slot, so scanning
+        // stops there; only a fully-empty region scans all the way to `on_chain_nonce`.
+        let mut highest_occupied: Option<u64> = None;
+        let mut chunk_end = observed;
+        while chunk_end > on_chain_nonce {
+            let chunk_start =
+                std::cmp::max(on_chain_nonce, chunk_end.saturating_sub(REWIND_SCAN_CHUNK));
+            let occupancy = self
+                .transaction_repository
+                .get_nonce_occupancy(&self.relayer.id, chunk_start, chunk_end)
+                .await
+                .map_err(|e| RelayerError::Internal(e.to_string()))?;
+
+            if let Some((nonce, _)) = occupancy.iter().rev().find(|(_, status)| status.is_some()) {
+                highest_occupied = Some(*nonce);
+                break;
+            }
+            chunk_end = chunk_start;
+        }
+
+        let target = match highest_occupied {
+            Some(n) => std::cmp::max(on_chain_nonce, n + 1),
+            None => on_chain_nonce,
+        };
+
+        if target >= observed {
+            return Ok(());
+        }
+
+        let applied = self
+            .transaction_counter_service
+            .set_if_equals(observed, target)
+            .await?;
+
+        if applied {
+            info!(
+                relayer_id = %self.relayer.id,
+                observed = observed,
+                target = target,
+                on_chain_nonce = on_chain_nonce,
+                "rewound nonce counter over verified-empty region"
+            );
+        } else {
+            debug!(
+                relayer_id = %self.relayer.id,
+                "counter moved concurrently; skipping rewind, next health run will retry"
+            );
+        }
+
+        Ok(())
     }
 
     /// Creates a gap-filling NOOP transaction for a specific nonce.
@@ -359,24 +478,66 @@ where
             .await
             .map_err(|e| RelayerError::Internal(e.to_string()))?;
 
-        // Push through prepare pipeline first, then schedule delayed status check as safety net
-        self.job_producer
+        // Push through prepare pipeline first, then schedule delayed status check as safety
+        // net. Attempt both jobs independently: the status-check job re-drives a stuck Pending
+        // tx via handle_pending_state, so a single successful enqueue is enough to progress.
+        let request_result = self
+            .job_producer
             .produce_transaction_request_job(
                 TransactionRequest::new(tx.id.clone(), tx.relayer_id.clone()),
                 None,
             )
-            .await
-            .map_err(RelayerError::from)?;
+            .await;
+        if let Err(e) = &request_result {
+            error!(
+                tx_id = %tx.id,
+                nonce = nonce,
+                error = %e,
+                "failed to enqueue gap-filling NOOP request job, continuing"
+            );
+        }
 
-        self.job_producer
+        let status_result = self
+            .job_producer
             .produce_check_transaction_status_job(
                 TransactionStatusCheck::new(tx.id.clone(), tx.relayer_id.clone(), NetworkType::Evm),
                 Some(calculate_scheduled_timestamp(
                     EVM_STATUS_CHECK_INITIAL_DELAY_SECONDS,
                 )),
             )
-            .await
-            .map_err(RelayerError::from)?;
+            .await;
+        if let Err(e) = &status_result {
+            error!(
+                tx_id = %tx.id,
+                nonce = nonce,
+                error = %e,
+                "failed to enqueue gap-filling NOOP status-check job"
+            );
+        }
+
+        if let (Err(request_err), Err(_)) = (request_result, status_result) {
+            // Neither job scheduled: the Pending record would occupy the gap slot forever
+            // (Pending counts as active occupancy). Fail it so a future health run re-fills.
+            if let Err(update_err) = self
+                .transaction_repository
+                .partial_update(
+                    tx.id.clone(),
+                    TransactionUpdateRequest {
+                        status: Some(TransactionStatus::Failed),
+                        status_reason: Some("Gap-filling NOOP could not be scheduled".to_string()),
+                        ..Default::default()
+                    },
+                )
+                .await
+            {
+                error!(
+                    tx_id = %tx.id,
+                    error = %update_err,
+                    "failed to mark unscheduled gap-filling NOOP as Failed"
+                );
+            }
+            return Err(RelayerError::from(request_err));
+        }
 
         info!(
             tx_id = %tx.id,
@@ -573,6 +734,29 @@ mod tests {
             status,
             ..Default::default()
         }
+    }
+
+    fn create_test_network_model() -> NetworkRepoModel {
+        use crate::config::{EvmNetworkConfig, NetworkConfigCommon};
+        let config = EvmNetworkConfig {
+            common: NetworkConfigCommon {
+                network: "mainnet".to_string(),
+                from: None,
+                rpc_urls: Some(vec![crate::models::RpcConfig::new(
+                    "https://mainnet.infura.io/v3/test".to_string(),
+                )]),
+                explorer_urls: None,
+                average_blocktime_ms: Some(12000),
+                is_testnet: Some(false),
+                tags: Some(vec!["mainnet".to_string()]),
+            },
+            chain_id: Some(1),
+            required_confirmations: Some(1),
+            features: Some(vec!["eip1559".to_string()]),
+            symbol: Some("ETH".to_string()),
+            gas_price_cache: None,
+        };
+        NetworkRepoModel::new_evm(config)
     }
 
     #[tokio::test]
@@ -805,12 +989,14 @@ mod tests {
             .expect_get_transaction_count()
             .returning(|_| Box::pin(ready(Ok(5u64))));
 
-        // sync_nonce calls get() then set(); detect_nonce_gaps calls get() again
+        // resolve_nonce_gaps reads get() (observed); sync_nonce calls sync_floor()
         counter
             .expect_get()
             .returning(|| Box::pin(ready(Ok(Some(5u64)))));
 
-        counter.expect_set().returning(|_| Box::pin(ready(Ok(()))));
+        counter
+            .expect_sync_floor()
+            .returning(|floor| Box::pin(ready(Ok(floor))));
 
         // Scan finds no txs → empty gaps
         tx_repo
@@ -854,12 +1040,14 @@ mod tests {
             .expect_get_transaction_count()
             .returning(|_| Box::pin(ready(Ok(5u64))));
 
-        // sync_nonce calls get() then set(); detect_nonce_gaps calls get() again
+        // resolve_nonce_gaps reads get() (observed); sync_nonce calls sync_floor()
         counter
             .expect_get()
             .returning(|| Box::pin(ready(Ok(Some(8u64)))));
 
-        counter.expect_set().returning(|_| Box::pin(ready(Ok(()))));
+        counter
+            .expect_sync_floor()
+            .returning(|floor| Box::pin(ready(Ok(floor))));
 
         // detect_nonce_gaps uses batch occupancy check
         tx_repo.expect_get_nonce_occupancy().returning(|_, _, _| {
@@ -930,9 +1118,7 @@ mod tests {
         assert_eq!(result, 1);
     }
 
-    /// When nonce_hint is provided and counter is behind it, resolve_nonce_gaps
-    /// should raise the counter before scanning. This simulates a counter reset
-    /// where a tx at nonce 10 exists but counter was reset to 5.
+    /// When a nonce hint is provided and the counter is behind it, resolve_nonce_gaps raises the counter before scanning.
     #[tokio::test]
     async fn test_resolve_nonce_gaps_with_hint_raises_counter() {
         use crate::config::{EvmNetworkConfig, NetworkConfigCommon};
@@ -954,7 +1140,7 @@ mod tests {
             .returning(|_| Box::pin(ready(Ok(5u64))));
 
         // Counter is at 5 (was reset), but hint says there's a tx at nonce 10
-        // So resolve_nonce_gaps should raise counter to 11 before scanning.
+        // So resolve_nonce_gaps should raise counter to 11 via sync_floor before scanning.
         let counter_values = std::sync::Arc::new(std::sync::Mutex::new(5u64));
         let cv_get = counter_values.clone();
         counter.expect_get().returning(move || {
@@ -962,10 +1148,13 @@ mod tests {
             Box::pin(ready(Ok(Some(val))))
         });
 
-        let cv_set = counter_values.clone();
-        counter.expect_set().returning(move |val| {
-            *cv_set.lock().unwrap() = val;
-            Box::pin(ready(Ok(())))
+        let cv_sf = counter_values.clone();
+        counter.expect_sync_floor().returning(move |floor| {
+            let mut guard = cv_sf.lock().unwrap();
+            if *guard < floor {
+                *guard = floor;
+            }
+            Box::pin(ready(Ok(*guard)))
         });
 
         // Occupancy scan: nonce 5-9 empty (gaps), nonce 10 has an active Submitted tx
@@ -1040,6 +1229,586 @@ mod tests {
 
         // Verify counter was raised
         assert_eq!(*counter_values.lock().unwrap(), 11);
+    }
+
+    /// Rewind (a): a fully-empty drift region rewinds the counter down to the chain nonce.
+    #[tokio::test]
+    async fn test_try_rewind_counter_empty_region_rewinds_to_chain() {
+        use mockall::predicate::eq;
+
+        let (provider, relayer_repo, network_repo, mut tx_repo, job_producer, signer, mut counter) =
+            setup_mocks();
+        let relayer_model = create_test_relayer();
+
+        // Region [100, 365) is entirely empty.
+        tx_repo
+            .expect_get_nonce_occupancy()
+            .returning(|_, from, to| Ok((from..to).map(|n| (n, None)).collect()));
+
+        // Empty region → target == on_chain_nonce; CAS lowers 365 → 100.
+        counter
+            .expect_set_if_equals()
+            .with(eq(365u64), eq(100u64))
+            .times(1)
+            .returning(|_, _| Box::pin(ready(Ok(true))));
+
+        let relayer = EvmRelayer::new(
+            relayer_model,
+            signer,
+            provider,
+            create_test_evm_network(),
+            Arc::new(relayer_repo),
+            Arc::new(network_repo),
+            Arc::new(tx_repo),
+            Arc::new(counter),
+            Arc::new(job_producer),
+        )
+        .unwrap();
+
+        relayer.try_rewind_counter(100, 365).await.unwrap();
+    }
+
+    /// Rewind (b): a terminal (Failed) record bounds the rewind — the counter stops just above it.
+    #[tokio::test]
+    async fn test_try_rewind_counter_bounded_by_terminal_record() {
+        use mockall::predicate::eq;
+
+        let (provider, relayer_repo, network_repo, mut tx_repo, job_producer, signer, mut counter) =
+            setup_mocks();
+        let relayer_model = create_test_relayer();
+
+        // A Failed record sits at nonce 150 within the region.
+        tx_repo
+            .expect_get_nonce_occupancy()
+            .returning(|_, from, to| {
+                Ok((from..to)
+                    .map(|n| {
+                        if n == 150 {
+                            (n, Some(TransactionStatus::Failed))
+                        } else {
+                            (n, None)
+                        }
+                    })
+                    .collect())
+            });
+
+        // Highest record at 150 → target 151; CAS lowers 365 → 151.
+        counter
+            .expect_set_if_equals()
+            .with(eq(365u64), eq(151u64))
+            .times(1)
+            .returning(|_, _| Box::pin(ready(Ok(true))));
+
+        let relayer = EvmRelayer::new(
+            relayer_model,
+            signer,
+            provider,
+            create_test_evm_network(),
+            Arc::new(relayer_repo),
+            Arc::new(network_repo),
+            Arc::new(tx_repo),
+            Arc::new(counter),
+            Arc::new(job_producer),
+        )
+        .unwrap();
+
+        relayer.try_rewind_counter(100, 365).await.unwrap();
+    }
+
+    /// Rewind (e): a region wider than `MAX_REWIND_SCAN_RANGE` is skipped without any scan or CAS write.
+    #[tokio::test]
+    async fn test_try_rewind_counter_region_too_large_skips() {
+        let (provider, relayer_repo, network_repo, tx_repo, job_producer, signer, counter) =
+            setup_mocks();
+        let relayer_model = create_test_relayer();
+
+        // No get_nonce_occupancy and no set_if_equals expectations: either call panics,
+        // proving the oversized region is skipped without a partial scan.
+        let relayer = EvmRelayer::new(
+            relayer_model,
+            signer,
+            provider,
+            create_test_evm_network(),
+            Arc::new(relayer_repo),
+            Arc::new(network_repo),
+            Arc::new(tx_repo),
+            Arc::new(counter),
+            Arc::new(job_producer),
+        )
+        .unwrap();
+
+        relayer
+            .try_rewind_counter(0, MAX_REWIND_SCAN_RANGE + 2)
+            .await
+            .unwrap();
+    }
+
+    /// Rewind (c): an active record bounds the rewind, and the gap-fill still runs in the same pass.
+    #[tokio::test]
+    async fn test_resolve_nonce_gaps_rewinds_and_fills_in_same_run() {
+        use mockall::predicate::eq;
+
+        let (
+            mut provider,
+            relayer_repo,
+            mut network_repo,
+            mut tx_repo,
+            mut job_producer,
+            signer,
+            mut counter,
+        ) = setup_mocks();
+        let relayer_model = create_test_relayer();
+
+        // on-chain nonce 100, counter (observed) at 105.
+        provider
+            .expect_get_transaction_count()
+            .returning(|_| Box::pin(ready(Ok(100u64))));
+
+        counter
+            .expect_get()
+            .returning(|| Box::pin(ready(Ok(Some(105u64)))));
+
+        counter
+            .expect_sync_floor()
+            .returning(|floor| Box::pin(ready(Ok(floor))));
+
+        // A single active record sits at nonce 102.
+        tx_repo
+            .expect_get_nonce_occupancy()
+            .returning(|_, from, to| {
+                Ok((from..to)
+                    .map(|n| {
+                        if n == 102 {
+                            (n, Some(TransactionStatus::Submitted))
+                        } else {
+                            (n, None)
+                        }
+                    })
+                    .collect())
+            });
+
+        // Highest record 102 → target 103; CAS lowers 105 → 103.
+        counter
+            .expect_set_if_equals()
+            .with(eq(105u64), eq(103u64))
+            .times(1)
+            .returning(|_, _| Box::pin(ready(Ok(true))));
+
+        // Double-check finds the gap slots empty.
+        tx_repo.expect_find_by_nonce().returning(|_, _| Ok(None));
+
+        let network_model = create_test_network_model();
+        network_repo
+            .expect_get_by_name()
+            .returning(move |_, _| Ok(Some(network_model.clone())));
+
+        tx_repo.expect_create().returning(Ok);
+
+        job_producer
+            .expect_produce_transaction_request_job()
+            .returning(|_, _| Box::pin(ready(Ok(()))));
+        job_producer
+            .expect_produce_check_transaction_status_job()
+            .returning(|_, _| Box::pin(ready(Ok(()))));
+
+        let relayer = EvmRelayer::new(
+            relayer_model,
+            signer,
+            provider,
+            create_test_evm_network(),
+            Arc::new(relayer_repo),
+            Arc::new(network_repo),
+            Arc::new(tx_repo),
+            Arc::new(counter),
+            Arc::new(job_producer),
+        )
+        .unwrap();
+
+        // Gaps below the anchor at 102 are nonces 100 and 101.
+        let filled = relayer.resolve_nonce_gaps(None).await.unwrap();
+        assert_eq!(filled, 2);
+    }
+
+    /// Rewind (d): the CAS returns false (counter moved concurrently) — no error, and gap-fill still runs.
+    #[tokio::test]
+    async fn test_resolve_nonce_gaps_rewind_cas_false_continues_to_fill() {
+        let (
+            mut provider,
+            relayer_repo,
+            mut network_repo,
+            mut tx_repo,
+            mut job_producer,
+            signer,
+            mut counter,
+        ) = setup_mocks();
+        let relayer_model = create_test_relayer();
+
+        provider
+            .expect_get_transaction_count()
+            .returning(|_| Box::pin(ready(Ok(100u64))));
+
+        counter
+            .expect_get()
+            .returning(|| Box::pin(ready(Ok(Some(105u64)))));
+
+        counter
+            .expect_sync_floor()
+            .returning(|floor| Box::pin(ready(Ok(floor))));
+
+        // Active record at 103 → rewind target 104.
+        tx_repo
+            .expect_get_nonce_occupancy()
+            .returning(|_, from, to| {
+                Ok((from..to)
+                    .map(|n| {
+                        if n == 103 {
+                            (n, Some(TransactionStatus::Submitted))
+                        } else {
+                            (n, None)
+                        }
+                    })
+                    .collect())
+            });
+
+        // CAS fails — counter moved since observed; rewind is skipped without error.
+        counter
+            .expect_set_if_equals()
+            .returning(|_, _| Box::pin(ready(Ok(false))));
+
+        tx_repo.expect_find_by_nonce().returning(|_, _| Ok(None));
+
+        let network_model = create_test_network_model();
+        network_repo
+            .expect_get_by_name()
+            .returning(move |_, _| Ok(Some(network_model.clone())));
+
+        tx_repo.expect_create().returning(Ok);
+
+        job_producer
+            .expect_produce_transaction_request_job()
+            .returning(|_, _| Box::pin(ready(Ok(()))));
+        job_producer
+            .expect_produce_check_transaction_status_job()
+            .returning(|_, _| Box::pin(ready(Ok(()))));
+
+        let relayer = EvmRelayer::new(
+            relayer_model,
+            signer,
+            provider,
+            create_test_evm_network(),
+            Arc::new(relayer_repo),
+            Arc::new(network_repo),
+            Arc::new(tx_repo),
+            Arc::new(counter),
+            Arc::new(job_producer),
+        )
+        .unwrap();
+
+        // Gaps below the anchor at 103 are nonces 100, 101, 102.
+        let filled = relayer.resolve_nonce_gaps(None).await.unwrap();
+        assert_eq!(filled, 3);
+    }
+
+    /// Rewind (f): a failing counter `get()` propagates as an error.
+    #[tokio::test]
+    async fn test_resolve_nonce_gaps_propagates_counter_get_error() {
+        let (provider, relayer_repo, network_repo, tx_repo, job_producer, signer, mut counter) =
+            setup_mocks();
+        let relayer_model = create_test_relayer();
+
+        counter.expect_get().returning(|| {
+            Box::pin(ready(Err(
+                crate::repositories::TransactionCounterError::NotFound(
+                    "transient read failure".to_string(),
+                ),
+            )))
+        });
+
+        let relayer = EvmRelayer::new(
+            relayer_model,
+            signer,
+            provider,
+            create_test_evm_network(),
+            Arc::new(relayer_repo),
+            Arc::new(network_repo),
+            Arc::new(tx_repo),
+            Arc::new(counter),
+            Arc::new(job_producer),
+        )
+        .unwrap();
+
+        let result = relayer.resolve_nonce_gaps(None).await;
+        assert!(result.is_err());
+    }
+
+    /// Gap-fill NOOP (g1): one job enqueues successfully — creation returns Ok and the record is not failed.
+    #[tokio::test]
+    async fn test_create_gap_filling_noop_one_job_enqueued_returns_ok() {
+        let (
+            provider,
+            relayer_repo,
+            mut network_repo,
+            mut tx_repo,
+            mut job_producer,
+            signer,
+            counter,
+        ) = setup_mocks();
+        let relayer_model = create_test_relayer();
+
+        let network_model = create_test_network_model();
+        network_repo
+            .expect_get_by_name()
+            .returning(move |_, _| Ok(Some(network_model.clone())));
+
+        tx_repo.expect_create().returning(Ok);
+
+        // Request job fails to enqueue.
+        job_producer
+            .expect_produce_transaction_request_job()
+            .returning(|_, _| {
+                Box::pin(ready(Err(crate::jobs::JobProducerError::QueueError(
+                    "queue down".to_string(),
+                ))))
+            });
+        // Status-check job succeeds — one enqueue is enough to progress.
+        job_producer
+            .expect_produce_check_transaction_status_job()
+            .returning(|_, _| Box::pin(ready(Ok(()))));
+
+        // partial_update must NOT be called (no expectation → any call panics).
+
+        let relayer = EvmRelayer::new(
+            relayer_model,
+            signer,
+            provider,
+            create_test_evm_network(),
+            Arc::new(relayer_repo),
+            Arc::new(network_repo),
+            Arc::new(tx_repo),
+            Arc::new(counter),
+            Arc::new(job_producer),
+        )
+        .unwrap();
+
+        let tx = relayer.create_gap_filling_noop(7).await.unwrap();
+        assert_eq!(tx.status, TransactionStatus::Pending);
+    }
+
+    /// Gap-fill NOOP (g2): both jobs fail to enqueue — the record is marked Failed and the enqueue error propagates.
+    #[tokio::test]
+    async fn test_create_gap_filling_noop_both_jobs_fail_marks_failed() {
+        let (
+            provider,
+            relayer_repo,
+            mut network_repo,
+            mut tx_repo,
+            mut job_producer,
+            signer,
+            counter,
+        ) = setup_mocks();
+        let relayer_model = create_test_relayer();
+
+        let network_model = create_test_network_model();
+        network_repo
+            .expect_get_by_name()
+            .returning(move |_, _| Ok(Some(network_model.clone())));
+
+        tx_repo.expect_create().returning(Ok);
+
+        job_producer
+            .expect_produce_transaction_request_job()
+            .returning(|_, _| {
+                Box::pin(ready(Err(crate::jobs::JobProducerError::QueueError(
+                    "queue down".to_string(),
+                ))))
+            });
+        job_producer
+            .expect_produce_check_transaction_status_job()
+            .returning(|_, _| {
+                Box::pin(ready(Err(crate::jobs::JobProducerError::QueueError(
+                    "queue down".to_string(),
+                ))))
+            });
+
+        // The stranded Pending record is failed so a future health run can re-fill.
+        tx_repo
+            .expect_partial_update()
+            .withf(|_, update| update.status == Some(TransactionStatus::Failed))
+            .times(1)
+            .returning(|_, _| Ok(make_tx_with_status(TransactionStatus::Failed)));
+
+        let relayer = EvmRelayer::new(
+            relayer_model,
+            signer,
+            provider,
+            create_test_evm_network(),
+            Arc::new(relayer_repo),
+            Arc::new(network_repo),
+            Arc::new(tx_repo),
+            Arc::new(counter),
+            Arc::new(job_producer),
+        )
+        .unwrap();
+
+        let result = relayer.create_gap_filling_noop(7).await;
+        assert!(result.is_err());
+    }
+
+    /// `sync_nonce` raises the counter to the chain floor via a single atomic `sync_floor` call and never lowers it.
+    #[tokio::test]
+    async fn issue818_t2_sync_nonce_raises_counter_to_chain_floor_only() {
+        use mockall::predicate::eq;
+
+        let (mut provider, relayer_repo, network_repo, tx_repo, job_producer, signer, mut counter) =
+            setup_mocks();
+        let relayer_model = create_test_relayer();
+
+        // On-chain nonce is 100 (chain has moved less far than local counter).
+        provider
+            .expect_get_transaction_count()
+            .returning(|_| Box::pin(ready(Ok(100u64))));
+
+        // sync_nonce calls sync_floor(100) exactly once; the counter is already at 365
+        // so the effective value stays 365. `get`/`set` are never called (no expectations).
+        counter
+            .expect_sync_floor()
+            .with(eq(100u64))
+            .times(1)
+            .returning(|_| Box::pin(ready(Ok(365u64))));
+
+        let relayer = EvmRelayer::new(
+            relayer_model,
+            signer,
+            provider,
+            create_test_evm_network(),
+            Arc::new(relayer_repo),
+            Arc::new(network_repo),
+            Arc::new(tx_repo),
+            Arc::new(counter),
+            Arc::new(job_producer),
+        )
+        .unwrap();
+
+        relayer.sync_nonce().await.unwrap();
+    }
+
+    /// A failing `sync_floor` store call propagates as an error from `sync_nonce`.
+    #[tokio::test]
+    async fn issue818_t3_sync_nonce_propagates_counter_store_error() {
+        let (mut provider, relayer_repo, network_repo, tx_repo, job_producer, signer, mut counter) =
+            setup_mocks();
+        let relayer_model = create_test_relayer();
+
+        // On-chain nonce is 100.
+        provider
+            .expect_get_transaction_count()
+            .returning(|_| Box::pin(ready(Ok(100u64))));
+
+        // The atomic sync_floor fails with a transient store error.
+        counter.expect_sync_floor().returning(|_| {
+            Box::pin(ready(Err(
+                crate::repositories::TransactionCounterError::NotFound(
+                    "transient store failure".to_string(),
+                ),
+            )))
+        });
+
+        let relayer = EvmRelayer::new(
+            relayer_model,
+            signer,
+            provider,
+            create_test_evm_network(),
+            Arc::new(relayer_repo),
+            Arc::new(network_repo),
+            Arc::new(tx_repo),
+            Arc::new(counter),
+            Arc::new(job_producer),
+        )
+        .unwrap();
+
+        let result = relayer.sync_nonce().await;
+        assert!(
+            result.is_err(),
+            "sync_nonce must propagate the counter store failure: {result:?}"
+        );
+    }
+
+    /// A gap slot occupied by a `Pending` record (e.g. a stalled NOOP) counts as active occupancy, so `detect_nonce_gaps` does not report it as a gap.
+    #[tokio::test]
+    async fn issue818_t4_zombie_noop_pending_slot_hides_gap() {
+        let (provider, relayer_repo, network_repo, mut tx_repo, job_producer, signer, counter) =
+            setup_mocks();
+        let relayer_model = create_test_relayer();
+
+        // Occupancy: nonce 6 is a stalled gap-fill NOOP still in `Pending`,
+        // wedged between two genuinely active txs.
+        tx_repo.expect_get_nonce_occupancy().returning(|_, _, _| {
+            Ok(vec![
+                (5, Some(TransactionStatus::Submitted)),
+                (6, Some(TransactionStatus::Pending)),
+                (7, Some(TransactionStatus::Sent)),
+            ])
+        });
+
+        let relayer = EvmRelayer::new(
+            relayer_model,
+            signer,
+            provider,
+            create_test_evm_network(),
+            Arc::new(relayer_repo),
+            Arc::new(network_repo),
+            Arc::new(tx_repo),
+            Arc::new(counter),
+            Arc::new(job_producer),
+        )
+        .unwrap();
+
+        // on_chain_nonce provided (5) so no provider RPC is needed.
+        let gaps = relayer.detect_nonce_gaps(Some(5), None).await.unwrap();
+
+        assert!(
+            gaps.is_empty(),
+            "expected zero gaps because Pending slot 6 counts as active occupancy, got {gaps:?}"
+        );
+        assert!(
+            !gaps.contains(&6),
+            "slot 6 must NOT be reported as a gap while its NOOP record is Pending"
+        );
+    }
+
+    /// When the scan window contains no tx record at all, `detect_nonce_gaps` has no anchor and reports zero gaps.
+    #[tokio::test]
+    async fn issue818_t4_no_anchor_empty_scan_window_reports_zero_gaps() {
+        let (provider, relayer_repo, network_repo, mut tx_repo, job_producer, signer, counter) =
+            setup_mocks();
+        let relayer_model = create_test_relayer();
+
+        // Counter has drifted far ahead (365) while on-chain nonce is 100, but the
+        // entire scan window [100, 200) is EMPTY — no tx records exist there.
+        tx_repo
+            .expect_get_nonce_occupancy()
+            .returning(|_, from, to| Ok((from..to).map(|n| (n, None)).collect()));
+
+        let relayer = EvmRelayer::new(
+            relayer_model,
+            signer,
+            provider,
+            create_test_evm_network(),
+            Arc::new(relayer_repo),
+            Arc::new(network_repo),
+            Arc::new(tx_repo),
+            Arc::new(counter),
+            Arc::new(job_producer),
+        )
+        .unwrap();
+
+        // on-chain nonce 100, NO nonce hint. Scan window is [100, 100+100) = [100, 200).
+        let gaps = relayer.detect_nonce_gaps(Some(100), None).await.unwrap();
+
+        assert!(
+            gaps.is_empty(),
+            "expected zero gaps because the scan window has no anchor tx, got {gaps:?}"
+        );
     }
 
     #[tokio::test]

--- a/src/domain/transaction/evm/status.rs
+++ b/src/domain/transaction/evm/status.rs
@@ -4,7 +4,7 @@
 
 use alloy::network::ReceiptResponse;
 use chrono::{DateTime, Duration, Utc};
-use dashmap::DashMap;
+use dashmap::{mapref::entry::Entry, DashMap};
 use eyre::Result;
 use std::sync::OnceLock;
 use std::time::{Duration as StdDuration, Instant};
@@ -55,16 +55,22 @@ impl TtlDebounce {
     }
 
     fn should_fire(&self, key: &str) -> bool {
-        // The read guard must drop before the insert to avoid a shard deadlock.
-        let recent = self
-            .entries
-            .get(key)
-            .is_some_and(|last| last.elapsed() < self.ttl);
-        if recent {
-            return false;
+        // Entry holds the shard lock across check-and-set, so concurrent
+        // callers cannot both fire within the same TTL window.
+        match self.entries.entry(key.to_string()) {
+            Entry::Occupied(mut entry) => {
+                if entry.get().elapsed() < self.ttl {
+                    false
+                } else {
+                    entry.insert(Instant::now());
+                    true
+                }
+            }
+            Entry::Vacant(entry) => {
+                entry.insert(Instant::now());
+                true
+            }
         }
-        self.entries.insert(key.to_string(), Instant::now());
-        true
     }
 }
 

--- a/src/domain/transaction/evm/status.rs
+++ b/src/domain/transaction/evm/status.rs
@@ -4,7 +4,10 @@
 
 use alloy::network::ReceiptResponse;
 use chrono::{DateTime, Duration, Utc};
+use dashmap::DashMap;
 use eyre::Result;
+use std::sync::OnceLock;
+use std::time::{Duration as StdDuration, Instant};
 use tracing::{debug, error, warn};
 
 use super::super::common::is_active_nonce_status;
@@ -36,6 +39,45 @@ use crate::{
     services::{provider::EvmProviderTrait, signer::Signer},
     utils::{get_resubmit_timeout_for_speed, get_resubmit_timeout_with_backoff},
 };
+
+/// Per-key TTL gate: `should_fire` returns true at most once per `ttl` per key.
+struct TtlDebounce {
+    entries: DashMap<String, Instant>,
+    ttl: StdDuration,
+}
+
+impl TtlDebounce {
+    fn new(ttl: StdDuration) -> Self {
+        Self {
+            entries: DashMap::new(),
+            ttl,
+        }
+    }
+
+    fn should_fire(&self, key: &str) -> bool {
+        // The read guard must drop before the insert to avoid a shard deadlock.
+        let recent = self
+            .entries
+            .get(key)
+            .is_some_and(|last| last.elapsed() < self.ttl);
+        if recent {
+            return false;
+        }
+        self.entries.insert(key.to_string(), Instant::now());
+        true
+    }
+}
+
+/// Per-relayer debounce for nonce-health job *production* in `detect_nonce_gap_ahead`.
+///
+/// The distributed lock taken when the health job runs already dedupes concurrent
+/// *execution*, but with many transactions stuck on the same gapped relayer, every
+/// status-check cycle for every one of them would otherwise enqueue its own job.
+/// This bounds enqueue volume to at most one per relayer per TTL window.
+static NONCE_HEALTH_DEBOUNCE: OnceLock<TtlDebounce> = OnceLock::new();
+
+/// TTL for the `NONCE_HEALTH_DEBOUNCE` window.
+const NONCE_HEALTH_DEBOUNCE_TTL: StdDuration = StdDuration::from_secs(30);
 
 impl<P, RR, NR, TR, J, S, TCR, PC> EvmRelayerTransaction<P, RR, NR, TR, J, S, TCR, PC>
 where
@@ -492,11 +534,22 @@ where
             "nonce gaps confirmed below tx, scheduling nonce health to fill"
         );
 
-        if let Err(e) = self.schedule_relayer_nonce_health_job(tx).await {
-            warn!(
+        // Debounce job *production* per relayer — detection/return value is unaffected.
+        let debounce =
+            NONCE_HEALTH_DEBOUNCE.get_or_init(|| TtlDebounce::new(NONCE_HEALTH_DEBOUNCE_TTL));
+        if debounce.should_fire(&tx.relayer_id) {
+            if let Err(e) = self.schedule_relayer_nonce_health_job(tx).await {
+                warn!(
+                    tx_id = %tx.id,
+                    error = %e,
+                    "failed to schedule nonce health job for nonce gap"
+                );
+            }
+        } else {
+            debug!(
                 tx_id = %tx.id,
-                error = %e,
-                "failed to schedule nonce health job for nonce gap"
+                relayer_id = %tx.relayer_id,
+                "nonce health job production debounced for relayer"
             );
         }
 
@@ -1114,6 +1167,14 @@ where
         let age_since_sent = get_age_since_status_change(&tx)?;
 
         if age_since_sent > get_evm_resend_timeout() {
+            // A nonce gap below this tx makes any resubmit futile; the detector schedules
+            // the nonce-health job itself. Only worth the RPC once the tx is already stale.
+            if let Some(true) = self.detect_nonce_gap_ahead(&tx).await {
+                return self
+                    .update_transaction_status_if_needed(tx, TransactionStatus::Sent, None)
+                    .await;
+            }
+
             warn!(
                 tx_id = %tx.id,
                 relayer_id = %tx.relayer_id,
@@ -2325,6 +2386,277 @@ mod tests {
             let result = evm_transaction.handle_sent_state(tx.clone()).await.unwrap();
 
             assert_eq!(result.status, TransactionStatus::Sent);
+        }
+
+        /// An aged `Sent` tx with a confirmed nonce gap below it skips the resubmit
+        /// and schedules a nonce-health job instead (tx stays `Sent`).
+        #[tokio::test]
+        async fn issue818_t5_sent_state_nonce_gap_ahead_skips_resubmit() {
+            use std::sync::atomic::{AtomicUsize, Ordering};
+            use std::sync::Arc as StdArc;
+
+            let mut mocks = default_test_mocks();
+            let relayer = create_test_relayer();
+
+            // Aged Sent tx (60s > 25s resend timeout) with nonce 300. Unique relayer id
+            // so the nonce-health debounce doesn't interact with other tests.
+            let mut tx = make_test_transaction(TransactionStatus::Sent);
+            tx.relayer_id = "issue818-t5-relayer".to_string();
+            tx.sent_at = Some((Utc::now() - Duration::seconds(60)).to_rfc3339());
+            tx.network_data = NetworkTransactionData::Evm(EvmTransactionData {
+                nonce: Some(300),
+                ..tx.network_data.get_evm_transaction_data().unwrap()
+            });
+
+            // should_noop: network lookup + block gas limit (does not noop).
+            mocks
+                .network_repo
+                .expect_get_by_chain_id()
+                .returning(|_, _| Ok(Some(create_test_network_model())));
+
+            mocks.provider.expect_get_block_by_number().returning(|| {
+                Box::pin(async {
+                    use alloy::{network::AnyRpcBlock, rpc::types::Block};
+                    let mut block: Block = Block::default();
+                    block.header.gas_limit = 30_000_000u64;
+                    Ok(AnyRpcBlock::from(block))
+                })
+            });
+
+            // Chain nonce is far behind tx nonce (100 vs 300).
+            mocks
+                .provider
+                .expect_get_transaction_count()
+                .returning(|_| Box::pin(async { Ok(100) }));
+
+            // Scan is capped to on_chain_nonce + MAX_GAP_SCAN_RANGE (100 + 100 = 200).
+            // All slots empty -> confirmed gap.
+            mocks
+                .tx_repo
+                .expect_get_nonce_occupancy()
+                .withf(|relayer_id, from, to| {
+                    relayer_id == "issue818-t5-relayer" && *from == 100 && *to == 200
+                })
+                .returning(|_, from, to| Ok((from..to).map(|n| (n, None)).collect()));
+
+            // Nonce health job should be produced (unique relayer id, so not debounced).
+            let health_calls = StdArc::new(AtomicUsize::new(0));
+            let health_calls_clone = health_calls.clone();
+            mocks
+                .job_producer
+                .expect_produce_relayer_health_check_job()
+                .withf(|job, _| {
+                    job.metadata.as_ref().map_or(false, |m| {
+                        m.get("health_check_action") == Some(&"nonce_health".to_string())
+                    })
+                })
+                .returning(move |_, _| {
+                    health_calls_clone.fetch_add(1, Ordering::SeqCst);
+                    Box::pin(async { Ok(()) })
+                });
+
+            // Should NOT call produce_submit_transaction_job (resubmit skipped) —
+            // mockall will panic if an unexpected call is made.
+
+            let evm_transaction = make_test_evm_relayer_transaction(relayer, mocks);
+            let result = evm_transaction.handle_sent_state(tx.clone()).await.unwrap();
+
+            assert_eq!(result.status, TransactionStatus::Sent);
+            assert_eq!(
+                health_calls.load(Ordering::SeqCst),
+                1,
+                "nonce health job should be produced when the Sent-state gap check confirms a gap"
+            );
+        }
+
+        /// When `detect_nonce_gap_ahead` can't determine an answer (RPC error),
+        /// the Sent-state resubmit fails open and proceeds.
+        #[tokio::test]
+        async fn issue818_sent_state_gap_check_rpc_failure_proceeds_to_resubmit() {
+            let mut mocks = default_test_mocks();
+            let relayer = create_test_relayer();
+
+            let mut tx = make_test_transaction(TransactionStatus::Sent);
+            tx.relayer_id = "issue818-rpc-failure-relayer".to_string();
+            tx.sent_at = Some((Utc::now() - Duration::seconds(60)).to_rfc3339());
+            tx.network_data = NetworkTransactionData::Evm(EvmTransactionData {
+                nonce: Some(300),
+                ..tx.network_data.get_evm_transaction_data().unwrap()
+            });
+
+            mocks
+                .network_repo
+                .expect_get_by_chain_id()
+                .returning(|_, _| Ok(Some(create_test_network_model())));
+
+            mocks.provider.expect_get_block_by_number().returning(|| {
+                Box::pin(async {
+                    use alloy::{network::AnyRpcBlock, rpc::types::Block};
+                    let mut block: Block = Block::default();
+                    block.header.gas_limit = 30_000_000u64;
+                    Ok(AnyRpcBlock::from(block))
+                })
+            });
+
+            // RPC fails for the on-chain nonce lookup — gap check is skipped (None).
+            mocks
+                .provider
+                .expect_get_transaction_count()
+                .returning(|_| {
+                    Box::pin(async {
+                        Err(crate::services::provider::ProviderError::Other(
+                            "rpc timeout".to_string(),
+                        ))
+                    })
+                });
+
+            // Resubmission should still proceed (fail-open).
+            mocks
+                .job_producer
+                .expect_produce_submit_transaction_job()
+                .returning(|_, _| Box::pin(async { Ok(()) }));
+
+            mocks
+                .job_producer
+                .expect_produce_check_transaction_status_job()
+                .returning(|_, _| Box::pin(async { Ok(()) }));
+
+            let evm_transaction = make_test_evm_relayer_transaction(relayer, mocks);
+            let result = evm_transaction.handle_sent_state(tx.clone()).await.unwrap();
+
+            assert_eq!(result.status, TransactionStatus::Sent);
+        }
+
+        /// With no nonce gap below the tx, the Sent-state resubmit proceeds normally.
+        #[tokio::test]
+        async fn issue818_sent_state_no_gap_proceeds_to_resubmit() {
+            let mut mocks = default_test_mocks();
+            let relayer = create_test_relayer();
+
+            let mut tx = make_test_transaction(TransactionStatus::Sent);
+            tx.relayer_id = "issue818-no-gap-relayer".to_string();
+            tx.sent_at = Some((Utc::now() - Duration::seconds(60)).to_rfc3339());
+            tx.network_data = NetworkTransactionData::Evm(EvmTransactionData {
+                nonce: Some(270),
+                ..tx.network_data.get_evm_transaction_data().unwrap()
+            });
+
+            mocks
+                .network_repo
+                .expect_get_by_chain_id()
+                .returning(|_, _| Ok(Some(create_test_network_model())));
+
+            mocks.provider.expect_get_block_by_number().returning(|| {
+                Box::pin(async {
+                    use alloy::{network::AnyRpcBlock, rpc::types::Block};
+                    let mut block: Block = Block::default();
+                    block.header.gas_limit = 30_000_000u64;
+                    Ok(AnyRpcBlock::from(block))
+                })
+            });
+
+            // tx_nonce=270, on_chain=269 -> single slot to check.
+            mocks
+                .provider
+                .expect_get_transaction_count()
+                .returning(|_| Box::pin(async { Ok(269) }));
+
+            // Nonce 269 has an active Submitted tx -> no gap.
+            mocks
+                .tx_repo
+                .expect_get_nonce_occupancy()
+                .returning(|_, from, to| {
+                    Ok((from..to)
+                        .map(|n| (n, Some(TransactionStatus::Submitted)))
+                        .collect())
+                });
+
+            // Should proceed to resubmit (no health job expected).
+            mocks
+                .job_producer
+                .expect_produce_submit_transaction_job()
+                .returning(|_, _| Box::pin(async { Ok(()) }));
+
+            mocks
+                .job_producer
+                .expect_produce_check_transaction_status_job()
+                .returning(|_, _| Box::pin(async { Ok(()) }));
+
+            let evm_transaction = make_test_evm_relayer_transaction(relayer, mocks);
+            let result = evm_transaction.handle_sent_state(tx.clone()).await.unwrap();
+
+            assert_eq!(result.status, TransactionStatus::Sent);
+        }
+
+        /// A second gap detection for the same relayer within the debounce TTL skips
+        /// resubmission both times but enqueues only one nonce-health job.
+        #[tokio::test]
+        async fn issue818_nonce_health_debounce_produces_once_within_ttl() {
+            use std::sync::atomic::{AtomicUsize, Ordering};
+            use std::sync::Arc as StdArc;
+
+            let mut mocks = default_test_mocks();
+            let relayer = create_test_relayer();
+
+            let mut tx = make_test_transaction(TransactionStatus::Sent);
+            tx.relayer_id = "issue818-debounce-relayer".to_string();
+            tx.sent_at = Some((Utc::now() - Duration::seconds(60)).to_rfc3339());
+            tx.network_data = NetworkTransactionData::Evm(EvmTransactionData {
+                nonce: Some(300),
+                ..tx.network_data.get_evm_transaction_data().unwrap()
+            });
+
+            mocks
+                .network_repo
+                .expect_get_by_chain_id()
+                .returning(|_, _| Ok(Some(create_test_network_model())));
+
+            mocks.provider.expect_get_block_by_number().returning(|| {
+                Box::pin(async {
+                    use alloy::{network::AnyRpcBlock, rpc::types::Block};
+                    let mut block: Block = Block::default();
+                    block.header.gas_limit = 30_000_000u64;
+                    Ok(AnyRpcBlock::from(block))
+                })
+            });
+
+            mocks
+                .provider
+                .expect_get_transaction_count()
+                .returning(|_| Box::pin(async { Ok(100) }));
+
+            mocks
+                .tx_repo
+                .expect_get_nonce_occupancy()
+                .returning(|_, from, to| Ok((from..to).map(|n| (n, None)).collect()));
+
+            let health_calls = StdArc::new(AtomicUsize::new(0));
+            let health_calls_clone = health_calls.clone();
+            mocks
+                .job_producer
+                .expect_produce_relayer_health_check_job()
+                .returning(move |_, _| {
+                    health_calls_clone.fetch_add(1, Ordering::SeqCst);
+                    Box::pin(async { Ok(()) })
+                });
+
+            let evm_transaction = make_test_evm_relayer_transaction(relayer, mocks);
+
+            // First detection for this relayer: produces the health job.
+            let result1 = evm_transaction.handle_sent_state(tx.clone()).await.unwrap();
+            assert_eq!(result1.status, TransactionStatus::Sent);
+
+            // Second detection immediately after, same relayer: debounced, no
+            // second job produced. Resubmit is still skipped in both cases —
+            // debounce only affects job *production*, not gap detection.
+            let result2 = evm_transaction.handle_sent_state(tx.clone()).await.unwrap();
+            assert_eq!(result2.status, TransactionStatus::Sent);
+
+            assert_eq!(
+                health_calls.load(Ordering::SeqCst),
+                1,
+                "nonce health job should be produced only once within the debounce TTL"
+            );
         }
     }
 

--- a/src/domain/transaction/evm/status.rs
+++ b/src/domain/transaction/evm/status.rs
@@ -72,6 +72,12 @@ impl TtlDebounce {
             }
         }
     }
+
+    /// Releases the window for `key` so the next caller can fire immediately.
+    /// Used when the action gated by `should_fire` failed and should be retried.
+    fn clear(&self, key: &str) {
+        self.entries.remove(key);
+    }
 }
 
 /// Per-relayer debounce for nonce-health job *production* in `detect_nonce_gap_ahead`.
@@ -550,6 +556,9 @@ where
                     error = %e,
                     "failed to schedule nonce health job for nonce gap"
                 );
+                // A failed enqueue must not hold the window: no job was produced, so
+                // let the next detection on this relayer retry immediately.
+                debounce.clear(&tx.relayer_id);
             }
         } else {
             debug!(
@@ -2592,6 +2601,25 @@ mod tests {
             let result = evm_transaction.handle_sent_state(tx.clone()).await.unwrap();
 
             assert_eq!(result.status, TransactionStatus::Sent);
+        }
+
+        /// A failed enqueue must not hold the debounce window: after `clear`, the
+        /// next caller fires immediately instead of waiting out the TTL.
+        #[test]
+        fn ttl_debounce_clear_releases_window() {
+            use crate::domain::transaction::evm::status::TtlDebounce;
+
+            let debounce = TtlDebounce::new(std::time::Duration::from_secs(3600));
+            assert!(debounce.should_fire("relayer-1"));
+            assert!(!debounce.should_fire("relayer-1"));
+
+            debounce.clear("relayer-1");
+            assert!(debounce.should_fire("relayer-1"));
+
+            // Clearing one key must not affect another relayer's window.
+            assert!(debounce.should_fire("relayer-2"));
+            debounce.clear("relayer-1");
+            assert!(!debounce.should_fire("relayer-2"));
         }
 
         /// A second gap detection for the same relayer within the debounce TTL skips

--- a/src/repositories/transaction_counter/mod.rs
+++ b/src/repositories/transaction_counter/mod.rs
@@ -57,6 +57,11 @@ pub trait TransactionCounterTrait {
 
     async fn decrement(&self, relayer_id: &str, address: &str) -> Result<u64, RepositoryError>;
 
+    /// Blind unconditional write of the counter to `value`.
+    ///
+    /// This overwrites the counter regardless of its current value. Production code should
+    /// prefer `sync_floor` (to atomically raise the counter) or `set_if_equals` (to atomically
+    /// lower it under a compare-and-set guard); `set` is intended for tests and bootstrap.
     async fn set(&self, relayer_id: &str, address: &str, value: u64)
         -> Result<(), RepositoryError>;
 
@@ -72,6 +77,20 @@ pub trait TransactionCounterTrait {
         address: &str,
         floor: u64,
     ) -> Result<u64, RepositoryError>;
+
+    /// Atomic compare-and-set used for rewind/rollback.
+    ///
+    /// Sets the counter to `value` only if the current value equals `expected` AND
+    /// `value < expected`, guarding against clobbering a counter that has moved on
+    /// since it was last observed. Returns whether the write applied. A missing key
+    /// is a no-op and returns `false`.
+    async fn set_if_equals(
+        &self,
+        relayer_id: &str,
+        address: &str,
+        expected: u64,
+        value: u64,
+    ) -> Result<bool, RepositoryError>;
 
     /// Remove all stored counter entries from the underlying backend.
     /// Intended for startup reset flows when `RESET_STORAGE_ON_START` is enabled.
@@ -167,6 +186,27 @@ impl TransactionCounterTrait for TransactionCounterRepositoryStorage {
             }
             TransactionCounterRepositoryStorage::Redis(counter) => {
                 counter.sync_floor(relayer_id, address, floor).await
+            }
+        }
+    }
+
+    async fn set_if_equals(
+        &self,
+        relayer_id: &str,
+        address: &str,
+        expected: u64,
+        value: u64,
+    ) -> Result<bool, RepositoryError> {
+        match self {
+            TransactionCounterRepositoryStorage::InMemory(counter) => {
+                counter
+                    .set_if_equals(relayer_id, address, expected, value)
+                    .await
+            }
+            TransactionCounterRepositoryStorage::Redis(counter) => {
+                counter
+                    .set_if_equals(relayer_id, address, expected, value)
+                    .await
             }
         }
     }

--- a/src/repositories/transaction_counter/transaction_counter_in_memory.rs
+++ b/src/repositories/transaction_counter/transaction_counter_in_memory.rs
@@ -85,6 +85,28 @@ impl TransactionCounterTrait for InMemoryTransactionCounter {
         Ok(*entry)
     }
 
+    async fn set_if_equals(
+        &self,
+        relayer_id: &str,
+        address: &str,
+        expected: u64,
+        value: u64,
+    ) -> Result<bool, RepositoryError> {
+        // Hold the shard entry lock across read-compare-write so the compare-and-set is atomic
+        // with respect to concurrent `sync_floor`/`set`/`get_and_increment` on the same key.
+        // Never inserts: a missing key is a no-op that returns `false`.
+        match self
+            .store
+            .get_mut(&(relayer_id.to_string(), address.to_string()))
+        {
+            Some(mut entry) if *entry == expected && value < expected => {
+                *entry = value;
+                Ok(true)
+            }
+            _ => Ok(false),
+        }
+    }
+
     async fn drop_all_entries(&self) -> Result<(), RepositoryError> {
         self.store.clear();
         Ok(())
@@ -157,6 +179,52 @@ mod tests {
         let effective = store.sync_floor("relayer_1", "0xabc", 7).await.unwrap();
         assert_eq!(effective, 7);
         assert_eq!(store.get("relayer_1", "0xabc").await.unwrap(), Some(7));
+    }
+
+    #[tokio::test]
+    async fn test_set_if_equals_applies_when_expected_matches_and_value_is_lower() {
+        let store = InMemoryTransactionCounter::new();
+        let (relayer, address) = ("relayer_1", "0xabc");
+
+        store.set(relayer, address, 15).await.unwrap();
+
+        let applied = store.set_if_equals(relayer, address, 15, 5).await.unwrap();
+        assert!(applied);
+        assert_eq!(store.get(relayer, address).await.unwrap(), Some(5));
+    }
+
+    #[tokio::test]
+    async fn test_set_if_equals_returns_false_when_current_does_not_match_expected() {
+        let store = InMemoryTransactionCounter::new();
+        let (relayer, address) = ("relayer_1", "0xabc");
+
+        store.set(relayer, address, 20).await.unwrap();
+
+        let applied = store.set_if_equals(relayer, address, 15, 5).await.unwrap();
+        assert!(!applied);
+        assert_eq!(store.get(relayer, address).await.unwrap(), Some(20));
+    }
+
+    #[tokio::test]
+    async fn test_set_if_equals_returns_false_on_missing_key() {
+        let store = InMemoryTransactionCounter::new();
+        let (relayer, address) = ("relayer_1", "0xabc");
+
+        let applied = store.set_if_equals(relayer, address, 15, 5).await.unwrap();
+        assert!(!applied);
+        assert_eq!(store.get(relayer, address).await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn test_set_if_equals_returns_false_when_value_not_lower() {
+        let store = InMemoryTransactionCounter::new();
+        let (relayer, address) = ("relayer_1", "0xabc");
+
+        store.set(relayer, address, 15).await.unwrap();
+
+        let applied = store.set_if_equals(relayer, address, 15, 15).await.unwrap();
+        assert!(!applied);
+        assert_eq!(store.get(relayer, address).await.unwrap(), Some(15));
     }
 
     #[tokio::test]

--- a/src/repositories/transaction_counter/transaction_counter_redis.rs
+++ b/src/repositories/transaction_counter/transaction_counter_redis.rs
@@ -260,6 +260,56 @@ impl TransactionCounterTrait for RedisTransactionCounter {
         Ok(effective)
     }
 
+    async fn set_if_equals(
+        &self,
+        relayer_id: &str,
+        address: &str,
+        expected: u64,
+        value: u64,
+    ) -> Result<bool, RepositoryError> {
+        if relayer_id.is_empty() {
+            return Err(RepositoryError::InvalidData(
+                "Relayer ID cannot be empty".to_string(),
+            ));
+        }
+
+        if address.is_empty() {
+            return Err(RepositoryError::InvalidData(
+                "Address cannot be empty".to_string(),
+            ));
+        }
+
+        let key = self.counter_key(relayer_id, address);
+        debug!(relayer_id = %relayer_id, address = %address, expected = %expected, value = %value, "setting counter if current value matches expected");
+
+        let mut conn = self
+            .get_connection(self.connections.primary(), "set_if_equals")
+            .await?;
+
+        // Atomic compare-and-set: only lower the counter to `value` if the current value is
+        // exactly `expected` and `value` is genuinely lower, guarding against clobbering a
+        // counter that has moved on since it was last observed.
+        const SET_IF_EQUALS_LUA: &str = r#"
+            local cur = redis.call('GET', KEYS[1])
+            if cur and (tonumber(cur) == tonumber(ARGV[1])) and (tonumber(ARGV[2]) < tonumber(ARGV[1])) then
+                redis.call('SET', KEYS[1], ARGV[2])
+                return 1
+            end
+            return 0
+        "#;
+
+        let applied: bool = redis::Script::new(SET_IF_EQUALS_LUA)
+            .key(&key)
+            .arg(expected)
+            .arg(value)
+            .invoke_async(&mut conn)
+            .await
+            .map_err(|e| self.map_redis_error(e, "set_if_equals"))?;
+
+        debug!(expected = %expected, value = %value, applied = %applied, "counter set_if_equals evaluated");
+        Ok(applied)
+    }
+
     async fn drop_all_entries(&self) -> Result<(), RepositoryError> {
         let mut conn = self
             .get_connection(self.connections.primary(), "drop_all_entries")
@@ -394,6 +444,72 @@ mod tests {
         let effective = repo.sync_floor(&relayer_id, &address, 7).await.unwrap();
         assert_eq!(effective, 7);
         assert_eq!(repo.get(&relayer_id, &address).await.unwrap(), Some(7));
+    }
+
+    #[tokio::test]
+    #[ignore = "Requires active Redis instance"]
+    async fn test_set_if_equals_applies_when_expected_matches_and_value_is_lower() {
+        let repo = setup_test_repo().await;
+        let relayer_id = uuid::Uuid::new_v4().to_string();
+        let address = uuid::Uuid::new_v4().to_string();
+
+        repo.set(&relayer_id, &address, 15).await.unwrap();
+
+        let applied = repo
+            .set_if_equals(&relayer_id, &address, 15, 5)
+            .await
+            .unwrap();
+        assert!(applied);
+        assert_eq!(repo.get(&relayer_id, &address).await.unwrap(), Some(5));
+    }
+
+    #[tokio::test]
+    #[ignore = "Requires active Redis instance"]
+    async fn test_set_if_equals_returns_false_when_current_does_not_match_expected() {
+        let repo = setup_test_repo().await;
+        let relayer_id = uuid::Uuid::new_v4().to_string();
+        let address = uuid::Uuid::new_v4().to_string();
+
+        repo.set(&relayer_id, &address, 20).await.unwrap();
+
+        let applied = repo
+            .set_if_equals(&relayer_id, &address, 15, 5)
+            .await
+            .unwrap();
+        assert!(!applied);
+        assert_eq!(repo.get(&relayer_id, &address).await.unwrap(), Some(20));
+    }
+
+    #[tokio::test]
+    #[ignore = "Requires active Redis instance"]
+    async fn test_set_if_equals_returns_false_on_missing_key() {
+        let repo = setup_test_repo().await;
+        let relayer_id = uuid::Uuid::new_v4().to_string();
+        let address = uuid::Uuid::new_v4().to_string();
+
+        let applied = repo
+            .set_if_equals(&relayer_id, &address, 15, 5)
+            .await
+            .unwrap();
+        assert!(!applied);
+        assert_eq!(repo.get(&relayer_id, &address).await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    #[ignore = "Requires active Redis instance"]
+    async fn test_set_if_equals_returns_false_when_value_not_lower() {
+        let repo = setup_test_repo().await;
+        let relayer_id = uuid::Uuid::new_v4().to_string();
+        let address = uuid::Uuid::new_v4().to_string();
+
+        repo.set(&relayer_id, &address, 15).await.unwrap();
+
+        let applied = repo
+            .set_if_equals(&relayer_id, &address, 15, 15)
+            .await
+            .unwrap();
+        assert!(!applied);
+        assert_eq!(repo.get(&relayer_id, &address).await.unwrap(), Some(15));
     }
 
     #[tokio::test]
@@ -572,5 +688,53 @@ mod tests {
         // Verify final value is 110
         let final_value = repo.get(&relayer_id, &address).await.unwrap();
         assert_eq!(final_value, Some(110));
+    }
+
+    #[tokio::test]
+    #[ignore = "Requires active Redis instance"]
+    async fn test_concurrent_get_and_increment_races_set_if_equals() {
+        let repo = setup_test_repo().await;
+        let relayer_id = uuid::Uuid::new_v4().to_string();
+        let address = uuid::Uuid::new_v4().to_string();
+
+        repo.set(&relayer_id, &address, 100).await.unwrap();
+
+        // Race several increments against a single set_if_equals rollback attempt.
+        let mut handles: Vec<tokio::task::JoinHandle<Option<u64>>> = Vec::new();
+        for _ in 0..10 {
+            let repo = repo.clone();
+            let relayer_id = relayer_id.clone();
+            let address = address.clone();
+            handles.push(tokio::spawn(async move {
+                repo.get_and_increment(&relayer_id, &address).await.ok()
+            }));
+        }
+        {
+            let repo = repo.clone();
+            let relayer_id = relayer_id.clone();
+            let address = address.clone();
+            handles.push(tokio::spawn(async move {
+                repo.set_if_equals(&relayer_id, &address, 100, 50)
+                    .await
+                    .ok()
+                    .map(|applied| applied as u64)
+            }));
+        }
+
+        for handle in handles {
+            handle.await.unwrap();
+        }
+
+        // The CAS can only apply if it wins the race to run before any increment observes the
+        // counter (the only moment `cur == expected` holds, since increments only move the
+        // counter upward from 100). So either: the CAS ran first, rolled the counter back to
+        // 50, and all 10 increments then landed on top of that (final = 60); or an increment
+        // ran first, the CAS then saw a value != 100 and was refused, and all 10 increments
+        // completed untouched (final = 110). No increment is ever lost either way.
+        let final_value = repo.get(&relayer_id, &address).await.unwrap().unwrap();
+        assert!(
+            final_value == 60 || final_value == 110,
+            "unexpected final value: {final_value}"
+        );
     }
 }

--- a/src/repositories/transaction_counter/transaction_counter_redis.rs
+++ b/src/repositories/transaction_counter/transaction_counter_redis.rs
@@ -240,13 +240,22 @@ impl TransactionCounterTrait for RedisTransactionCounter {
 
         // Atomic monotonic max: raise to `floor` only if the current value is lower (or unset),
         // never rewind below an already-allocated sequence. Returns the effective value.
+        //
+        // Comparison and return are string-based: Lua 5.1 numbers are f64, exact only to
+        // 2^53 — not enough for Stellar sequences (~2^57+). Length-then-lexicographic
+        // ordering is correct because the key only ever holds canonical non-negative
+        // decimals (written via SET from u64 / INCR).
         const SYNC_FLOOR_LUA: &str = r#"
-            local cur = redis.call('GET', KEYS[1])
-            if (not cur) or (tonumber(cur) < tonumber(ARGV[1])) then
-                redis.call('SET', KEYS[1], ARGV[1])
-                return tonumber(ARGV[1])
+            local function numlt(a, b)
+                if #a ~= #b then return #a < #b end
+                return a < b
             end
-            return tonumber(cur)
+            local cur = redis.call('GET', KEYS[1])
+            if (not cur) or numlt(cur, ARGV[1]) then
+                redis.call('SET', KEYS[1], ARGV[1])
+                return ARGV[1]
+            end
+            return cur
         "#;
 
         let effective: u64 = redis::Script::new(SYNC_FLOOR_LUA)
@@ -289,9 +298,18 @@ impl TransactionCounterTrait for RedisTransactionCounter {
         // Atomic compare-and-set: only lower the counter to `value` if the current value is
         // exactly `expected` and `value` is genuinely lower, guarding against clobbering a
         // counter that has moved on since it was last observed.
+        //
+        // Comparisons are string-based: Lua 5.1 numbers are f64, exact only to 2^53 —
+        // adjacent Stellar sequences (~2^57+) would collide as doubles and let a stale
+        // CAS apply. Equality is exact on canonical decimals; ordering is
+        // length-then-lexicographic (valid for canonical non-negative decimals).
         const SET_IF_EQUALS_LUA: &str = r#"
+            local function numlt(a, b)
+                if #a ~= #b then return #a < #b end
+                return a < b
+            end
             local cur = redis.call('GET', KEYS[1])
-            if cur and (tonumber(cur) == tonumber(ARGV[1])) and (tonumber(ARGV[2]) < tonumber(ARGV[1])) then
+            if cur and (cur == ARGV[1]) and numlt(ARGV[2], ARGV[1]) then
                 redis.call('SET', KEYS[1], ARGV[2])
                 return 1
             end
@@ -510,6 +528,66 @@ mod tests {
             .unwrap();
         assert!(!applied);
         assert_eq!(repo.get(&relayer_id, &address).await.unwrap(), Some(15));
+    }
+
+    /// Values above 2^53 are indistinguishable as Lua doubles — adjacent Stellar-scale
+    /// sequences must still compare exactly (string comparison, not `tonumber`).
+    #[tokio::test]
+    #[ignore = "Requires active Redis instance"]
+    async fn test_set_if_equals_exact_above_f64_precision() {
+        let repo = setup_test_repo().await;
+        let relayer_id = uuid::Uuid::new_v4().to_string();
+        let address = uuid::Uuid::new_v4().to_string();
+
+        // 2^57 and 2^57 + 1 round to the same f64.
+        let big = 1u64 << 57;
+        repo.set(&relayer_id, &address, big).await.unwrap();
+
+        // Stale expected (off by one) must NOT match.
+        let applied = repo
+            .set_if_equals(&relayer_id, &address, big + 1, big - 10)
+            .await
+            .unwrap();
+        assert!(!applied);
+        assert_eq!(repo.get(&relayer_id, &address).await.unwrap(), Some(big));
+
+        // Exact expected must match, and `value` one below must count as lower.
+        let applied = repo
+            .set_if_equals(&relayer_id, &address, big, big - 1)
+            .await
+            .unwrap();
+        assert!(applied);
+        assert_eq!(
+            repo.get(&relayer_id, &address).await.unwrap(),
+            Some(big - 1)
+        );
+    }
+
+    /// `sync_floor` must distinguish adjacent values above 2^53 and return them intact.
+    #[tokio::test]
+    #[ignore = "Requires active Redis instance"]
+    async fn test_sync_floor_exact_above_f64_precision() {
+        let repo = setup_test_repo().await;
+        let relayer_id = uuid::Uuid::new_v4().to_string();
+        let address = uuid::Uuid::new_v4().to_string();
+
+        let big = 1u64 << 57;
+        repo.set(&relayer_id, &address, big).await.unwrap();
+
+        // One above must raise (equal-as-f64, greater-as-integer).
+        let effective = repo
+            .sync_floor(&relayer_id, &address, big + 1)
+            .await
+            .unwrap();
+        assert_eq!(effective, big + 1);
+        assert_eq!(
+            repo.get(&relayer_id, &address).await.unwrap(),
+            Some(big + 1)
+        );
+
+        // One below must not lower, and the returned value must be exact.
+        let effective = repo.sync_floor(&relayer_id, &address, big).await.unwrap();
+        assert_eq!(effective, big + 1);
     }
 
     #[tokio::test]

--- a/src/services/transaction_counter/mod.rs
+++ b/src/services/transaction_counter/mod.rs
@@ -34,6 +34,12 @@ pub trait TransactionCounterServiceTrait: Send + Sync {
     async fn get(&self) -> Result<Option<u64>, TransactionCounterError>;
     async fn get_and_increment(&self) -> Result<u64, TransactionCounterError>;
     async fn decrement(&self) -> Result<u64, TransactionCounterError>;
+
+    /// Blind unconditional write of the counter to `value`.
+    ///
+    /// This overwrites the counter regardless of its current value. Production code should
+    /// prefer `sync_floor` (to atomically raise the counter) or `set_if_equals` (to atomically
+    /// lower it under a compare-and-set guard); `set` is intended for tests and bootstrap.
     async fn set(&self, value: u64) -> Result<(), TransactionCounterError>;
 
     /// Monotonically raise the counter to `floor` only if the current value is lower.
@@ -43,6 +49,18 @@ pub trait TransactionCounterServiceTrait: Send + Sync {
     /// already advanced the counter beyond `floor` are never rewound. Returns the effective
     /// value after the operation (always `>= floor`).
     async fn sync_floor(&self, floor: u64) -> Result<u64, TransactionCounterError>;
+
+    /// Atomic compare-and-set used for rewind/rollback.
+    ///
+    /// Sets the counter to `value` only if the current value equals `expected` AND
+    /// `value < expected`, guarding against clobbering a counter that has moved on
+    /// since it was last observed. Returns whether the write applied. A missing key
+    /// is a no-op and returns `false`.
+    async fn set_if_equals(
+        &self,
+        expected: u64,
+        value: u64,
+    ) -> Result<bool, TransactionCounterError>;
 }
 
 #[async_trait]
@@ -85,6 +103,17 @@ where
             .await
             .map_err(|e| TransactionCounterError::NotFound(e.to_string()))
     }
+
+    async fn set_if_equals(
+        &self,
+        expected: u64,
+        value: u64,
+    ) -> Result<bool, TransactionCounterError> {
+        self.store
+            .set_if_equals(&self.relayer_id, &self.address, expected, value)
+            .await
+            .map_err(|e| TransactionCounterError::NotFound(e.to_string()))
+    }
 }
 
 #[cfg(test)]
@@ -124,5 +153,24 @@ mod tests {
         let effective = service.sync_floor(20).await.unwrap();
         assert_eq!(effective, 20);
         assert_eq!(service.get().await.unwrap(), Some(20));
+    }
+
+    #[tokio::test]
+    async fn test_set_if_equals_delegates_to_store() {
+        let store = Arc::new(InMemoryTransactionCounter::default());
+        let service =
+            TransactionCounterService::new("relayer_id".to_string(), "address".to_string(), store);
+
+        service.set(15).await.unwrap();
+
+        // A stale `expected` must not apply.
+        let applied = service.set_if_equals(10, 5).await.unwrap();
+        assert!(!applied);
+        assert_eq!(service.get().await.unwrap(), Some(15));
+
+        // A matching `expected` with a genuinely lower `value` applies.
+        let applied = service.set_if_equals(15, 5).await.unwrap();
+        assert!(applied);
+        assert_eq!(service.get().await.unwrap(), Some(5));
     }
 }

--- a/tests/integration/tests/authorization.rs
+++ b/tests/integration/tests/authorization.rs
@@ -31,10 +31,11 @@ async fn test_authorization_middleware_success() {
         repository_storage_type: RepositoryStorageType::InMemory,
         reset_storage_on_start: false,
         storage_encryption_key: None,
-        transaction_expiration_hours: 4,
+        transaction_expiration_hours: 4.0,
         provider_failure_expiration_secs: 60,
         provider_failure_threshold: 3,
         provider_pause_duration_secs: 60,
+        ..ServerConfig::from_env()
     });
 
     let app = test::init_service(
@@ -92,10 +93,11 @@ async fn test_authorization_middleware_failure() {
         repository_storage_type: RepositoryStorageType::InMemory,
         reset_storage_on_start: false,
         storage_encryption_key: None,
-        transaction_expiration_hours: 4,
+        transaction_expiration_hours: 4.0,
         provider_failure_expiration_secs: 60,
         provider_failure_threshold: 3,
         provider_pause_duration_secs: 60,
+        ..ServerConfig::from_env()
     });
 
     let app = test::init_service(

--- a/tests/integration/tests/evm/mod.rs
+++ b/tests/integration/tests/evm/mod.rs
@@ -2,3 +2,4 @@
 
 mod basic_transfer;
 mod contract_interaction;
+mod nonce_drift_recovery;

--- a/tests/integration/tests/evm/nonce_drift_recovery.rs
+++ b/tests/integration/tests/evm/nonce_drift_recovery.rs
@@ -1,0 +1,212 @@
+//! EVM nonce drift recovery integration test (issue #818)
+//!
+//! Reproduces the incident shape from #818 against a live Redis + Anvil stack:
+//! the Redis nonce counter drifts above the on-chain nonce (a failure between
+//! the counter increment and the tx-record persist "burns" nonces), leaving new
+//! transactions stuck ahead of the chain. Verifies the relayer self-heals via
+//! its nonce-health machinery — rewinding the counter over the verified-empty
+//! region above the stuck tx and gap-filling the burned nonces below it with
+//! NOOPs — without any storage reset.
+
+use crate::integration::common::{
+    client::RelayerClient,
+    confirmation::{wait_for_receipt, ReceiptConfig},
+    context::{is_evm_network, run_multi_network_test},
+    evm_helpers::{setup_test_relayer, verify_network_ready},
+    registry::TestRegistry,
+};
+use eyre::WrapErr;
+use openzeppelin_relayer::models::relayer::RelayerResponse;
+use redis::AsyncCommands;
+use serial_test::serial;
+use std::time::{Duration, Instant};
+use tracing::{info, info_span, warn};
+
+/// Burn address for test transfers
+const BURN_ADDRESS: &str = "0x000000000000000000000000000000000000dEaD";
+
+/// Test value for transfers (0.000001 ETH in wei)
+const TRANSFER_VALUE: &str = "1000000000000";
+
+/// Nonces "burned" below the stuck tx — the health run must gap-fill these with NOOPs.
+const BURNED_BELOW: u64 = 3;
+
+/// Nonces "burned" above the stuck tx — the health run must rewind the counter over these.
+const BURNED_ABOVE: u64 = 4;
+
+/// Max wait for the stuck tx to recover. Dominated by the resubmit timeout that
+/// gates gap detection (~3 min for "fast"), then NOOP fills + mining.
+const RECOVERY_MAX_WAIT_MS: u64 = 420_000;
+
+/// Max wait for the counter rewind to be visible in Redis after recovery.
+const REWIND_VISIBLE_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Max wait for the stuck tx's async nonce allocation to appear in the counter.
+const ALLOCATION_TIMEOUT: Duration = Duration::from_secs(30);
+
+async fn redis_connection() -> eyre::Result<redis::aio::MultiplexedConnection> {
+    let url = std::env::var("REDIS_URL").unwrap_or_else(|_| "redis://127.0.0.1:6379".to_string());
+    let client = redis::Client::open(url.as_str())
+        .wrap_err_with(|| format!("Failed to open Redis client for {url}"))?;
+    client
+        .get_multiplexed_async_connection()
+        .await
+        .wrap_err_with(|| format!("Failed to connect to Redis at {url}"))
+}
+
+/// Finds the relayer's nonce counter key without assuming address formatting.
+///
+/// Returns `None` when no key exists — the relayer is running with in-memory
+/// storage (`REPOSITORY_STORAGE_TYPE` != `redis`), where this test cannot
+/// manipulate the counter.
+async fn find_counter_key(
+    con: &mut redis::aio::MultiplexedConnection,
+    relayer_id: &str,
+) -> eyre::Result<Option<String>> {
+    let prefix = std::env::var("REDIS_KEY_PREFIX").unwrap_or_else(|_| "oz-relayer".to_string());
+    let pattern = format!("{prefix}:transaction_counter:{relayer_id}:*");
+    let keys: Vec<String> = con.keys(&pattern).await?;
+    match keys.as_slice() {
+        [key] => Ok(Some(key.clone())),
+        [] => Ok(None),
+        _ => Err(eyre::eyre!(
+            "Expected exactly one counter key for {pattern}, found {keys:?}"
+        )),
+    }
+}
+
+async fn send_transfer(client: &RelayerClient, relayer_id: &str) -> eyre::Result<String> {
+    let tx_request = serde_json::json!({
+        "to": BURN_ADDRESS,
+        "value": TRANSFER_VALUE,
+        "data": "0x",
+        "gas_limit": 21000,
+        "speed": "fast"
+    });
+    let tx_response = client.send_transaction(relayer_id, tx_request).await?;
+    Ok(tx_response.id)
+}
+
+async fn run_nonce_drift_recovery_test(
+    network: String,
+    relayer_info: RelayerResponse,
+) -> eyre::Result<()> {
+    let _span = info_span!("nonce_drift_recovery", network = %network, relayer = %relayer_info.id)
+        .entered();
+
+    // This test writes the relayer's counter key directly in Redis and relies on
+    // cheap, fast NOOP fills — local Anvil only.
+    if std::env::var("MODE").is_ok_and(|m| m.eq_ignore_ascii_case("testnet")) {
+        info!("Skipping nonce drift recovery test in testnet mode");
+        return Ok(());
+    }
+
+    let registry = TestRegistry::load()?;
+    verify_network_ready(&registry, &network, &relayer_info)?;
+
+    let client = RelayerClient::from_env()?;
+    let relayer = setup_test_relayer(&client, &relayer_info).await?;
+
+    // Baseline transfer: proves the relayer works and guarantees the counter key
+    // exists in Redis and matches the on-chain nonce.
+    let baseline_id = send_transfer(&client, &relayer.id).await?;
+    let receipt_config = ReceiptConfig::from_network(&network)?;
+    wait_for_receipt(&client, &relayer.id, &baseline_id, &receipt_config).await?;
+    info!(tx_id = %baseline_id, "Baseline transfer confirmed");
+
+    let mut con = redis_connection().await?;
+    let Some(counter_key) = find_counter_key(&mut con, &relayer.id).await? else {
+        warn!(
+            relayer_id = %relayer.id,
+            "SKIPPED: no Redis counter key — relayer is not using Redis storage. \
+             Set REPOSITORY_STORAGE_TYPE=redis (and STORAGE_ENCRYPTION_KEY) in \
+             .env.integration to run this test."
+        );
+        return Ok(());
+    };
+    let c0: u64 = con.get(&counter_key).await?;
+    info!(counter_key = %counter_key, counter = c0, "Counter in sync with chain");
+
+    // Simulate burned nonces below: the next tx will allocate c0 + BURNED_BELOW,
+    // landing ahead of the chain and getting stuck in the node's queue.
+    let _: () = con.set(&counter_key, c0 + BURNED_BELOW).await?;
+    let stuck_id = send_transfer(&client, &relayer.id).await?;
+    info!(tx_id = %stuck_id, nonce = c0 + BURNED_BELOW, "Sent tx stuck ahead of chain");
+
+    // Nonce allocation happens asynchronously in the prepare job — wait until the
+    // stuck tx's allocation moves the counter to c0 + BURNED_BELOW + 1.
+    let after_alloc = c0 + BURNED_BELOW + 1;
+    let deadline = Instant::now() + ALLOCATION_TIMEOUT;
+    loop {
+        let counter: u64 = con.get(&counter_key).await?;
+        if counter == after_alloc {
+            break;
+        }
+        if counter != c0 + BURNED_BELOW || Instant::now() > deadline {
+            return Err(eyre::eyre!(
+                "Counter is {counter}, expected {after_alloc} after stuck-tx allocation; \
+                 a health run may have interfered — rerun the test"
+            ));
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+
+    // Simulate burned nonces above the stuck tx's record. The health run must
+    // rewind the counter over this verified-empty region via CAS.
+    let inflated = after_alloc + BURNED_ABOVE;
+    let _: () = con.set(&counter_key, inflated).await?;
+    info!(counter = inflated, "Inflated counter above stuck tx");
+
+    // Recovery: a status check on the stuck tx detects the gap ahead and enqueues
+    // a nonce-health job, which rewinds the counter and gap-fills the burned
+    // nonces below with NOOPs; the NOOPs mine, then the stuck tx mines.
+    let recovery_config = ReceiptConfig::custom(&network, 2_000, RECOVERY_MAX_WAIT_MS);
+    wait_for_receipt(&client, &relayer.id, &stuck_id, &recovery_config).await?;
+    info!(tx_id = %stuck_id, "Stuck tx recovered and confirmed");
+
+    // The rewind runs before the gap fill in the same health run, so by now the
+    // counter must have been CAS'd from `inflated` down to after_alloc
+    // (= highest tx record + 1). Poll briefly to absorb read lag.
+    let deadline = Instant::now() + REWIND_VISIBLE_TIMEOUT;
+    loop {
+        let counter: u64 = con.get(&counter_key).await?;
+        if counter == after_alloc {
+            info!(counter = counter, "Counter rewound over burned region");
+            break;
+        }
+        if Instant::now() > deadline {
+            return Err(eyre::eyre!(
+                "Counter is {counter}, expected rewind to {after_alloc} within {:?}",
+                REWIND_VISIBLE_TIMEOUT
+            ));
+        }
+        tokio::time::sleep(Duration::from_secs(2)).await;
+    }
+
+    // A normal transfer must now allocate the rewound nonce and confirm — the
+    // relayer is fully healed with no storage reset.
+    let final_id = send_transfer(&client, &relayer.id).await?;
+    wait_for_receipt(&client, &relayer.id, &final_id, &receipt_config).await?;
+    let final_counter: u64 = con.get(&counter_key).await?;
+    if final_counter != after_alloc + 1 {
+        return Err(eyre::eyre!(
+            "Counter is {final_counter}, expected {} after post-recovery transfer",
+            after_alloc + 1
+        ));
+    }
+    info!(tx_id = %final_id, counter = final_counter, "Post-recovery transfer confirmed");
+
+    Ok(())
+}
+
+/// Test nonce drift recovery (issue #818) on all selected EVM networks
+#[tokio::test]
+#[serial]
+async fn test_evm_nonce_drift_recovery() {
+    run_multi_network_test(
+        "nonce_drift_recovery",
+        is_evm_network,
+        run_nonce_drift_recovery_test,
+    )
+    .await;
+}


### PR DESCRIPTION
On EVM networks the relayer's nonce counter drifts above the on-chain nonce when a failure lands between the counter increment and the transaction-record persist. Every counter write was monotonic-upward, so the drift was permanent: new transactions were rejected with "nonce too high" forever, stuck Sent transactions were repriced and resubmitted every status cycle with no terminal condition, and the only recovery was a full storage wipe.

Closes #818.

## Approach

- Adds an atomic `set_if_equals` compare-and-set to the transaction counter, the downward counterpart of `sync_floor`. It lives on the shared trait so the Stellar sequence counter (same vulnerability class, follow-up) can reuse it.
- EVM counter writes become atomic: `sync_nonce` now uses `sync_floor` instead of read-max-write. This also fixes a latent bug where a swallowed counter-read error caused a blind write of the chain nonce, which could rewind a healthy counter and hand out duplicate nonces.
- Nonce-health runs now trim the drift: when the region between the chain nonce and the counter is verified free of transaction records, the counter is CAS-rewound to on-chain reality. Records of any status bound the rewind, since a Failed record can be a reverted transaction whose nonce was consumed. A region wider than 100k slots is never scanned piecemeal; the rewind is skipped with a loud log instead.
- `handle_sent_state` gets the same nonce-gap check `handle_submitted_state` already had, so transactions blocked by a gap stop being futilely resubmitted every cycle. Health-job production is debounced per relayer because thousands of stuck transactions would otherwise enqueue redundant jobs faster than the execution lock can drain them.
- Gap-filling NOOPs whose driving jobs both fail to enqueue are marked Failed instead of silently occupying their nonce slot forever.
- Deliberately not included: rolling back the allocation when the persist fails in `prepare_transaction`. The rewind heals burned nonces within a health cycle, and this keeps the hot prepare path untouched.

## Testing

Unit tests cover the CAS semantics, the rewind bounds (empty region, terminal-record bound, oversized region, concurrent-move CAS failure), the Sent-state gap check including fail-open on RPC errors, and the debounce. The Redis-gated tests (including a racing-increment CAS test) were run against a live Redis and pass; note they are `#[ignore]`d and do not run in CI.

An end-to-end integration test (`nonce_drift_recovery`) reproduces the incident shape against the live Redis + Anvil stack: burned nonces below a stuck tx and above it, then asserts the health run rewinds the counter over the empty region, gap-fills below with NOOPs, confirms the stuck tx, and processes a normal transfer afterward. Verified locally (`rewound nonce counter over verified-empty region observed=15 target=11 on_chain_nonce=7`). It requires the relayer to run `REPOSITORY_STORAGE_TYPE=redis` (documented in `.env.integration.example`) and skips loudly otherwise — the integration stack's in-memory default never exercises the Redis repositories, which may be worth revisiting separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved EVM nonce synchronization to prevent counter drift and safely recover from gaps.
  * Reduced duplicate nonce-health jobs through short-term debouncing.
  * Prevented resubmission of stuck transactions when an active nonce gap is detected.
  * Improved gap-filling reliability by handling transaction and status jobs independently.
* **Reliability**
  * Added safer counter rollback behavior to avoid overwriting newer nonce updates during recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
