### PR TITLE
fix: Rebuild dead plugin socket listener and guard pipeline runtime drop

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -66,6 +66,34 @@ fn load_config_file(config_file_path: &str) -> Result<Config> {
     config::load_config(config_file_path).wrap_err("Failed to load config file")
 }
 
+/// Owns the pipeline runtime and shuts it down via `shutdown_background()` on drop.
+///
+/// `drop`ping a multi-thread `tokio::runtime::Runtime` blocks the current thread
+/// until all runtime threads exit, which panics when called from within an async
+/// context (`main` runs under `#[actix_web::main]`). Without this guard, any `?`
+/// early-return between runtime construction and shutdown (queue workers, HTTP
+/// bind, metrics bind) would hit that panic and mask the real startup error.
+/// `shutdown_background()` is non-blocking and safe to call from async code.
+struct PipelineRuntimeGuard(Option<tokio::runtime::Runtime>);
+
+impl PipelineRuntimeGuard {
+    fn handle(&self) -> tokio::runtime::Handle {
+        self.0
+            .as_ref()
+            .expect("runtime is only taken in Drop")
+            .handle()
+            .clone()
+    }
+}
+
+impl Drop for PipelineRuntimeGuard {
+    fn drop(&mut self) {
+        if let Some(runtime) = self.0.take() {
+            runtime.shutdown_background();
+        }
+    }
+}
+
 #[actix_web::main]
 async fn main() -> Result<()> {
     dotenv().ok();
@@ -106,13 +134,15 @@ async fn main() -> Result<()> {
     metrics::set_worker_threads("pipeline", runtime_config.tokio_worker_threads);
     metrics::set_worker_threads("http", runtime_config.actix_workers);
 
-    let pipeline_runtime = tokio::runtime::Builder::new_multi_thread()
-        .worker_threads(runtime_config.tokio_worker_threads)
-        .enable_all()
-        .thread_name("relayer-pipeline")
-        .build()
-        .wrap_err("Failed to build the pipeline runtime")?;
-    let pipeline_handle = pipeline_runtime.handle().clone();
+    let pipeline_runtime = PipelineRuntimeGuard(Some(
+        tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(runtime_config.tokio_worker_threads)
+            .enable_all()
+            .thread_name("relayer-pipeline")
+            .build()
+            .wrap_err("Failed to build the pipeline runtime")?,
+    ));
+    let pipeline_handle = pipeline_runtime.handle();
 
     // Re-home the plugin shared-socket service's background tasks onto the
     // pipeline runtime as well (the plugin-execution path behind the 504 storms).
@@ -275,12 +305,10 @@ async fn main() -> Result<()> {
     // warnings until the process is killed. No-op if no plugin ever started the socket.
     openzeppelin_relayer::services::plugins::shutdown_shared_socket_service().await;
 
-    // Shut down the pipeline runtime last. `shutdown_background()` (not `drop`) is
-    // required here: `drop`ping a multi-thread `tokio::runtime::Runtime` blocks the
-    // current thread until all runtime threads exit, which panics when called from
-    // within an async context (this function runs under `#[actix_web::main]`).
-    // `shutdown_background()` is non-blocking and safe to call from async code.
-    pipeline_runtime.shutdown_background();
+    // Shut down the pipeline runtime last. Dropping the guard calls
+    // `shutdown_background()` (see `PipelineRuntimeGuard`) — never the blocking
+    // `Runtime` drop, which would panic inside this async context.
+    drop(pipeline_runtime);
 
     Ok(())
 }

--- a/src/services/plugins/shared_socket.rs
+++ b/src/services/plugins/shared_socket.rs
@@ -431,7 +431,8 @@ impl SharedSocketService {
 
     /// Start the shared socket service
     /// This spawns a background task that listens for connections
-    /// Safe to call multiple times - will only start once per instance
+    /// Safe to call multiple times - idempotent while the listener is running;
+    /// a failed bind or abnormal listener exit resets state so a later call retries
     #[allow(clippy::type_complexity)]
     pub async fn start<J, RR, TR, NR, NFR, SR, TCR, PR, AKR>(
         self: Arc<Self>,

--- a/src/services/plugins/shared_socket.rs
+++ b/src/services/plugins/shared_socket.rs
@@ -458,8 +458,17 @@ impl SharedSocketService {
         }
 
         // Create the listener and move it into the task
-        let listener = UnixListener::bind(&self.socket_path)
-            .map_err(|e| PluginError::SocketError(format!("Failed to bind listener: {e}")))?;
+        let listener = match UnixListener::bind(&self.socket_path) {
+            Ok(listener) => listener,
+            Err(e) => {
+                // Undo the `started` swap above, otherwise every future start()
+                // becomes a no-op and plugin executions are bricked until restart.
+                self.started.store(false, Ordering::Release);
+                return Err(PluginError::SocketError(format!(
+                    "Failed to bind listener: {e}"
+                )));
+            }
+        };
         let executions = self.executions.clone();
         let relayer_api = Arc::new(RelayerApi);
         let socket_path = self.socket_path.clone();
@@ -471,7 +480,9 @@ impl SharedSocketService {
             socket_path
         );
 
-        // Spawn the listener task onto the pipeline runtime.
+        // Spawn the listener task onto the pipeline runtime. Weak so the task
+        // doesn't keep the service alive (its Drop sends the shutdown signal).
+        let service = Arc::downgrade(&self);
         spawn_on_pipeline(async move {
             debug!("Shared socket service: listener task started");
             // Bound consecutive accept() failures so a shutting-down runtime can never
@@ -560,6 +571,20 @@ impl SharedSocketService {
 
             // Cleanup on shutdown
             let _ = std::fs::remove_file(&socket_path);
+            // On a non-shutdown exit (e.g. persistent accept errors), reset the
+            // started flag — after the socket file is removed, so a concurrent
+            // start() can't race the bind against the stale file — allowing the
+            // listener to be rebuilt. Graceful shutdown leaves `started == true`
+            // so ensure_shared_socket_started() stays a no-op during teardown.
+            if !*shutdown_rx.borrow() {
+                if let Some(service) = service.upgrade() {
+                    service.started.store(false, Ordering::Release);
+                    warn!(
+                        "Shared socket service: listener stopped without shutdown signal; \
+                        it will be rebuilt on the next plugin execution"
+                    );
+                }
+            }
             info!("Shared socket service: listener stopped");
         });
 
@@ -1788,6 +1813,36 @@ mod tests {
 
         // Second start should also succeed (early return)
         service.clone().start(thin).await.unwrap();
+
+        service.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn test_bind_failure_resets_started_flag() {
+        let temp_dir = tempdir().unwrap();
+        let socket_path = temp_dir.path().join("shared_bind_fail.sock");
+
+        let service = Arc::new(SharedSocketService::new(socket_path.to_str().unwrap()).unwrap());
+        let state = create_mock_app_state(None, None, None, None, None, None).await;
+        let thin = Arc::new(web::ThinData(state));
+
+        // Occupy the socket path with a plain file so UnixListener::bind fails.
+        std::fs::write(&socket_path, b"occupied").unwrap();
+
+        let result = service.clone().start(thin.clone()).await;
+        assert!(result.is_err(), "start() should fail when bind fails");
+
+        // The failed start must have reset the started flag: after clearing the
+        // path, a second start() should bind successfully instead of no-op'ing
+        // on a stale flag (which would leave the service permanently dead).
+        std::fs::remove_file(&socket_path).unwrap();
+        service.clone().start(thin).await.unwrap();
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(
+            std::path::Path::new(socket_path.to_str().unwrap()).exists(),
+            "Listener should be bound after retry"
+        );
 
         service.shutdown().await;
     }


### PR DESCRIPTION
# Summary

Addresses items 3 and 4 of #824 (items 1, 2, and 5 were fixed in #831/#832).

**Shared plugin socket listener dies permanently after repeated accept errors.** The accept loop deliberately stops after 10 consecutive `accept()` failures (~200ms of failures, plausible under EMFILE during a plugin burst), but it left the `started` flag set. Since the service lives in a process-wide `OnceLock`, `ensure_shared_socket_started()` became a permanent no-op and every subsequent plugin execution failed until process restart. The listener task now resets the flag on non-shutdown exits — after the socket file is removed, so a concurrent `start()` can't race its bind against the stale file — and the listener is rebuilt on the next plugin execution. Graceful-shutdown exits leave the flag set so teardown stays a no-op. The same reset is applied to the latent sibling bug where a `UnixListener::bind` failure inside `start()` returned an error but left the flag set.

**Startup errors after pipeline-runtime construction panic on `Runtime` drop.** The pipeline runtime was only shut down via `shutdown_background()` on the happy path; any `?` early-return between its construction and shutdown (queue worker init, HTTP bind — port already in use is the routine ops case —, metrics bind) dropped the owned `Runtime` inside `#[actix_web::main]`, panicking with "Cannot drop a runtime in a context where blocking is not allowed" and masking the real error. A small guard struct now calls `shutdown_background()` on drop, covering every exit path. Happy-path shutdown ordering (worker drain → plugin pool → shared socket → runtime) is unchanged.

## Testing Process

- `cargo check` and `cargo test --lib services::plugins -- --test-threads=1` (the `script_executor`/`runner` TypeScript-execution tests fail identically on unmodified `main` in this environment and are unrelated).
- New test `test_bind_failure_resets_started_flag`: pre-creates the socket path as a plain file so `bind` fails, asserts `start()` errors, then asserts a second `start()` succeeds after clearing the path — proving the flag was reset. A deterministic test for the accept-error path is not practical (it would require injecting 10 consecutive `accept()` failures into a bound listener), so that path is covered by the same flag-reset logic exercised here plus the existing shutdown tests verifying graceful exits keep the flag set.
- The runtime guard in `main.rs` has no unit-testable surface; verification is compile-level plus the existing `main` tests.

## Checklist

- [x] Add a reference to related issues in the PR description.
- [x] Add unit tests if applicable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved background pipeline shutdown to prevent runtime-related crashes during application shutdown.
  * Fixed socket services becoming unavailable after a failed startup attempt.
  * Socket listeners now recover and can be started successfully after bind failures.

* **Tests**
  * Added coverage to verify socket service recovery after a failed bind.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->