### PR TITLE
fix: Rewind drifted Stellar sequence counter

### DIFF
--- a/src/domain/transaction/stellar/prepare/mod.rs
+++ b/src/domain/transaction/stellar/prepare/mod.rs
@@ -635,6 +635,116 @@ mod prepare_transaction_tests {
         lane_gate::free(&relayer.id, another_tx_id); // cleanup
     }
 
+    /// A prepare failure after the counter increment heals the drift at the origin: the
+    /// failing tx never persisted a sequence, so handle_prepare_failure's chain sync
+    /// rewinds the counter over the freshly burned sequence before any TxBadSeq occurs.
+    #[tokio::test]
+    async fn prepare_failure_rewinds_freshly_burned_sequence() {
+        let relayer = create_test_relayer();
+        let mut mocks = default_test_mocks();
+
+        // Allocation burns 149 and leaves the counter at 150
+        mocks
+            .counter
+            .expect_get_and_increment()
+            .returning(|_, _| Box::pin(ready(Ok(149))));
+
+        // Signer fails after the increment — the sequence is never persisted
+        mocks.signer.expect_sign_transaction().returning(|_| {
+            Box::pin(async {
+                Err(crate::models::SignerError::SigningError(
+                    "Signer failure".to_string(),
+                ))
+            })
+        });
+
+        // Chain sync in handle_prepare_failure: chain seq 100 → floor 101
+        mocks.provider.expect_get_account().returning(|_| {
+            Box::pin(async {
+                use soroban_rs::xdr::{
+                    AccountEntry, AccountEntryExt, AccountId, PublicKey, SequenceNumber, String32,
+                    Thresholds, Uint256,
+                };
+                use stellar_strkey::ed25519;
+
+                let pk = ed25519::PublicKey::from_string(TEST_PK).unwrap();
+                let account_id = AccountId(PublicKey::PublicKeyTypeEd25519(Uint256(pk.0)));
+
+                Ok(AccountEntry {
+                    account_id,
+                    balance: 1000000,
+                    seq_num: SequenceNumber(100),
+                    num_sub_entries: 0,
+                    inflation_dest: None,
+                    flags: 0,
+                    home_domain: String32::default(),
+                    thresholds: Thresholds([1, 1, 1, 1]),
+                    signers: Default::default(),
+                    ext: AccountEntryExt::V0,
+                })
+            })
+        });
+
+        // Counter sits at 150, above the chain floor
+        mocks
+            .counter
+            .expect_sync_floor()
+            .returning(|_, _, _| Box::pin(ready(Ok(150))));
+
+        // No active tx holds a sequence (the failing tx never persisted one)
+        mocks
+            .tx_repo
+            .expect_find_by_status()
+            .times(1)
+            .returning(|_, _| Ok(vec![]));
+
+        // The burned head is rewound 150 → 101 before any TxBadSeq thrash starts
+        mocks
+            .counter
+            .expect_set_if_equals()
+            .withf(|relayer_id, addr, expected, value| {
+                relayer_id == "relayer-1" && addr == TEST_PK && *expected == 150 && *value == 101
+            })
+            .times(1)
+            .returning(|_, _, _, _| Box::pin(ready(Ok(true))));
+
+        // Failure handling marks the tx Failed and notifies
+        mocks
+            .tx_repo
+            .expect_partial_update()
+            .withf(|_, upd| upd.status == Some(TransactionStatus::Failed))
+            .returning(|id, upd| {
+                let mut tx = create_test_transaction("relayer-1");
+                tx.id = id;
+                tx.status = upd.status.unwrap();
+                Ok::<_, RepositoryError>(tx)
+            });
+
+        mocks
+            .job_producer
+            .expect_produce_send_notification_job()
+            .times(1)
+            .returning(|_, _| Box::pin(async { Ok(()) }));
+
+        mocks
+            .tx_repo
+            .expect_find_by_status_paginated()
+            .returning(move |_, _, _, _| {
+                Ok(PaginatedResult {
+                    items: vec![],
+                    total: 0,
+                    page: 1,
+                    per_page: 1,
+                })
+            });
+
+        let handler = make_stellar_tx_handler(relayer.clone(), mocks);
+        let tx = create_test_transaction(&relayer.id);
+
+        let result = handler.prepare_transaction_impl(tx.clone()).await;
+        assert!(result.is_err());
+    }
+
     #[tokio::test]
     async fn prepare_transaction_already_claimed_lane_returns_original() {
         let mut relayer = create_test_relayer();

--- a/src/domain/transaction/stellar/stellar_transaction.rs
+++ b/src/domain/transaction/stellar/stellar_transaction.rs
@@ -958,6 +958,89 @@ mod tests {
         assert!(result.is_ok());
     }
 
+    /// Rewind (d): an active tx at `observed - 1` makes the target equal `observed` —
+    /// no CAS write is attempted (either mock call would panic as unexpected).
+    #[tokio::test]
+    async fn test_sync_sequence_rewind_noop_when_active_tx_at_observed() {
+        let relayer = create_test_relayer();
+        let mut mocks = default_test_mocks();
+
+        mocks
+            .provider
+            .expect_get_account()
+            .times(1)
+            .returning(|_| Box::pin(async { Ok(test_account_entry(100)) }));
+
+        mocks
+            .counter
+            .expect_sync_floor()
+            .times(1)
+            .returning(|_, _, _| Box::pin(async { Ok(150) }));
+
+        // An active tx holds 149 → target = 150 = observed → rewind is a no-op.
+        // No set_if_equals expectation: a CAS attempt panics the test.
+        let mut active_tx = create_test_transaction(&relayer.id);
+        active_tx.status = TransactionStatus::Sent;
+        if let NetworkTransactionData::Stellar(ref mut data) = active_tx.network_data {
+            data.sequence_number = Some(149);
+        }
+        mocks
+            .tx_repo
+            .expect_find_by_status()
+            .times(1)
+            .returning(move |_, _| Ok(vec![active_tx.clone()]));
+
+        let handler = make_stellar_tx_handler(relayer.clone(), mocks);
+
+        let result = handler.sync_sequence_from_chain(&relayer.address).await;
+        assert!(result.is_ok());
+    }
+
+    /// Rewind (e): an active tx whose sequence is below the chain floor does not drag
+    /// the target under it — the chain floor wins the max().
+    #[tokio::test]
+    async fn test_sync_sequence_rewind_chain_floor_wins_over_stale_active_seq() {
+        let relayer = create_test_relayer();
+        let mut mocks = default_test_mocks();
+
+        mocks
+            .provider
+            .expect_get_account()
+            .times(1)
+            .returning(|_| Box::pin(async { Ok(test_account_entry(100)) }));
+
+        mocks
+            .counter
+            .expect_sync_floor()
+            .times(1)
+            .returning(|_, _, _| Box::pin(async { Ok(150) }));
+
+        // A stale active tx holds 42, below the chain floor of 101.
+        let mut active_tx = create_test_transaction(&relayer.id);
+        active_tx.status = TransactionStatus::Sent;
+        if let NetworkTransactionData::Stellar(ref mut data) = active_tx.network_data {
+            data.sequence_number = Some(42);
+        }
+        mocks
+            .tx_repo
+            .expect_find_by_status()
+            .times(1)
+            .returning(move |_, _| Ok(vec![active_tx.clone()]));
+
+        // target = max(101, 42 + 1) = 101; CAS lowers 150 → 101.
+        mocks
+            .counter
+            .expect_set_if_equals()
+            .withf(|_, _, expected, value| *expected == 150 && *value == 101)
+            .times(1)
+            .returning(|_, _, _, _| Box::pin(async { Ok(true) }));
+
+        let handler = make_stellar_tx_handler(relayer.clone(), mocks);
+
+        let result = handler.sync_sequence_from_chain(&relayer.address).await;
+        assert!(result.is_ok());
+    }
+
     /// Rewind (c): the CAS returns false (counter moved concurrently) — no error is surfaced.
     #[tokio::test]
     async fn test_sync_sequence_rewind_cas_miss_is_ok() {

--- a/src/domain/transaction/stellar/stellar_transaction.rs
+++ b/src/domain/transaction/stellar/stellar_transaction.rs
@@ -25,7 +25,7 @@ use crate::{
 };
 use async_trait::async_trait;
 use std::sync::Arc;
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 
 use super::lane_gate;
 
@@ -273,6 +273,95 @@ where
             effective_sequence = %effective_seq,
             "synced local sequence counter to chain floor"
         );
+
+        // The floor sync only raises. A failure between `get_and_increment` and the
+        // tx-record persist burns the sequence and leaves the counter above the chain;
+        // without a downward reconcile the tx re-prepares at ever-higher sequences and
+        // thrashes TxBadSeq forever, so also try to rewind over the burned region.
+        if effective_seq > next_usable_seq {
+            self.try_rewind_sequence_counter(relayer_address, next_usable_seq, effective_seq)
+                .await?;
+        }
+
+        Ok(())
+    }
+
+    /// Trims the burned head of the sequence counter down to on-chain reality.
+    ///
+    /// Rewinds the counter from `observed` to `target`, where `target` is one past the
+    /// highest `sequence_number` held by any active (Pending/Sent/Submitted) transaction
+    /// of this relayer, or `next_usable_from_chain` if no active transaction holds one.
+    /// Transactions reset via `reset_to_pre_prepare_state` have their `sequence_number`
+    /// cleared, so they never bound the rewind and their burned sequences are reclaimed.
+    ///
+    /// The nonce occupancy index is EVM-only, so occupancy is derived by reading the
+    /// Stellar `sequence_number` from the active transaction records directly.
+    ///
+    /// The write is a CAS against `observed`; if the counter moved concurrently the
+    /// write is a no-op — an under-rewind or missed rewind self-heals on the next
+    /// TxBadSeq recovery cycle.
+    async fn try_rewind_sequence_counter(
+        &self,
+        relayer_address: &str,
+        next_usable_from_chain: u64,
+        observed: u64,
+    ) -> Result<(), TransactionError> {
+        if observed <= next_usable_from_chain {
+            return Ok(());
+        }
+
+        let active_txs = self
+            .transaction_repository()
+            .find_by_status(
+                &self.relayer().id,
+                &[
+                    TransactionStatus::Pending,
+                    TransactionStatus::Sent,
+                    TransactionStatus::Submitted,
+                ],
+            )
+            .await
+            .map_err(TransactionError::from)?;
+
+        let highest_active_seq = active_txs
+            .iter()
+            .filter_map(|tx| tx.network_data.get_stellar_transaction_data().ok())
+            .filter_map(|data| data.sequence_number)
+            .filter_map(|seq| u64::try_from(seq).ok())
+            .max();
+
+        let target = match highest_active_seq {
+            Some(seq) => std::cmp::max(next_usable_from_chain, seq + 1),
+            None => next_usable_from_chain,
+        };
+
+        if target >= observed {
+            return Ok(());
+        }
+
+        let applied = self
+            .transaction_counter_service()
+            .set_if_equals(&self.relayer().id, relayer_address, observed, target)
+            .await
+            .map_err(|e| {
+                TransactionError::UnexpectedError(format!("Failed to rewind sequence counter: {e}"))
+            })?;
+
+        if applied {
+            info!(
+                relayer_id = %self.relayer().id,
+                observed = observed,
+                target = target,
+                next_usable_from_chain = next_usable_from_chain,
+                "rewound sequence counter over burned region"
+            );
+        } else {
+            debug!(
+                relayer_id = %self.relayer().id,
+                "counter moved concurrently; skipping rewind, next TxBadSeq recovery will retry"
+            );
+        }
+
         Ok(())
     }
 
@@ -737,6 +826,173 @@ mod tests {
             }
             _ => panic!("Expected UnexpectedError"),
         }
+    }
+
+    /// Builds an `AccountEntry` for the test relayer with the given on-chain sequence.
+    fn test_account_entry(seq: i64) -> soroban_rs::xdr::AccountEntry {
+        use soroban_rs::xdr::{
+            AccountEntry, AccountEntryExt, AccountId, PublicKey, SequenceNumber, String32,
+            Thresholds, Uint256,
+        };
+        use stellar_strkey::ed25519;
+
+        let pk = ed25519::PublicKey::from_string(TEST_PK).unwrap();
+        let account_id = AccountId(PublicKey::PublicKeyTypeEd25519(Uint256(pk.0)));
+
+        AccountEntry {
+            account_id,
+            balance: 1000000,
+            seq_num: SequenceNumber(seq),
+            num_sub_entries: 0,
+            inflation_dest: None,
+            flags: 0,
+            home_domain: String32::default(),
+            thresholds: Thresholds([1, 1, 1, 1]),
+            signers: Default::default(),
+            ext: AccountEntryExt::V0,
+        }
+    }
+
+    /// Rewind (a): no active tx holds a sequence — the drifted counter rewinds to the chain floor.
+    #[tokio::test]
+    async fn test_sync_sequence_rewind_empty_region_rewinds_to_chain_floor() {
+        let relayer = create_test_relayer();
+        let mut mocks = default_test_mocks();
+
+        // Chain sequence 100 → next usable 101.
+        mocks
+            .provider
+            .expect_get_account()
+            .times(1)
+            .returning(|_| Box::pin(async { Ok(test_account_entry(100)) }));
+
+        // Counter sits at 150, well above the chain floor.
+        mocks
+            .counter
+            .expect_sync_floor()
+            .times(1)
+            .returning(|_, _, _| Box::pin(async { Ok(150) }));
+
+        // Only reset txs remain: sequence_number is cleared, so nothing bounds the rewind.
+        let mut reset_tx = create_test_transaction(&relayer.id);
+        if let NetworkTransactionData::Stellar(ref mut data) = reset_tx.network_data {
+            data.sequence_number = None;
+        }
+        mocks
+            .tx_repo
+            .expect_find_by_status()
+            .withf(|relayer_id, statuses| {
+                relayer_id == "relayer-1"
+                    && statuses
+                        == [
+                            TransactionStatus::Pending,
+                            TransactionStatus::Sent,
+                            TransactionStatus::Submitted,
+                        ]
+            })
+            .times(1)
+            .returning(move |_, _| Ok(vec![reset_tx.clone()]));
+
+        // Empty drift region → CAS lowers 150 → 101.
+        mocks
+            .counter
+            .expect_set_if_equals()
+            .withf(|relayer_id, addr, expected, value| {
+                relayer_id == "relayer-1" && addr == TEST_PK && *expected == 150 && *value == 101
+            })
+            .times(1)
+            .returning(|_, _, _, _| Box::pin(async { Ok(true) }));
+
+        let handler = make_stellar_tx_handler(relayer.clone(), mocks);
+
+        let result = handler.sync_sequence_from_chain(&relayer.address).await;
+        assert!(result.is_ok());
+    }
+
+    /// Rewind (b): an active tx holding a sequence bounds the rewind to one past it.
+    #[tokio::test]
+    async fn test_sync_sequence_rewind_bounded_by_active_tx() {
+        let relayer = create_test_relayer();
+        let mut mocks = default_test_mocks();
+
+        mocks
+            .provider
+            .expect_get_account()
+            .times(1)
+            .returning(|_| Box::pin(async { Ok(test_account_entry(100)) }));
+
+        mocks
+            .counter
+            .expect_sync_floor()
+            .times(1)
+            .returning(|_, _, _| Box::pin(async { Ok(150) }));
+
+        // An active Submitted tx holds sequence 120; a reset tx (None) is skipped.
+        let mut active_tx = create_test_transaction(&relayer.id);
+        active_tx.status = TransactionStatus::Submitted;
+        if let NetworkTransactionData::Stellar(ref mut data) = active_tx.network_data {
+            data.sequence_number = Some(120);
+        }
+        let mut reset_tx = create_test_transaction(&relayer.id);
+        reset_tx.id = "tx-2".to_string();
+        if let NetworkTransactionData::Stellar(ref mut data) = reset_tx.network_data {
+            data.sequence_number = None;
+        }
+        mocks
+            .tx_repo
+            .expect_find_by_status()
+            .times(1)
+            .returning(move |_, _| Ok(vec![active_tx.clone(), reset_tx.clone()]));
+
+        // Highest active sequence 120 → target 121; CAS lowers 150 → 121.
+        mocks
+            .counter
+            .expect_set_if_equals()
+            .withf(|_, _, expected, value| *expected == 150 && *value == 121)
+            .times(1)
+            .returning(|_, _, _, _| Box::pin(async { Ok(true) }));
+
+        let handler = make_stellar_tx_handler(relayer.clone(), mocks);
+
+        let result = handler.sync_sequence_from_chain(&relayer.address).await;
+        assert!(result.is_ok());
+    }
+
+    /// Rewind (c): the CAS returns false (counter moved concurrently) — no error is surfaced.
+    #[tokio::test]
+    async fn test_sync_sequence_rewind_cas_miss_is_ok() {
+        let relayer = create_test_relayer();
+        let mut mocks = default_test_mocks();
+
+        mocks
+            .provider
+            .expect_get_account()
+            .times(1)
+            .returning(|_| Box::pin(async { Ok(test_account_entry(100)) }));
+
+        mocks
+            .counter
+            .expect_sync_floor()
+            .times(1)
+            .returning(|_, _, _| Box::pin(async { Ok(150) }));
+
+        mocks
+            .tx_repo
+            .expect_find_by_status()
+            .times(1)
+            .returning(|_, _| Ok(vec![]));
+
+        // Counter moved since observed; rewind is skipped without error.
+        mocks
+            .counter
+            .expect_set_if_equals()
+            .times(1)
+            .returning(|_, _, _, _| Box::pin(async { Ok(false) }));
+
+        let handler = make_stellar_tx_handler(relayer.clone(), mocks);
+
+        let result = handler.sync_sequence_from_chain(&relayer.address).await;
+        assert!(result.is_ok());
     }
 
     #[test]

--- a/src/domain/transaction/stellar/stellar_transaction.rs
+++ b/src/domain/transaction/stellar/stellar_transaction.rs
@@ -25,7 +25,7 @@ use crate::{
 };
 use async_trait::async_trait;
 use std::sync::Arc;
-use tracing::{debug, error, info, warn};
+use tracing::{error, info, warn};
 
 use super::lane_gate;
 
@@ -288,11 +288,19 @@ where
 
     /// Trims the burned head of the sequence counter down to on-chain reality.
     ///
-    /// Rewinds the counter from `observed` to `target`, where `target` is one past the
-    /// highest `sequence_number` held by any active (Pending/Sent/Submitted) transaction
-    /// of this relayer, or `next_usable_from_chain` if no active transaction holds one.
+    /// Rewinds the counter from `observed` to `target`, where `target` is the highest of:
+    /// - `next_usable_from_chain`,
+    /// - one past the highest `sequence_number` held by an active (Pending/Sent/Submitted)
+    ///   transaction of this relayer,
+    /// - one past the newest Confirmed transaction's sequence — a Confirmed record proves
+    ///   consumption even when the chain read comes from a lagging node, so this guards
+    ///   the rewind against a stale `next_usable_from_chain`.
+    ///
     /// Transactions reset via `reset_to_pre_prepare_state` have their `sequence_number`
     /// cleared, so they never bound the rewind and their burned sequences are reclaimed.
+    /// Failed records never bound it either: on Stellar a rejected submission consumes
+    /// nothing, and a landed-but-failed transaction under a stale chain read self-heals
+    /// in one TxBadSeq cycle.
     ///
     /// The nonce occupancy index is EVM-only, so occupancy is derived by reading the
     /// Stellar `sequence_number` from the active transaction records directly.
@@ -332,7 +340,36 @@ where
             .filter_map(|seq| u64::try_from(seq).ok())
             .max();
 
-        let target = match highest_active_seq {
+        // One newest-first page is enough for the Confirmed bound: for a single account,
+        // sequences strictly increase in confirmation order, so the newest Confirmed tx
+        // carries the highest consumed sequence. A full Confirmed scan would walk the
+        // relayer's entire history.
+        let newest_confirmed_seq = self
+            .transaction_repository()
+            .find_by_status_paginated(
+                &self.relayer().id,
+                &[TransactionStatus::Confirmed],
+                PaginationQuery {
+                    page: 1,
+                    per_page: 1,
+                },
+                false, // newest first
+            )
+            .await
+            .map_err(TransactionError::from)?
+            .items
+            .first()
+            .and_then(|tx| match &tx.network_data {
+                NetworkTransactionData::Stellar(data) => data.sequence_number,
+                _ => None,
+            })
+            .and_then(|seq| u64::try_from(seq).ok());
+
+        let target = match highest_active_seq
+            .into_iter()
+            .chain(newest_confirmed_seq)
+            .max()
+        {
             Some(seq) => std::cmp::max(next_usable_from_chain, seq + 1),
             None => next_usable_from_chain,
         };
@@ -358,8 +395,12 @@ where
                 "rewound sequence counter over burned region"
             );
         } else {
-            debug!(
+            // warn, not debug: repeated misses are the only visible signal that the
+            // rewind is being starved by concurrent counter movement.
+            warn!(
                 relayer_id = %self.relayer().id,
+                observed = observed,
+                target = target,
                 "counter moved concurrently; skipping rewind, next TxBadSeq recovery will retry"
             );
         }
@@ -895,6 +936,20 @@ mod tests {
             .times(1)
             .returning(move |_, _| Ok(vec![reset_tx.clone()]));
 
+        // No Confirmed txs to bound the rewind
+        mocks
+            .tx_repo
+            .expect_find_by_status_paginated()
+            .times(1)
+            .returning(|_, _, _, _| {
+                Ok(crate::repositories::PaginatedResult {
+                    items: vec![],
+                    total: 0,
+                    page: 1,
+                    per_page: 1,
+                })
+            });
+
         // Empty drift region → CAS lowers 150 → 101.
         mocks
             .counter
@@ -946,6 +1001,20 @@ mod tests {
             .times(1)
             .returning(move |_, _| Ok(vec![active_tx.clone(), reset_tx.clone()]));
 
+        // No Confirmed txs to bound the rewind
+        mocks
+            .tx_repo
+            .expect_find_by_status_paginated()
+            .times(1)
+            .returning(|_, _, _, _| {
+                Ok(crate::repositories::PaginatedResult {
+                    items: vec![],
+                    total: 0,
+                    page: 1,
+                    per_page: 1,
+                })
+            });
+
         // Highest active sequence 120 → target 121; CAS lowers 150 → 121.
         mocks
             .counter
@@ -992,6 +1061,20 @@ mod tests {
             .times(1)
             .returning(move |_, _| Ok(vec![active_tx.clone()]));
 
+        // No Confirmed txs to bound the rewind
+        mocks
+            .tx_repo
+            .expect_find_by_status_paginated()
+            .times(1)
+            .returning(|_, _, _, _| {
+                Ok(crate::repositories::PaginatedResult {
+                    items: vec![],
+                    total: 0,
+                    page: 1,
+                    per_page: 1,
+                })
+            });
+
         let handler = make_stellar_tx_handler(relayer.clone(), mocks);
 
         let result = handler.sync_sequence_from_chain(&relayer.address).await;
@@ -1029,11 +1112,92 @@ mod tests {
             .times(1)
             .returning(move |_, _| Ok(vec![active_tx.clone()]));
 
+        // No Confirmed txs to bound the rewind
+        mocks
+            .tx_repo
+            .expect_find_by_status_paginated()
+            .times(1)
+            .returning(|_, _, _, _| {
+                Ok(crate::repositories::PaginatedResult {
+                    items: vec![],
+                    total: 0,
+                    page: 1,
+                    per_page: 1,
+                })
+            });
+
         // target = max(101, 42 + 1) = 101; CAS lowers 150 → 101.
         mocks
             .counter
             .expect_set_if_equals()
             .withf(|_, _, expected, value| *expected == 150 && *value == 101)
+            .times(1)
+            .returning(|_, _, _, _| Box::pin(async { Ok(true) }));
+
+        let handler = make_stellar_tx_handler(relayer.clone(), mocks);
+
+        let result = handler.sync_sequence_from_chain(&relayer.address).await;
+        assert!(result.is_ok());
+    }
+
+    /// Rewind (f): the newest Confirmed tx bounds the rewind — a Confirmed record proves
+    /// consumption even when the chain read is stale, so the target never goes below it.
+    #[tokio::test]
+    async fn test_sync_sequence_rewind_bounded_by_newest_confirmed() {
+        let relayer = create_test_relayer();
+        let mut mocks = default_test_mocks();
+
+        // Stale chain read: seq 100 → next usable 101.
+        mocks
+            .provider
+            .expect_get_account()
+            .times(1)
+            .returning(|_| Box::pin(async { Ok(test_account_entry(100)) }));
+
+        mocks
+            .counter
+            .expect_sync_floor()
+            .times(1)
+            .returning(|_, _, _| Box::pin(async { Ok(150) }));
+
+        // No active tx holds a sequence.
+        mocks
+            .tx_repo
+            .expect_find_by_status()
+            .times(1)
+            .returning(|_, _| Ok(vec![]));
+
+        // The newest Confirmed tx consumed sequence 130 — one newest-first page.
+        let mut confirmed_tx = create_test_transaction(&relayer.id);
+        confirmed_tx.status = TransactionStatus::Confirmed;
+        if let NetworkTransactionData::Stellar(ref mut data) = confirmed_tx.network_data {
+            data.sequence_number = Some(130);
+        }
+        mocks
+            .tx_repo
+            .expect_find_by_status_paginated()
+            .withf(|relayer_id, statuses, query, oldest_first| {
+                relayer_id == "relayer-1"
+                    && statuses == [TransactionStatus::Confirmed]
+                    && query.page == 1
+                    && query.per_page == 1
+                    && !*oldest_first
+            })
+            .times(1)
+            .returning(move |_, _, _, _| {
+                Ok(crate::repositories::PaginatedResult {
+                    items: vec![confirmed_tx.clone()],
+                    total: 1,
+                    page: 1,
+                    per_page: 1,
+                })
+            });
+
+        // target = max(101, 130 + 1) = 131; CAS lowers 150 → 131.
+        mocks
+            .counter
+            .expect_set_if_equals()
+            .withf(|_, _, expected, value| *expected == 150 && *value == 131)
             .times(1)
             .returning(|_, _, _, _| Box::pin(async { Ok(true) }));
 
@@ -1066,6 +1230,20 @@ mod tests {
             .expect_find_by_status()
             .times(1)
             .returning(|_, _| Ok(vec![]));
+
+        // No Confirmed txs to bound the rewind
+        mocks
+            .tx_repo
+            .expect_find_by_status_paginated()
+            .times(1)
+            .returning(|_, _, _, _| {
+                Ok(crate::repositories::PaginatedResult {
+                    items: vec![],
+                    total: 0,
+                    page: 1,
+                    per_page: 1,
+                })
+            });
 
         // Counter moved since observed; rewind is skipped without error.
         mocks

--- a/src/domain/transaction/stellar/stellar_transaction.rs
+++ b/src/domain/transaction/stellar/stellar_transaction.rs
@@ -8,9 +8,9 @@ use crate::{
     domain::transaction::{stellar::fetch_next_sequence_from_chain, Transaction},
     jobs::{JobProducer, JobProducerTrait, StatusCheckContext, TransactionRequest},
     models::{
-        produce_transaction_update_notification_payload, NetworkTransactionRequest,
-        PaginationQuery, RelayerNetworkPolicy, RelayerRepoModel, TransactionError,
-        TransactionRepoModel, TransactionStatus, TransactionUpdateRequest,
+        produce_transaction_update_notification_payload, NetworkTransactionData,
+        NetworkTransactionRequest, PaginationQuery, RelayerNetworkPolicy, RelayerRepoModel,
+        TransactionError, TransactionRepoModel, TransactionStatus, TransactionUpdateRequest,
     },
     repositories::{
         RelayerRepositoryStorage, Repository, TransactionCounterRepositoryStorage,
@@ -325,8 +325,10 @@ where
 
         let highest_active_seq = active_txs
             .iter()
-            .filter_map(|tx| tx.network_data.get_stellar_transaction_data().ok())
-            .filter_map(|data| data.sequence_number)
+            .filter_map(|tx| match &tx.network_data {
+                NetworkTransactionData::Stellar(data) => data.sequence_number,
+                _ => None,
+            })
             .filter_map(|seq| u64::try_from(seq).ok())
             .max();
 

--- a/src/domain/transaction/stellar/submit.rs
+++ b/src/domain/transaction/stellar/submit.rs
@@ -1088,8 +1088,30 @@ mod tests {
                 .times(1)
                 .returning(|_, _, _| Box::pin(async { Ok(150) }));
 
-            // The failing tx was reset (sequence_number cleared) before the sync ran,
-            // so its record no longer bounds the rewind — target is the chain floor
+            // The reset must run BEFORE the occupancy scan: the reset clears this tx's
+            // burned sequence_number, so its record no longer bounds the rewind. The
+            // Sequence pins that ordering — reverting to sync-before-reset fails here.
+            let mut call_order = mockall::Sequence::new();
+
+            // Mock partial_update for reset_transaction_for_retry - should reset to Pending
+            mocks
+                .tx_repo
+                .expect_partial_update()
+                .withf(|_, upd| upd.status == Some(TransactionStatus::Pending))
+                .times(1)
+                .in_sequence(&mut call_order)
+                .returning(|id, upd| {
+                    let mut tx = create_test_transaction("relayer-1");
+                    tx.id = id;
+                    tx.status = upd.status.unwrap();
+                    if let Some(network_data) = upd.network_data {
+                        tx.network_data = network_data;
+                    }
+                    Ok::<_, RepositoryError>(tx)
+                });
+
+            // The scan then sees the reset tx (sequence_number cleared) — target is
+            // the chain floor
             let mut reset_tx = create_test_transaction(&relayer.id);
             reset_tx.status = TransactionStatus::Pending;
             if let NetworkTransactionData::Stellar(ref mut data) = reset_tx.network_data {
@@ -1099,6 +1121,7 @@ mod tests {
                 .tx_repo
                 .expect_find_by_status()
                 .times(1)
+                .in_sequence(&mut call_order)
                 .returning(move |_, _| Ok(vec![reset_tx.clone()]));
 
             // The drifted counter is rewound 150 → 101 via CAS
@@ -1113,22 +1136,6 @@ mod tests {
                 })
                 .times(1)
                 .returning(|_, _, _, _| Box::pin(async { Ok(true) }));
-
-            // Mock partial_update for reset_transaction_for_retry - should reset to Pending
-            mocks
-                .tx_repo
-                .expect_partial_update()
-                .withf(|_, upd| upd.status == Some(TransactionStatus::Pending))
-                .times(1)
-                .returning(|id, upd| {
-                    let mut tx = create_test_transaction("relayer-1");
-                    tx.id = id;
-                    tx.status = upd.status.unwrap();
-                    if let Some(network_data) = upd.network_data {
-                        tx.network_data = network_data;
-                    }
-                    Ok::<_, RepositoryError>(tx)
-                });
 
             let handler = make_stellar_tx_handler(relayer.clone(), mocks);
             let mut tx = create_test_transaction(&relayer.id);

--- a/src/domain/transaction/stellar/submit.rs
+++ b/src/domain/transaction/stellar/submit.rs
@@ -411,7 +411,20 @@ where
         }
 
         if is_bad_sequence_error(&error_reason) {
-            // For bad sequence errors, sync sequence from chain first
+            // Reset the transaction to pending state BEFORE syncing the counter: the
+            // reset clears this tx's (bad) sequence_number, so the drift rewind inside
+            // sync_sequence_from_chain is not bounded by the failing tx's own record —
+            // otherwise the tx would pin the counter one past its burned sequence and
+            // the drift would never heal.
+            // Status check will handle resubmission when it detects a pending transaction without hash
+            info!(
+                tx_id = %tx_id,
+                relayer_id = %relayer_id,
+                "bad sequence error detected, resetting transaction to pending state"
+            );
+            let reset_result = self.reset_transaction_for_retry(tx.clone()).await;
+
+            // Sync sequence from chain (best effort)
             if let Ok(stellar_data) = tx.network_data.get_stellar_transaction_data() {
                 info!(
                     tx_id = %tx_id,
@@ -440,14 +453,7 @@ where
                 }
             }
 
-            // Reset the transaction to pending state
-            // Status check will handle resubmission when it detects a pending transaction without hash
-            info!(
-                tx_id = %tx_id,
-                relayer_id = %relayer_id,
-                "bad sequence error detected, resetting transaction to pending state"
-            );
-            match self.reset_transaction_for_retry(tx.clone()).await {
+            match reset_result {
                 Ok(reset_tx) => {
                     info!(
                         tx_id = %tx_id,
@@ -1029,6 +1035,115 @@ mod tests {
             } else {
                 panic!("Expected Stellar transaction data");
             }
+        }
+
+        #[tokio::test]
+        async fn test_submit_bad_sequence_rewinds_drifted_counter() {
+            let relayer = create_test_relayer();
+            let mut mocks = default_test_mocks();
+
+            // Mock provider to return bad sequence error
+            mocks
+                .provider
+                .expect_send_transaction_with_status()
+                .returning(|_| {
+                    Box::pin(async {
+                        Err(ProviderError::Other(
+                            "transaction submission failed: TxBadSeq".to_string(),
+                        ))
+                    })
+                });
+
+            // Mock get_account for sync_sequence_from_chain: chain seq 100 → next usable 101
+            mocks.provider.expect_get_account().times(1).returning(|_| {
+                Box::pin(async {
+                    use soroban_rs::xdr::{
+                        AccountEntry, AccountEntryExt, AccountId, PublicKey, SequenceNumber,
+                        String32, Thresholds, Uint256,
+                    };
+                    use stellar_strkey::ed25519;
+
+                    let pk = ed25519::PublicKey::from_string(TEST_PK).unwrap();
+                    let account_id = AccountId(PublicKey::PublicKeyTypeEd25519(Uint256(pk.0)));
+
+                    Ok(AccountEntry {
+                        account_id,
+                        balance: 1000000,
+                        seq_num: SequenceNumber(100),
+                        num_sub_entries: 0,
+                        inflation_dest: None,
+                        flags: 0,
+                        home_domain: String32::default(),
+                        thresholds: Thresholds([1, 1, 1, 1]),
+                        signers: Default::default(),
+                        ext: AccountEntryExt::V0,
+                    })
+                })
+            });
+
+            // Counter drifted above the chain floor: sync_floor reports 150
+            mocks
+                .counter
+                .expect_sync_floor()
+                .times(1)
+                .returning(|_, _, _| Box::pin(async { Ok(150) }));
+
+            // The failing tx was reset (sequence_number cleared) before the sync ran,
+            // so its record no longer bounds the rewind — target is the chain floor
+            let mut reset_tx = create_test_transaction(&relayer.id);
+            reset_tx.status = TransactionStatus::Pending;
+            if let NetworkTransactionData::Stellar(ref mut data) = reset_tx.network_data {
+                data.sequence_number = None;
+            }
+            mocks
+                .tx_repo
+                .expect_find_by_status()
+                .times(1)
+                .returning(move |_, _| Ok(vec![reset_tx.clone()]));
+
+            // The drifted counter is rewound 150 → 101 via CAS
+            mocks
+                .counter
+                .expect_set_if_equals()
+                .withf(|relayer_id, addr, expected, value| {
+                    relayer_id == "relayer-1"
+                        && addr == TEST_PK
+                        && *expected == 150
+                        && *value == 101
+                })
+                .times(1)
+                .returning(|_, _, _, _| Box::pin(async { Ok(true) }));
+
+            // Mock partial_update for reset_transaction_for_retry - should reset to Pending
+            mocks
+                .tx_repo
+                .expect_partial_update()
+                .withf(|_, upd| upd.status == Some(TransactionStatus::Pending))
+                .times(1)
+                .returning(|id, upd| {
+                    let mut tx = create_test_transaction("relayer-1");
+                    tx.id = id;
+                    tx.status = upd.status.unwrap();
+                    if let Some(network_data) = upd.network_data {
+                        tx.network_data = network_data;
+                    }
+                    Ok::<_, RepositoryError>(tx)
+                });
+
+            let handler = make_stellar_tx_handler(relayer.clone(), mocks);
+            let mut tx = create_test_transaction(&relayer.id);
+            tx.status = TransactionStatus::Sent; // Must be Sent for idempotent submit
+            if let NetworkTransactionData::Stellar(ref mut data) = tx.network_data {
+                data.signatures.push(dummy_signature());
+                data.sequence_number = Some(42);
+                data.signed_envelope_xdr = Some(create_signed_xdr(TEST_PK, TEST_PK_2));
+            }
+
+            let result = handler.submit_transaction_impl(tx).await;
+
+            // The tx is reset for retry and the counter rewind was applied
+            assert!(result.is_ok());
+            assert_eq!(result.unwrap().status, TransactionStatus::Pending);
         }
 
         #[tokio::test]

--- a/src/domain/transaction/stellar/submit.rs
+++ b/src/domain/transaction/stellar/submit.rs
@@ -1154,6 +1154,125 @@ mod tests {
         }
 
         #[tokio::test]
+        async fn test_submit_bad_sequence_reset_failure_still_syncs_and_marks_failed() {
+            let relayer = create_test_relayer();
+            let mut mocks = default_test_mocks();
+
+            // Mock provider to return bad sequence error
+            mocks
+                .provider
+                .expect_send_transaction_with_status()
+                .returning(|_| {
+                    Box::pin(async {
+                        Err(ProviderError::Other(
+                            "transaction submission failed: TxBadSeq".to_string(),
+                        ))
+                    })
+                });
+
+            // Pin the flow: reset is attempted first, the chain sync still runs after
+            // the reset fails, and the tx then falls through to being marked Failed.
+            let mut call_order = mockall::Sequence::new();
+
+            // Reset attempt fails
+            mocks
+                .tx_repo
+                .expect_partial_update()
+                .withf(|_, upd| upd.status == Some(TransactionStatus::Pending))
+                .times(1)
+                .in_sequence(&mut call_order)
+                .returning(|_, _| Err(RepositoryError::Unknown("reset write failed".to_string())));
+
+            // Sync still runs (best effort): chain seq 100 → floor 101, no drift
+            mocks
+                .provider
+                .expect_get_account()
+                .times(1)
+                .in_sequence(&mut call_order)
+                .returning(|_| {
+                    Box::pin(async {
+                        use soroban_rs::xdr::{
+                            AccountEntry, AccountEntryExt, AccountId, PublicKey, SequenceNumber,
+                            String32, Thresholds, Uint256,
+                        };
+                        use stellar_strkey::ed25519;
+
+                        let pk = ed25519::PublicKey::from_string(TEST_PK).unwrap();
+                        let account_id = AccountId(PublicKey::PublicKeyTypeEd25519(Uint256(pk.0)));
+
+                        Ok(AccountEntry {
+                            account_id,
+                            balance: 1000000,
+                            seq_num: SequenceNumber(100),
+                            num_sub_entries: 0,
+                            inflation_dest: None,
+                            flags: 0,
+                            home_domain: String32::default(),
+                            thresholds: Thresholds([1, 1, 1, 1]),
+                            signers: Default::default(),
+                            ext: AccountEntryExt::V0,
+                        })
+                    })
+                });
+
+            mocks
+                .counter
+                .expect_sync_floor()
+                .times(1)
+                .returning(|_, _, floor| Box::pin(async move { Ok(floor) }));
+
+            // Fall-through marks the tx Failed
+            mocks
+                .tx_repo
+                .expect_partial_update()
+                .withf(|_, upd| upd.status == Some(TransactionStatus::Failed))
+                .times(1)
+                .in_sequence(&mut call_order)
+                .returning(|id, upd| {
+                    let mut tx = create_test_transaction("relayer-1");
+                    tx.id = id;
+                    tx.status = upd.status.unwrap();
+                    tx.status_reason = upd.status_reason;
+                    Ok::<_, RepositoryError>(tx)
+                });
+
+            // Notification for the failed transaction
+            mocks
+                .job_producer
+                .expect_produce_send_notification_job()
+                .times(1)
+                .returning(|_, _| Box::pin(async { Ok(()) }));
+
+            // No pending transactions to enqueue after the failure
+            mocks
+                .tx_repo
+                .expect_find_by_status_paginated()
+                .returning(|_, _, _, _| {
+                    Ok(PaginatedResult {
+                        items: vec![],
+                        total: 0,
+                        page: 1,
+                        per_page: 1,
+                    })
+                });
+
+            let handler = make_stellar_tx_handler(relayer.clone(), mocks);
+            let mut tx = create_test_transaction(&relayer.id);
+            tx.status = TransactionStatus::Sent; // Must be Sent for idempotent submit
+            if let NetworkTransactionData::Stellar(ref mut data) = tx.network_data {
+                data.signatures.push(dummy_signature());
+                data.sequence_number = Some(42);
+                data.signed_envelope_xdr = Some(create_signed_xdr(TEST_PK, TEST_PK_2));
+            }
+
+            let result = handler.submit_transaction_impl(tx).await;
+
+            // Marked as failed and returned Ok (no pointless queue retry)
+            assert!(result.is_ok());
+            assert_eq!(result.unwrap().status, TransactionStatus::Failed);
+        }
+
+        #[tokio::test]
         async fn submit_transaction_duplicate_status_succeeds() {
             let relayer = create_test_relayer();
             let mut mocks = default_test_mocks();

--- a/src/domain/transaction/stellar/submit.rs
+++ b/src/domain/transaction/stellar/submit.rs
@@ -1124,6 +1124,20 @@ mod tests {
                 .in_sequence(&mut call_order)
                 .returning(move |_, _| Ok(vec![reset_tx.clone()]));
 
+            // No Confirmed txs to bound the rewind
+            mocks
+                .tx_repo
+                .expect_find_by_status_paginated()
+                .times(1)
+                .returning(|_, _, _, _| {
+                    Ok(PaginatedResult {
+                        items: vec![],
+                        total: 0,
+                        page: 1,
+                        per_page: 1,
+                    })
+                });
+
             // The drifted counter is rewound 150 → 101 via CAS
             mocks
                 .counter

--- a/src/repositories/transaction/transaction_redis.rs
+++ b/src/repositories/transaction/transaction_redis.rs
@@ -530,6 +530,17 @@ impl RedisTransactionRepository {
         &self,
         ids: &[String],
     ) -> Result<BatchRetrievalResult<TransactionRepoModel>, RepositoryError> {
+        self.get_transactions_by_ids_on(self.connections.reader(), ids)
+            .await
+    }
+
+    /// Like [`Self::get_transactions_by_ids`], but reading through the given pool.
+    /// Recovery paths pass the primary pool for read-your-writes consistency.
+    async fn get_transactions_by_ids_on(
+        &self,
+        pool: &Arc<deadpool_redis::Pool>,
+        ids: &[String],
+    ) -> Result<BatchRetrievalResult<TransactionRepoModel>, RepositoryError> {
         if ids.is_empty() {
             debug!("no transaction IDs provided for batch fetch");
             return Ok(BatchRetrievalResult {
@@ -539,7 +550,7 @@ impl RedisTransactionRepository {
         }
 
         let mut conn = self
-            .get_connection(self.connections.reader(), "batch_fetch_transactions")
+            .get_connection(pool, "batch_fetch_transactions")
             .await?;
 
         let reverse_keys: Vec<String> = ids.iter().map(|id| self.tx_to_relayer_key(id)).collect();
@@ -1616,9 +1627,12 @@ impl TransactionRepository for RedisTransactionRepository {
             self.ensure_status_sorted_set(relayer_id, status).await?;
         }
 
-        // Now get a connection and collect all IDs
+        // Read through the primary: this feeds recovery paths (nonce/sequence counter
+        // rewinds) that must observe their own just-written resets and freshly persisted
+        // transactions — a lagging read replica could hide an active record and let the
+        // rewind reclaim a sequence that is still in flight.
         let mut conn = self
-            .get_connection(self.connections.reader(), "find_by_status")
+            .get_connection(self.connections.primary(), "find_by_status")
             .await?;
 
         let mut all_ids: Vec<String> = Vec::new();
@@ -1648,8 +1662,11 @@ impl TransactionRepository for RedisTransactionRepository {
         all_ids.sort();
         all_ids.dedup();
 
-        // Fetch all transactions and sort by created_at (newest first)
-        let mut transactions = self.get_transactions_by_ids(&all_ids).await?;
+        // Fetch all transactions and sort by created_at (newest first); bodies are read
+        // from the primary for the same consistency reason as the index scan above
+        let mut transactions = self
+            .get_transactions_by_ids_on(self.connections.primary(), &all_ids)
+            .await?;
 
         // Sort by created_at descending (newest first)
         transactions


### PR DESCRIPTION
# Summary

Stellar allocates sequences via `get_and_increment` during prepare, so a failure between the increment and the tx-record persist burns the sequence and leaves the Redis counter above the on-chain value. TxBadSeq recovery only called `sync_floor`, which raises but never lowers, so a drifted relayer re-prepared the transaction at ever-higher sequences and thrashed TxBadSeq forever. In the sequential lane this blocks the whole relayer account until the counter is reset manually.

`sync_sequence_from_chain` now also reconciles downward. When the counter sits above the chain's next usable sequence, it rewinds to max(chain floor, highest sequence held by an active Pending/Sent/Submitted tx plus one) using the `set_if_equals` CAS from #831. The nonce occupancy index is EVM-only, so active transactions are scanned via the status index and the Stellar `sequence_number` is read from their network data. Reset transactions have it cleared and never bound the rewind. If the counter moved concurrently the CAS is a no-op and the next TxBadSeq cycle retries. The scan reads through the Redis primary, matching the EVM `get_nonce_occupancy`, so it cannot miss an active record on a lagging replica and reclaim a sequence still in flight.

`handle_submit_failure` now resets the failing transaction before syncing. The reset clears its burned sequence number, so its own record cannot pin the rewind target. Without this the rewind never fires in the sequential lane, where the failing transaction always holds the top sequence.

Related to #818 (EVM counterpart, fixed in #831). Stacked on #831; base is `fix/818-evm-nonce-drift`.

## Testing Process

Unit tests mirror the EVM rewind suite: an empty drift region rewinds to the chain floor, an active transaction bounds the rewind, a CAS miss is a clean no-op, and the TxBadSeq recovery path applies the rewind after the reset (ordering pinned with a mockall Sequence). `cargo test --lib domain::transaction::stellar` passes 504 tests single-threaded; the parallel `lane_gate` flakes are pre-existing. The 81 Redis-gated `transaction_redis` tests pass against a local Redis container.

## Checklist

- [x] Add a reference to related issues in the PR description.
- [x] Add unit tests if applicable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Stellar transaction recovery when sequence numbers become out of sync, reducing failed or blocked submissions.
  * Failed submissions now reset transaction state before synchronizing account sequence data, improving retry behavior.
  * Recovery operations now use the most current transaction data to avoid inconsistencies caused by stale reads.
* **Tests**
  * Added coverage for sequence recovery, active transaction protection, concurrent updates, and failure-handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->