### PR TITLE
fix(evm): Prevent nonce double-send from pending-recovery re-prepare

### DIFF
--- a/src/domain/transaction/evm/evm_transaction.rs
+++ b/src/domain/transaction/evm/evm_transaction.rs
@@ -269,25 +269,19 @@ where
         self.schedule_status_check(tx, None, Some(metadata)).await
     }
 
-    /// Schedules a targeted nonce health job for this transaction's relayer.
-    ///
-    /// Called when "nonce too high" retries are exhausted, indicating a persistent
-    /// counter drift rather than transient burst ordering. The health job will
-    /// detect and fill nonce gaps with NOOPs.
-    pub(super) async fn schedule_relayer_nonce_health_job(
+    /// Schedules a nonce health job for `relayer_id`. The optional nonce hint
+    /// lets resolve_nonce_gaps extend its scan range even if the counter was
+    /// reset below that nonce.
+    pub(super) async fn schedule_nonce_health_job(
         &self,
-        tx: &TransactionRepoModel,
+        relayer_id: &str,
+        nonce_hint: Option<u64>,
     ) -> Result<(), TransactionError> {
-        // Include the tx nonce as a hint so resolve_nonce_gaps can extend
-        // its scan range even if the counter was reset below this nonce.
-        let nonce_hint = tx
-            .network_data
-            .get_evm_transaction_data()
-            .ok()
-            .and_then(|d| d.nonce);
         let job = match nonce_hint {
-            Some(nonce) => RelayerHealthCheck::nonce_health_with_hint(tx.relayer_id.clone(), nonce),
-            None => RelayerHealthCheck::nonce_health(tx.relayer_id.clone()),
+            Some(nonce) => {
+                RelayerHealthCheck::nonce_health_with_hint(relayer_id.to_string(), nonce)
+            }
+            None => RelayerHealthCheck::nonce_health(relayer_id.to_string()),
         };
 
         self.job_producer()
@@ -298,6 +292,46 @@ where
                     "Failed to schedule nonce health check: {e}"
                 ))
             })
+    }
+
+    /// Schedules a targeted nonce health job for this transaction's relayer,
+    /// hinting with the transaction's own nonce.
+    ///
+    /// Called when "nonce too high" retries are exhausted, indicating a persistent
+    /// counter drift rather than transient burst ordering. The health job will
+    /// detect and fill nonce gaps with NOOPs.
+    pub(super) async fn schedule_relayer_nonce_health_job(
+        &self,
+        tx: &TransactionRepoModel,
+    ) -> Result<(), TransactionError> {
+        self.schedule_nonce_health_job(&tx.relayer_id, tx.network_data.evm_nonce())
+            .await
+    }
+
+    /// Best-effort gap fill when a transaction that may hold a consumed nonce
+    /// is marked Failed: if a nonce is assigned, schedule a nonce health job
+    /// so the abandoned slot is filled promptly; scheduling failures are
+    /// logged, never propagated.
+    pub(super) async fn schedule_nonce_health_if_assigned(
+        &self,
+        tx: &TransactionRepoModel,
+        context: &str,
+    ) {
+        if let Some(nonce) = tx.network_data.evm_nonce() {
+            if let Err(e) = self
+                .schedule_nonce_health_job(&tx.relayer_id, Some(nonce))
+                .await
+            {
+                warn!(
+                    tx_id = %tx.id,
+                    relayer_id = %tx.relayer_id,
+                    nonce,
+                    context,
+                    error = %e,
+                    "failed to schedule nonce health after Pending transaction failure"
+                );
+            }
+        }
     }
 
     /// Handles a "nonce too high" error by incrementing the retry counter and
@@ -785,9 +819,45 @@ where
                 ..Default::default()
             };
 
-            self.transaction_repository
-                .partial_update(tx.id.clone(), presign_update)
-                .await?
+            let (claimed_tx, applied) = self
+                .transaction_repository
+                .partial_update_if_evm_nonce_unset(tx.id.clone(), presign_update)
+                .await?;
+
+            if !applied {
+                warn!(
+                    tx_id = %claimed_tx.id,
+                    relayer_id = %claimed_tx.relayer_id,
+                    allocated_nonce = new_nonce,
+                    claimed_nonce = ?claimed_tx.network_data.evm_nonce(),
+                    "transaction nonce claim lost to concurrent prepare"
+                );
+
+                // Hint with the leaked (allocated) nonce, not the claimed one:
+                // the gap sits at the allocated value, and the health scan's
+                // upper bound is exclusive at hint + 1.
+                if let Err(e) = self
+                    .schedule_nonce_health_job(&claimed_tx.relayer_id, Some(new_nonce))
+                    .await
+                {
+                    warn!(
+                        tx_id = %claimed_tx.id,
+                        error = %e,
+                        "failed to schedule nonce health after nonce claim race"
+                    );
+                }
+
+                if claimed_tx.status != TransactionStatus::Pending {
+                    warn!(
+                        tx_id = %claimed_tx.id,
+                        status = ?claimed_tx.status,
+                        "transaction left Pending state during nonce claim, skipping signing"
+                    );
+                    return Ok(claimed_tx);
+                }
+            }
+
+            claimed_tx
         };
 
         // Apply price params for signing (recalculated on every attempt)
@@ -1569,6 +1639,31 @@ mod tests {
         }
     }
 
+    /// Wires the presign (claim) and postsign partial-update mocks for the
+    /// happy path: both apply the patch to a clone of `tx` and succeed.
+    fn expect_presign_and_postsign_updates(
+        mock: &mut MockTransactionRepository,
+        tx: &TransactionRepoModel,
+    ) {
+        let tx_clone = tx.clone();
+        mock.expect_partial_update_if_evm_nonce_unset()
+            .times(1)
+            .returning(move |_, update| {
+                let mut updated_tx = tx_clone.clone();
+                updated_tx.apply_partial_update(update);
+                Ok((updated_tx, true))
+            });
+
+        let tx_clone = tx.clone();
+        mock.expect_partial_update()
+            .times(1)
+            .returning(move |_, update| {
+                let mut updated_tx = tx_clone.clone();
+                updated_tx.apply_partial_update(update);
+                Ok(updated_tx)
+            });
+    }
+
     #[tokio::test]
     async fn test_prepare_transaction_with_sufficient_balance() {
         let mut mock_transaction = MockTransactionRepository::new();
@@ -1598,22 +1693,29 @@ mod tests {
             .expect_get_transaction_price_params()
             .returning(move |_, _| Ok(price_params.clone()));
 
-        mock_signer.expect_sign_transaction().returning(|_| {
-            Box::pin(ready(Ok(
-                crate::domain::relayer::SignTransactionResponse::Evm(
-                    crate::domain::relayer::SignTransactionResponseEvm {
-                        hash: "0xtx_hash".to_string(),
-                        signature: crate::models::EvmTransactionDataSignature {
-                            r: "r".to_string(),
-                            s: "s".to_string(),
-                            v: 1,
-                            sig: "0xsignature".to_string(),
+        mock_signer
+            .expect_sign_transaction()
+            .withf(|network_data| {
+                network_data
+                    .get_evm_transaction_data()
+                    .is_ok_and(|data| data.nonce == Some(42))
+            })
+            .returning(|_| {
+                Box::pin(ready(Ok(
+                    crate::domain::relayer::SignTransactionResponse::Evm(
+                        crate::domain::relayer::SignTransactionResponseEvm {
+                            hash: "0xtx_hash".to_string(),
+                            signature: crate::models::EvmTransactionDataSignature {
+                                r: "r".to_string(),
+                                s: "s".to_string(),
+                                v: 1,
+                                sig: "0xsignature".to_string(),
+                            },
+                            raw: vec![1, 2, 3],
                         },
-                        raw: vec![1, 2, 3],
-                    },
-                ),
-            )))
-        });
+                    ),
+                )))
+            });
 
         mock_provider
             .expect_get_balance()
@@ -1634,22 +1736,7 @@ mod tests {
                 })
             });
 
-        let test_tx_clone = test_tx.clone();
-        mock_transaction
-            .expect_partial_update()
-            .returning(move |_, update| {
-                let mut updated_tx = test_tx_clone.clone();
-                if let Some(status) = &update.status {
-                    updated_tx.status = status.clone();
-                }
-                if let Some(network_data) = &update.network_data {
-                    updated_tx.network_data = network_data.clone();
-                }
-                if let Some(hashes) = &update.hashes {
-                    updated_tx.hashes = hashes.clone();
-                }
-                Ok(updated_tx)
-            });
+        expect_presign_and_postsign_updates(&mut mock_transaction, &test_tx);
 
         mock_job_producer
             .expect_produce_submit_transaction_job()
@@ -1657,6 +1744,9 @@ mod tests {
         mock_job_producer
             .expect_produce_send_notification_job()
             .returning(|_, _| Box::pin(ready(Ok(()))));
+        mock_job_producer
+            .expect_produce_relayer_health_check_job()
+            .never();
 
         let mock_network = MockNetworkRepository::new();
 
@@ -1677,6 +1767,346 @@ mod tests {
         let prepared_tx = result.unwrap();
         assert_eq!(prepared_tx.status, TransactionStatus::Sent);
         assert!(!prepared_tx.hashes.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_prepare_transaction_uses_claimed_nonce_after_losing_claim() {
+        let mut mock_transaction = MockTransactionRepository::new();
+        let mock_relayer = MockRelayerRepository::new();
+        let mut mock_provider = MockEvmProviderTrait::new();
+        let mut mock_signer = MockSigner::new();
+        let mut mock_job_producer = MockJobProducerTrait::new();
+        let mut mock_price_calculator = MockPriceCalculator::new();
+        let mut counter_service = MockTransactionCounterTrait::new();
+        let relayer = create_test_relayer();
+        let test_tx = create_test_transaction();
+
+        counter_service
+            .expect_get_and_increment()
+            .times(1)
+            .returning(|_, _| Box::pin(ready(Ok(43))));
+
+        let price_params = PriceParams {
+            gas_price: Some(30_000_000_000),
+            max_fee_per_gas: None,
+            max_priority_fee_per_gas: None,
+            is_min_bumped: None,
+            extra_fee: None,
+            total_cost: U256::from(630_000_000_000_000u64),
+        };
+        mock_price_calculator
+            .expect_get_transaction_price_params()
+            .returning(move |_, _| Ok(price_params.clone()));
+
+        mock_provider
+            .expect_get_balance()
+            .with(eq("0xSender"))
+            .returning(|_| Box::pin(ready(Ok(U256::from(1_000_000_000_000_000_000u64)))));
+        mock_provider
+            .expect_get_block_by_number()
+            .times(1)
+            .returning(|| {
+                Box::pin(async {
+                    use alloy::{network::AnyRpcBlock, rpc::types::Block};
+                    let mut block: Block = Block::default();
+                    block.header.gas_limit = 30_000_000;
+                    Ok(AnyRpcBlock::from(block))
+                })
+            });
+
+        mock_signer
+            .expect_sign_transaction()
+            .withf(|network_data| {
+                network_data
+                    .get_evm_transaction_data()
+                    .is_ok_and(|data| data.nonce == Some(42))
+            })
+            .times(1)
+            .returning(|_| {
+                Box::pin(ready(Ok(
+                    crate::domain::relayer::SignTransactionResponse::Evm(
+                        crate::domain::relayer::SignTransactionResponseEvm {
+                            hash: "0xtx_hash".to_string(),
+                            signature: crate::models::EvmTransactionDataSignature {
+                                r: "r".to_string(),
+                                s: "s".to_string(),
+                                v: 1,
+                                sig: "0xsignature".to_string(),
+                            },
+                            raw: vec![1, 2, 3],
+                        },
+                    ),
+                )))
+            });
+
+        let mut claimed_tx = test_tx.clone();
+        let NetworkTransactionData::Evm(ref mut evm_data) = claimed_tx.network_data else {
+            panic!("Expected EVM transaction data");
+        };
+        evm_data.nonce = Some(42);
+        mock_transaction
+            .expect_partial_update_if_evm_nonce_unset()
+            .times(1)
+            .return_once(move |_, _| Ok((claimed_tx, false)));
+
+        let test_tx_clone = test_tx.clone();
+        mock_transaction
+            .expect_partial_update()
+            .times(1)
+            .returning(move |_, update| {
+                let mut updated_tx = test_tx_clone.clone();
+                updated_tx.apply_partial_update(update);
+                Ok(updated_tx)
+            });
+
+        mock_job_producer
+            .expect_produce_relayer_health_check_job()
+            .withf(|job, scheduled_on| {
+                scheduled_on.is_none()
+                    && job.relayer_id == "test-relayer-id"
+                    && job.metadata.as_ref().is_some_and(|metadata| {
+                        metadata.get("health_check_action") == Some(&"nonce_health".to_string())
+                            && metadata.get("nonce_hint") == Some(&"43".to_string())
+                    })
+            })
+            .times(1)
+            .returning(|_, _| Box::pin(ready(Ok(()))));
+        mock_job_producer
+            .expect_produce_submit_transaction_job()
+            .times(1)
+            .returning(|_, _| Box::pin(ready(Ok(()))));
+        mock_job_producer
+            .expect_produce_send_notification_job()
+            .returning(|_, _| Box::pin(ready(Ok(()))));
+
+        let evm_transaction = EvmRelayerTransaction {
+            relayer,
+            provider: mock_provider,
+            relayer_repository: Arc::new(mock_relayer),
+            network_repository: Arc::new(MockNetworkRepository::new()),
+            transaction_repository: Arc::new(mock_transaction),
+            transaction_counter_service: Arc::new(counter_service),
+            job_producer: Arc::new(mock_job_producer),
+            price_calculator: mock_price_calculator,
+            signer: mock_signer,
+        };
+
+        let prepared_tx = evm_transaction.prepare_transaction(test_tx).await.unwrap();
+
+        assert_eq!(
+            prepared_tx
+                .network_data
+                .get_evm_transaction_data()
+                .unwrap()
+                .nonce,
+            Some(42)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_prepare_transaction_preset_nonce_skips_counter_and_claim() {
+        let mut mock_transaction = MockTransactionRepository::new();
+        let mock_relayer = MockRelayerRepository::new();
+        let mut mock_provider = MockEvmProviderTrait::new();
+        let mut mock_signer = MockSigner::new();
+        let mut mock_job_producer = MockJobProducerTrait::new();
+        let mut mock_price_calculator = MockPriceCalculator::new();
+        let mut counter_service = MockTransactionCounterTrait::new();
+        let relayer = create_test_relayer();
+        let mut test_tx = create_test_transaction();
+        let NetworkTransactionData::Evm(ref mut evm_data) = test_tx.network_data else {
+            panic!("Expected EVM transaction data");
+        };
+        evm_data.nonce = Some(7);
+
+        // Preset nonce (gap-filling NOOPs, signing retries) must be reused:
+        // no counter consumption, no claim attempt.
+        counter_service.expect_get_and_increment().never();
+        mock_transaction
+            .expect_partial_update_if_evm_nonce_unset()
+            .never();
+
+        let price_params = PriceParams {
+            gas_price: Some(30_000_000_000),
+            max_fee_per_gas: None,
+            max_priority_fee_per_gas: None,
+            is_min_bumped: None,
+            extra_fee: None,
+            total_cost: U256::from(630_000_000_000_000u64),
+        };
+        mock_price_calculator
+            .expect_get_transaction_price_params()
+            .returning(move |_, _| Ok(price_params.clone()));
+
+        mock_provider
+            .expect_get_balance()
+            .with(eq("0xSender"))
+            .returning(|_| Box::pin(ready(Ok(U256::from(1_000_000_000_000_000_000u64)))));
+        mock_provider
+            .expect_get_block_by_number()
+            .times(1)
+            .returning(|| {
+                Box::pin(async {
+                    use alloy::{network::AnyRpcBlock, rpc::types::Block};
+                    let mut block: Block = Block::default();
+                    block.header.gas_limit = 30_000_000;
+                    Ok(AnyRpcBlock::from(block))
+                })
+            });
+
+        mock_signer
+            .expect_sign_transaction()
+            .withf(|network_data| {
+                network_data
+                    .get_evm_transaction_data()
+                    .is_ok_and(|data| data.nonce == Some(7))
+            })
+            .times(1)
+            .returning(|_| {
+                Box::pin(ready(Ok(
+                    crate::domain::relayer::SignTransactionResponse::Evm(
+                        crate::domain::relayer::SignTransactionResponseEvm {
+                            hash: "0xtx_hash".to_string(),
+                            signature: crate::models::EvmTransactionDataSignature {
+                                r: "r".to_string(),
+                                s: "s".to_string(),
+                                v: 1,
+                                sig: "0xsignature".to_string(),
+                            },
+                            raw: vec![1, 2, 3],
+                        },
+                    ),
+                )))
+            });
+
+        let test_tx_clone = test_tx.clone();
+        mock_transaction
+            .expect_partial_update()
+            .times(1)
+            .returning(move |_, update| {
+                let mut updated_tx = test_tx_clone.clone();
+                updated_tx.apply_partial_update(update);
+                Ok(updated_tx)
+            });
+
+        mock_job_producer
+            .expect_produce_relayer_health_check_job()
+            .never();
+        mock_job_producer
+            .expect_produce_submit_transaction_job()
+            .times(1)
+            .returning(|_, _| Box::pin(ready(Ok(()))));
+        mock_job_producer
+            .expect_produce_send_notification_job()
+            .returning(|_, _| Box::pin(ready(Ok(()))));
+
+        let evm_transaction = EvmRelayerTransaction {
+            relayer,
+            provider: mock_provider,
+            relayer_repository: Arc::new(mock_relayer),
+            network_repository: Arc::new(MockNetworkRepository::new()),
+            transaction_repository: Arc::new(mock_transaction),
+            transaction_counter_service: Arc::new(counter_service),
+            job_producer: Arc::new(mock_job_producer),
+            price_calculator: mock_price_calculator,
+            signer: mock_signer,
+        };
+
+        let prepared_tx = evm_transaction.prepare_transaction(test_tx).await.unwrap();
+
+        assert_eq!(
+            prepared_tx
+                .network_data
+                .get_evm_transaction_data()
+                .unwrap()
+                .nonce,
+            Some(7)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_prepare_transaction_lost_claim_to_finalized_tx_skips_signing() {
+        let mut mock_transaction = MockTransactionRepository::new();
+        let mock_relayer = MockRelayerRepository::new();
+        let mut mock_provider = MockEvmProviderTrait::new();
+        let mut mock_signer = MockSigner::new();
+        let mut mock_job_producer = MockJobProducerTrait::new();
+        let mut mock_price_calculator = MockPriceCalculator::new();
+        let mut counter_service = MockTransactionCounterTrait::new();
+        let relayer = create_test_relayer();
+        let test_tx = create_test_transaction();
+
+        counter_service
+            .expect_get_and_increment()
+            .times(1)
+            .returning(|_, _| Box::pin(ready(Ok(43))));
+
+        let price_params = PriceParams {
+            gas_price: Some(30_000_000_000),
+            max_fee_per_gas: None,
+            max_priority_fee_per_gas: None,
+            is_min_bumped: None,
+            extra_fee: None,
+            total_cost: U256::from(630_000_000_000_000u64),
+        };
+        mock_price_calculator
+            .expect_get_transaction_price_params()
+            .returning(move |_, _| Ok(price_params.clone()));
+
+        mock_provider
+            .expect_get_balance()
+            .with(eq("0xSender"))
+            .returning(|_| Box::pin(ready(Ok(U256::from(1_000_000_000_000_000_000u64)))));
+        mock_provider
+            .expect_get_block_by_number()
+            .times(1)
+            .returning(|| {
+                Box::pin(async {
+                    use alloy::{network::AnyRpcBlock, rpc::types::Block};
+                    let mut block: Block = Block::default();
+                    block.header.gas_limit = 30_000_000;
+                    Ok(AnyRpcBlock::from(block))
+                })
+            });
+
+        // The record finalized while this prepare was in flight: the claim is
+        // rejected and the returned record is no longer Pending.
+        let mut claimed_tx = test_tx.clone();
+        claimed_tx.status = TransactionStatus::Confirmed;
+        let NetworkTransactionData::Evm(ref mut evm_data) = claimed_tx.network_data else {
+            panic!("Expected EVM transaction data");
+        };
+        evm_data.nonce = Some(42);
+        mock_transaction
+            .expect_partial_update_if_evm_nonce_unset()
+            .times(1)
+            .return_once(move |_, _| Ok((claimed_tx, false)));
+
+        // No signing, no postsign write, no submit job.
+        mock_signer.expect_sign_transaction().never();
+        mock_transaction.expect_partial_update().never();
+        mock_job_producer
+            .expect_produce_submit_transaction_job()
+            .never();
+        mock_job_producer
+            .expect_produce_relayer_health_check_job()
+            .times(1)
+            .returning(|_, _| Box::pin(ready(Ok(()))));
+
+        let evm_transaction = EvmRelayerTransaction {
+            relayer,
+            provider: mock_provider,
+            relayer_repository: Arc::new(mock_relayer),
+            network_repository: Arc::new(MockNetworkRepository::new()),
+            transaction_repository: Arc::new(mock_transaction),
+            transaction_counter_service: Arc::new(counter_service),
+            job_producer: Arc::new(mock_job_producer),
+            price_calculator: mock_price_calculator,
+            signer: mock_signer,
+        };
+
+        let result = evm_transaction.prepare_transaction(test_tx).await.unwrap();
+        assert_eq!(result.status, TransactionStatus::Confirmed);
     }
 
     #[tokio::test]
@@ -1999,22 +2429,7 @@ mod tests {
                 })
             });
 
-        let test_tx_clone = test_tx.clone();
-        mock_transaction
-            .expect_partial_update()
-            .returning(move |_, update| {
-                let mut updated_tx = test_tx_clone.clone();
-                if let Some(status) = &update.status {
-                    updated_tx.status = status.clone();
-                }
-                if let Some(network_data) = &update.network_data {
-                    updated_tx.network_data = network_data.clone();
-                }
-                if let Some(hashes) = &update.hashes {
-                    updated_tx.hashes = hashes.clone();
-                }
-                Ok(updated_tx)
-            });
+        expect_presign_and_postsign_updates(&mut mock_transaction, &test_tx);
 
         mock_job_producer
             .expect_produce_submit_transaction_job()
@@ -2851,39 +3266,7 @@ mod tests {
             .expect_produce_send_notification_job()
             .returning(|_, _| Box::pin(ready(Ok(()))));
 
-        // Mock transaction repository partial_update calls
-        // Note: prepare_transaction calls partial_update twice:
-        // 1. Presign update (saves nonce before signing)
-        // 2. Postsign update (saves signed data and marks as Sent)
-        let expected_gas_limit = EXPECTED_GAS_WITH_BUFFER;
-
-        let test_tx_clone = test_tx.clone();
-        mock_transaction
-            .expect_partial_update()
-            .times(2)
-            .returning(move |_, update| {
-                let mut updated_tx = test_tx_clone.clone();
-
-                // Apply the updates from the request
-                if let Some(status) = &update.status {
-                    updated_tx.status = status.clone();
-                }
-                if let Some(network_data) = &update.network_data {
-                    updated_tx.network_data = network_data.clone();
-                } else {
-                    // If network_data is not being updated, ensure gas_limit is set
-                    if let NetworkTransactionData::Evm(ref mut evm_data) = updated_tx.network_data {
-                        if evm_data.gas_limit.is_none() {
-                            evm_data.gas_limit = Some(expected_gas_limit);
-                        }
-                    }
-                }
-                if let Some(hashes) = &update.hashes {
-                    updated_tx.hashes = hashes.clone();
-                }
-
-                Ok(updated_tx)
-            });
+        expect_presign_and_postsign_updates(&mut mock_transaction, &test_tx);
 
         let transaction = EvmRelayerTransaction::new(
             relayer.clone(),
@@ -2995,32 +3378,7 @@ mod tests {
             .expect_produce_send_notification_job()
             .returning(|_, _| Box::pin(ready(Ok(()))));
 
-        let expected_gas_limit = EXPECTED_GAS_WITH_BUFFER;
-        let test_tx_clone = test_tx.clone();
-        mock_transaction
-            .expect_partial_update()
-            .times(2)
-            .returning(move |_, update| {
-                let mut updated_tx = test_tx_clone.clone();
-
-                if let Some(status) = &update.status {
-                    updated_tx.status = status.clone();
-                }
-                if let Some(network_data) = &update.network_data {
-                    updated_tx.network_data = network_data.clone();
-                } else if let NetworkTransactionData::Evm(ref mut evm_data) =
-                    updated_tx.network_data
-                {
-                    if evm_data.gas_limit.is_none() {
-                        evm_data.gas_limit = Some(expected_gas_limit);
-                    }
-                }
-                if let Some(hashes) = &update.hashes {
-                    updated_tx.hashes = hashes.clone();
-                }
-
-                Ok(updated_tx)
-            });
+        expect_presign_and_postsign_updates(&mut mock_transaction, &test_tx);
 
         let transaction = EvmRelayerTransaction::new(
             relayer,

--- a/src/domain/transaction/evm/evm_transaction.rs
+++ b/src/domain/transaction/evm/evm_transaction.rs
@@ -328,7 +328,7 @@ where
                     nonce,
                     context,
                     error = %e,
-                    "failed to schedule nonce health after Pending transaction failure"
+                    "failed to schedule nonce health job"
                 );
             }
         }

--- a/src/domain/transaction/evm/status.rs
+++ b/src/domain/transaction/evm/status.rs
@@ -709,13 +709,14 @@ where
     ) -> Result<TransactionRepoModel, TransactionError> {
         let (should_noop, reason) = self.should_noop(&tx).await?;
         if should_noop {
-            // For Pending state transactions, nonces are not yet assigned, so we mark as Failed
-            // instead of NOOP. This matches prepare_transaction behavior.
+            // A Pending transaction can hold a nonce after the presign update. Mark it as Failed,
+            // then schedule gap fill when a nonce was assigned.
             debug!(
                 tx_id = %tx.id,
                 relayer_id = %tx.relayer_id,
+                nonce = ?tx.network_data.evm_nonce(),
                 reason = %reason.as_ref().unwrap_or(&"unknown".to_string()),
-                "marking pending transaction as Failed (nonce not assigned, no NOOP needed)"
+                "marking pending transaction as Failed"
             );
             let update = TransactionUpdateRequest {
                 status: Some(TransactionStatus::Failed),
@@ -726,6 +727,9 @@ where
                 .transaction_repository()
                 .partial_update(tx.id.clone(), update)
                 .await?;
+
+            self.schedule_nonce_health_if_assigned(&updated_tx, "pending timeout")
+                .await;
 
             let res = self.send_transaction_update_notification(&updated_tx).await;
             if let Err(e) = res {
@@ -981,13 +985,20 @@ where
 
         match tx.status {
             TransactionStatus::Pending => {
-                // Pending: no nonce assigned yet - safe to mark as Failed
+                // Pending can hold a presigned nonce. Mark it as Failed, then schedule gap fill
+                // when a nonce was assigned.
                 debug!(
                     tx_id = %tx.id,
                     relayer_id = %tx.relayer_id,
-                    "circuit breaker: Pending transaction (no nonce) - safe to mark as Failed"
+                    nonce = ?tx.network_data.evm_nonce(),
+                    "circuit breaker: marking Pending transaction as Failed"
                 );
-                self.mark_as_failed(tx, reason).await
+                let updated_tx = self.mark_as_failed(tx, reason).await?;
+
+                self.schedule_nonce_health_if_assigned(&updated_tx, "circuit breaker")
+                    .await;
+
+                Ok(updated_tx)
             }
             TransactionStatus::Sent => {
                 // Sent: nonce assigned but never broadcast to network.
@@ -3233,7 +3244,7 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn test_pending_state_with_noop() {
+        async fn test_pending_state_timeout_without_nonce_marks_failed_without_health_job() {
             // Create a pending transaction that is old (created 2 minutes ago)
             let mut mocks = default_test_mocks();
             let relayer = create_test_relayer();
@@ -3257,7 +3268,7 @@ mod tests {
             });
 
             // Expect partial_update to be called and simulate a Failed update
-            // (Pending state transactions are marked as Failed, not NOOP, since nonces aren't assigned)
+            // (Pending state transactions are marked as Failed, not NOOP.)
             let tx_clone = tx.clone();
             mocks
                 .tx_repo
@@ -3278,6 +3289,10 @@ mod tests {
                 .job_producer
                 .expect_produce_send_notification_job()
                 .returning(|_, _| Box::pin(async { Ok(()) }));
+            mocks
+                .job_producer
+                .expect_produce_relayer_health_check_job()
+                .times(0);
 
             let evm_transaction = make_test_evm_relayer_transaction(relayer, mocks);
             let result = evm_transaction
@@ -3286,6 +3301,71 @@ mod tests {
                 .unwrap();
 
             // Since should_noop returns true for pending timeout, transaction should be marked as Failed
+            assert_eq!(result.status, TransactionStatus::Failed);
+            assert!(result.status_reason.is_some());
+            assert!(result.status_reason.unwrap().contains("Pending state"));
+        }
+
+        #[tokio::test]
+        async fn test_pending_state_timeout_with_nonce_marks_failed_and_schedules_health_job() {
+            let mut mocks = default_test_mocks();
+            let relayer = create_test_relayer();
+            let mut tx = make_test_transaction(TransactionStatus::Pending);
+            tx.created_at = (Utc::now() - Duration::minutes(2)).to_rfc3339();
+            if let NetworkTransactionData::Evm(ref mut evm_data) = tx.network_data {
+                evm_data.nonce = Some(42);
+            }
+
+            mocks
+                .network_repo
+                .expect_get_by_chain_id()
+                .returning(|_, _| Ok(Some(create_test_network_model())));
+
+            mocks.provider.expect_get_block_by_number().returning(|| {
+                Box::pin(async {
+                    use alloy::{network::AnyRpcBlock, rpc::types::Block};
+                    let mut block: Block = Block::default();
+                    block.header.gas_limit = 30_000_000u64;
+                    Ok(AnyRpcBlock::from(block))
+                })
+            });
+
+            let tx_clone = tx.clone();
+            mocks
+                .tx_repo
+                .expect_partial_update()
+                .withf(|id, update| {
+                    id == "test-tx-id"
+                        && update.status == Some(TransactionStatus::Failed)
+                        && update.status_reason.is_some()
+                })
+                .returning(move |_, update| {
+                    let mut updated_tx = tx_clone.clone();
+                    updated_tx.status = update.status.unwrap_or(updated_tx.status);
+                    updated_tx.status_reason = update.status_reason.clone();
+                    Ok(updated_tx)
+                });
+            mocks
+                .job_producer
+                .expect_produce_relayer_health_check_job()
+                .withf(|job, scheduled_on| {
+                    scheduled_on.is_none()
+                        && job.relayer_id == "test-relayer-id"
+                        && job.metadata.as_ref().is_some_and(|metadata| {
+                            metadata.get("health_check_action") == Some(&"nonce_health".to_string())
+                                && metadata.get("nonce_hint") == Some(&"42".to_string())
+                        })
+                })
+                .times(1)
+                .returning(|_, _| Box::pin(async { Ok(()) }));
+            mocks
+                .job_producer
+                .expect_produce_send_notification_job()
+                .returning(|_, _| Box::pin(async { Ok(()) }));
+
+            let evm_transaction = make_test_evm_relayer_transaction(relayer, mocks);
+            let result = evm_transaction.handle_pending_state(tx).await.unwrap();
+
             assert_eq!(result.status, TransactionStatus::Failed);
             assert!(result.status_reason.is_some());
             assert!(result.status_reason.unwrap().contains("Pending state"));

--- a/src/domain/transaction/evm/status.rs
+++ b/src/domain/transaction/evm/status.rs
@@ -715,12 +715,15 @@ where
                 tx_id = %tx.id,
                 relayer_id = %tx.relayer_id,
                 nonce = ?tx.network_data.evm_nonce(),
-                reason = %reason.as_ref().unwrap_or(&"unknown".to_string()),
+                reason = %reason.as_deref().unwrap_or("unknown"),
                 "marking pending transaction as Failed"
             );
             let update = TransactionUpdateRequest {
                 status: Some(TransactionStatus::Failed),
-                status_reason: reason,
+                // should_noop's reasons end with "Replacing with NOOP.", but
+                // this branch fails the transaction instead of NOPing it.
+                status_reason: reason
+                    .map(|r| r.replace("Replacing with NOOP.", "Marked as Failed.")),
                 ..Default::default()
             };
             let updated_tx = self
@@ -4095,6 +4098,56 @@ mod tests {
             assert_eq!(result.status, TransactionStatus::Failed);
             assert!(result.status_reason.is_some());
             assert!(result.status_reason.unwrap().contains("consecutive errors"));
+        }
+
+        #[tokio::test]
+        async fn test_circuit_breaker_pending_with_nonce_fails_and_schedules_health_job() {
+            let mut mocks = default_test_mocks();
+            let relayer = create_test_relayer();
+            let mut tx = make_test_transaction(TransactionStatus::Pending);
+            if let NetworkTransactionData::Evm(ref mut evm_data) = tx.network_data {
+                evm_data.nonce = Some(42);
+            }
+
+            let tx_clone = tx.clone();
+            mocks
+                .tx_repo
+                .expect_partial_update()
+                .withf(|_, update| update.status == Some(TransactionStatus::Failed))
+                .returning(move |_, update| {
+                    let mut updated_tx = tx_clone.clone();
+                    updated_tx.status = update.status.unwrap_or(updated_tx.status);
+                    updated_tx.status_reason = update.status_reason.clone();
+                    Ok(updated_tx)
+                });
+
+            // The abandoned nonce must be handed to gap fill.
+            mocks
+                .job_producer
+                .expect_produce_relayer_health_check_job()
+                .withf(|job, scheduled_on| {
+                    scheduled_on.is_none()
+                        && job.metadata.as_ref().is_some_and(|metadata| {
+                            metadata.get("health_check_action") == Some(&"nonce_health".to_string())
+                                && metadata.get("nonce_hint") == Some(&"42".to_string())
+                        })
+                })
+                .times(1)
+                .returning(|_, _| Box::pin(async { Ok(()) }));
+            mocks
+                .job_producer
+                .expect_produce_send_notification_job()
+                .returning(|_, _| Box::pin(async { Ok(()) }));
+
+            let evm_transaction = make_test_evm_relayer_transaction(relayer, mocks);
+            let ctx = create_triggered_context();
+
+            let result = evm_transaction
+                .handle_status_impl(tx, Some(ctx))
+                .await
+                .unwrap();
+
+            assert_eq!(result.status, TransactionStatus::Failed);
         }
 
         #[tokio::test]

--- a/src/domain/transaction/util.rs
+++ b/src/domain/transaction/util.rs
@@ -63,6 +63,42 @@ where
         .map_err(|e| e.into())
 }
 
+/// Retrieves a transaction by its ID from the primary data source.
+///
+/// Job handlers (prepare/submit/status) must use this instead of
+/// [`get_transaction_by_id`]: they act on the record and need
+/// read-your-writes consistency, which the replica-backed read
+/// cannot guarantee when `REDIS_READER_URL` is configured.
+#[instrument(
+    level = "debug",
+    skip(state),
+    fields(
+        request_id = ?crate::observability::request_id::get_request_id(),
+        tx_id = %transaction_id,
+    )
+)]
+pub async fn get_transaction_by_id_on_primary<J, RR, TR, NR, NFR, SR, TCR, PR, AKR>(
+    transaction_id: String,
+    state: &ThinDataAppState<J, RR, TR, NR, NFR, SR, TCR, PR, AKR>,
+) -> Result<TransactionRepoModel, ApiError>
+where
+    J: JobProducerTrait + Send + Sync + 'static,
+    RR: RelayerRepository + Repository<RelayerRepoModel, String> + Send + Sync + 'static,
+    TR: TransactionRepository + Repository<TransactionRepoModel, String> + Send + Sync + 'static,
+    NR: NetworkRepository + Repository<NetworkRepoModel, String> + Send + Sync + 'static,
+    NFR: Repository<NotificationRepoModel, String> + Send + Sync + 'static,
+    SR: Repository<SignerRepoModel, String> + Send + Sync + 'static,
+    TCR: TransactionCounterTrait + Send + Sync + 'static,
+    PR: PluginRepositoryTrait + Send + Sync + 'static,
+    AKR: ApiKeyRepositoryTrait + Send + Sync + 'static,
+{
+    state
+        .transaction_repository
+        .get_by_id_on_primary(transaction_id)
+        .await
+        .map_err(|e| e.into())
+}
+
 /// Creates a relayer network transaction instance based on the relayer ID.
 ///
 /// # Arguments

--- a/src/jobs/handlers/transaction_request_handler.rs
+++ b/src/jobs/handlers/transaction_request_handler.rs
@@ -8,7 +8,7 @@ use tracing::instrument;
 
 use crate::{
     constants::WORKER_TRANSACTION_REQUEST_RETRIES,
-    domain::{get_relayer_transaction, get_transaction_by_id, Transaction},
+    domain::{get_relayer_transaction, get_transaction_by_id_on_primary, Transaction},
     jobs::{handle_result, Job, TransactionRequest},
     metrics::{observe_processing_time, STAGE_PREPARE_DURATION, STAGE_REQUEST_QUEUE_DWELL},
     models::DefaultAppState,
@@ -60,7 +60,8 @@ async fn handle_request(
 ) -> eyre::Result<()> {
     let relayer_transaction = get_relayer_transaction(request.relayer_id, state).await?;
 
-    let transaction = get_transaction_by_id(request.transaction_id.clone(), state).await?;
+    let transaction =
+        get_transaction_by_id_on_primary(request.transaction_id.clone(), state).await?;
 
     // Measure time from transaction creation to request handler start.
     // On first attempt this approximates queue dwell time. On retries it

--- a/src/jobs/handlers/transaction_status_handler.rs
+++ b/src/jobs/handlers/transaction_status_handler.rs
@@ -10,7 +10,9 @@ use tracing::{debug, info, instrument, warn};
 
 use crate::{
     constants::{get_max_consecutive_status_failures, get_max_total_status_failures},
-    domain::{get_relayer_transaction, get_transaction_by_id, is_final_state, Transaction},
+    domain::{
+        get_relayer_transaction, get_transaction_by_id_on_primary, is_final_state, Transaction,
+    },
     jobs::{Job, StatusCheckContext, TransactionStatusCheck},
     models::{
         ApiError, DefaultAppState, TransactionError, TransactionMetadata, TransactionRepoModel,
@@ -205,7 +207,7 @@ async fn handle_request(
     );
 
     // Fetch transaction - if this fails, we can't read counters yet
-    let transaction = match get_transaction_by_id(tx_id.clone(), state).await {
+    let transaction = match get_transaction_by_id_on_primary(tx_id.clone(), state).await {
         Ok(tx) => tx,
         Err(ApiError::NotFound(msg)) => {
             // Transaction not found - permanent failure, don't retry

--- a/src/jobs/handlers/transaction_submission_handler.rs
+++ b/src/jobs/handlers/transaction_submission_handler.rs
@@ -15,7 +15,7 @@ use crate::{
         WORKER_TRANSACTION_CANCEL_RETRIES, WORKER_TRANSACTION_RESEND_RETRIES,
         WORKER_TRANSACTION_RESUBMIT_RETRIES, WORKER_TRANSACTION_SUBMIT_RETRIES,
     },
-    domain::{get_relayer_transaction, get_transaction_by_id, Transaction},
+    domain::{get_relayer_transaction, get_transaction_by_id_on_primary, Transaction},
     jobs::{handle_result, Job, TransactionCommand, TransactionSend},
     metrics::{observe_processing_time, STAGE_SUBMISSION_QUEUE_DWELL, STAGE_SUBMIT_DURATION},
     models::DefaultAppState,
@@ -83,7 +83,8 @@ async fn handle_request(
     let relayer_transaction =
         get_relayer_transaction(status_request.relayer_id.clone(), state).await?;
 
-    let transaction = get_transaction_by_id(status_request.transaction_id, state).await?;
+    let transaction =
+        get_transaction_by_id_on_primary(status_request.transaction_id, state).await?;
 
     // Capture transaction info for completion log
     let tx_id = transaction.id.clone();

--- a/src/models/transaction/repository.rs
+++ b/src/models/transaction/repository.rs
@@ -105,7 +105,9 @@ pub struct TransactionUpdateRequest {
     /// Timestamp when gas price was determined
     #[serde(skip_serializing_if = "Option::is_none")]
     pub priced_at: Option<String>,
-    /// History of transaction hashes
+    /// History of transaction hashes. A non-empty patch is merged into the
+    /// stored list append-only (a stale snapshot cannot drop concurrent
+    /// writers' hashes); `Some(vec![])` is an explicit reset.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub hashes: Option<Vec<String>>,
     /// Number of no-ops in the transaction
@@ -203,7 +205,18 @@ impl TransactionRepoModel {
             self.priced_at = Some(priced_at);
         }
         if let Some(hashes) = update.hashes {
-            self.hashes = hashes;
+            // An empty patch is an explicit reset (Stellar retry). A non-empty
+            // patch is merged append-only so a writer holding a stale snapshot
+            // cannot drop hashes recorded by a concurrent writer.
+            if hashes.is_empty() {
+                self.hashes = hashes;
+            } else {
+                for hash in hashes {
+                    if !self.hashes.contains(&hash) {
+                        self.hashes.push(hash);
+                    }
+                }
+            }
         }
         if let Some(noop_count) = update.noop_count {
             self.noop_count = Some(noop_count);
@@ -247,6 +260,8 @@ impl TransactionRepoModel {
             confirmed_at: None,
             network_data,
             priced_at: None,
+            // Empty vec is the explicit reset signal: it clears the stored
+            // hash history instead of merging (see `hashes` field docs).
             hashes: Some(vec![]),
             noop_count: None,
             is_canceled: None,
@@ -266,6 +281,15 @@ pub enum NetworkTransactionData {
 }
 
 impl NetworkTransactionData {
+    /// Returns the EVM nonce without cloning the transaction data.
+    /// `None` for non-EVM networks or when no nonce is assigned.
+    pub fn evm_nonce(&self) -> Option<u64> {
+        match self {
+            NetworkTransactionData::Evm(data) => data.nonce,
+            _ => None,
+        }
+    }
+
     pub fn get_evm_transaction_data(&self) -> Result<EvmTransactionData, TransactionError> {
         match self {
             NetworkTransactionData::Evm(data) => Ok(data.clone()),
@@ -3384,6 +3408,44 @@ mod tests {
 
         // Verify that delete_at was set because status changed to final
         assert!(transaction.delete_at.is_some());
+    }
+
+    #[test]
+    fn test_apply_partial_update_merges_hashes_append_only() {
+        let mut transaction = create_test_transaction();
+        transaction.hashes = vec!["0xstored".to_string(), "0xshared".to_string()];
+
+        // A patch built from a stale snapshot (missing "0xstored") must not
+        // drop it from the record.
+        let update = TransactionUpdateRequest {
+            hashes: Some(vec!["0xshared".to_string(), "0xnew".to_string()]),
+            ..Default::default()
+        };
+        transaction.apply_partial_update(update);
+
+        assert_eq!(
+            transaction.hashes,
+            vec![
+                "0xstored".to_string(),
+                "0xshared".to_string(),
+                "0xnew".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn test_apply_partial_update_empty_hashes_clears() {
+        let mut transaction = create_test_transaction();
+        transaction.hashes = vec!["0xstored".to_string()];
+
+        // An explicit empty patch is a reset (Stellar retry path).
+        let update = TransactionUpdateRequest {
+            hashes: Some(vec![]),
+            ..Default::default()
+        };
+        transaction.apply_partial_update(update);
+
+        assert!(transaction.hashes.is_empty());
     }
 
     #[test]

--- a/src/repositories/transaction/mod.rs
+++ b/src/repositories/transaction/mod.rs
@@ -144,8 +144,8 @@ pub trait TransactionRepository: Repository<TransactionRepoModel, String> {
     ///
     /// Returns the stored transaction and whether the patch was applied.
     /// The update must not contain `status` or `hashes` (presign patches
-    /// never do; both are rejected as invalid). Callers must pass EVM
-    /// transactions — behavior on other networks is unspecified.
+    /// never do; both are rejected as invalid). Non-EVM records are never
+    /// patched: the claim returns the stored record with `applied == false`.
     async fn partial_update_if_evm_nonce_unset(
         &self,
         tx_id: String,

--- a/src/repositories/transaction/mod.rs
+++ b/src/repositories/transaction/mod.rs
@@ -45,6 +45,16 @@ pub trait TransactionRepository: Repository<TransactionRepoModel, String> {
         None
     }
 
+    /// Retrieves a transaction from the primary data source.
+    ///
+    /// Backends without read replicas use the standard repository read.
+    async fn get_by_id_on_primary(
+        &self,
+        id: String,
+    ) -> Result<TransactionRepoModel, RepositoryError> {
+        Repository::get_by_id(self, id).await
+    }
+
     /// Find transactions by relayer ID with pagination
     async fn find_by_relayer_id(
         &self,
@@ -129,6 +139,18 @@ pub trait TransactionRepository: Repository<TransactionRepoModel, String> {
         tx_id: String,
         update: TransactionUpdateRequest,
     ) -> Result<TransactionRepoModel, RepositoryError>;
+
+    /// Applies a presign patch only when the stored EVM nonce is unset.
+    ///
+    /// Returns the stored transaction and whether the patch was applied.
+    /// The update must not contain `status` or `hashes` (presign patches
+    /// never do; both are rejected as invalid). Callers must pass EVM
+    /// transactions — behavior on other networks is unspecified.
+    async fn partial_update_if_evm_nonce_unset(
+        &self,
+        tx_id: String,
+        update: TransactionUpdateRequest,
+    ) -> Result<(TransactionRepoModel, bool), RepositoryError>;
 
     /// Repairs stale Redis status-index entries whose indexed status diverged from
     /// the persisted transaction body.
@@ -250,6 +272,7 @@ mockall::mock! {
   #[async_trait]
   impl TransactionRepository for TransactionRepository {
       fn connection_info(&self) -> Option<(Arc<RedisConnections>, String)>;
+      async fn get_by_id_on_primary(&self, id: String) -> Result<TransactionRepoModel, RepositoryError>;
       async fn find_by_relayer_id(&self, relayer_id: &str, query: PaginationQuery) -> Result<PaginatedResult<TransactionRepoModel>, RepositoryError>;
       async fn find_by_status(&self, relayer_id: &str, statuses: &[TransactionStatus]) -> Result<Vec<TransactionRepoModel>, RepositoryError>;
       async fn find_by_status_paginated(&self, relayer_id: &str, statuses: &[TransactionStatus], query: PaginationQuery, oldest_first: bool) -> Result<PaginatedResult<TransactionRepoModel>, RepositoryError>;
@@ -258,6 +281,7 @@ mockall::mock! {
       async fn get_nonce_occupancy(&self, relayer_id: &str, from_nonce: u64, to_nonce: u64) -> Result<Vec<(u64, Option<TransactionStatus>)>, RepositoryError>;
       async fn update_status(&self, tx_id: String, status: TransactionStatus) -> Result<TransactionRepoModel, RepositoryError>;
       async fn partial_update(&self, tx_id: String, update: TransactionUpdateRequest) -> Result<TransactionRepoModel, RepositoryError>;
+      async fn partial_update_if_evm_nonce_unset(&self, tx_id: String, update: TransactionUpdateRequest) -> Result<(TransactionRepoModel, bool), RepositoryError>;
       async fn reconcile_stale_status_indexes(&self, relayer_id: &str) -> Result<usize, RepositoryError>;
       async fn update_network_data(&self, tx_id: String, network_data: NetworkTransactionData) -> Result<TransactionRepoModel, RepositoryError>;
       async fn set_sent_at(&self, tx_id: String, sent_at: String) -> Result<TransactionRepoModel, RepositoryError>;
@@ -324,6 +348,16 @@ impl TransactionRepository for TransactionRepositoryStorage {
     fn connection_info(&self) -> Option<(Arc<RedisConnections>, String)> {
         TransactionRepositoryStorage::connection_info(self)
             .map(|(connections, key_prefix)| (connections, key_prefix.to_string()))
+    }
+
+    async fn get_by_id_on_primary(
+        &self,
+        id: String,
+    ) -> Result<TransactionRepoModel, RepositoryError> {
+        match self {
+            TransactionRepositoryStorage::InMemory(repo) => repo.get_by_id_on_primary(id).await,
+            TransactionRepositoryStorage::Redis(repo) => repo.get_by_id_on_primary(id).await,
+        }
     }
 
     async fn find_by_relayer_id(
@@ -461,6 +495,21 @@ impl TransactionRepository for TransactionRepositoryStorage {
                 repo.partial_update(tx_id, update).await
             }
             TransactionRepositoryStorage::Redis(repo) => repo.partial_update(tx_id, update).await,
+        }
+    }
+
+    async fn partial_update_if_evm_nonce_unset(
+        &self,
+        tx_id: String,
+        update: TransactionUpdateRequest,
+    ) -> Result<(TransactionRepoModel, bool), RepositoryError> {
+        match self {
+            TransactionRepositoryStorage::InMemory(repo) => {
+                repo.partial_update_if_evm_nonce_unset(tx_id, update).await
+            }
+            TransactionRepositoryStorage::Redis(repo) => {
+                repo.partial_update_if_evm_nonce_unset(tx_id, update).await
+            }
         }
     }
 

--- a/src/repositories/transaction/transaction_in_memory.rs
+++ b/src/repositories/transaction/transaction_in_memory.rs
@@ -423,6 +423,34 @@ impl TransactionRepository for InMemoryTransactionRepository {
         }
     }
 
+    async fn partial_update_if_evm_nonce_unset(
+        &self,
+        tx_id: String,
+        update: TransactionUpdateRequest,
+    ) -> Result<(TransactionRepoModel, bool), RepositoryError> {
+        if update.status.is_some() || update.hashes.is_some() {
+            return Err(RepositoryError::InvalidData(
+                "Nonce claim update must not contain status or hashes".to_string(),
+            ));
+        }
+
+        let mut store = Self::acquire_lock(&self.store).await?;
+        let tx = store.get_mut(&tx_id).ok_or_else(|| {
+            RepositoryError::NotFound(format!("Transaction with ID {tx_id} not found"))
+        })?;
+
+        let nonce_is_unset = matches!(
+            &tx.network_data,
+            NetworkTransactionData::Evm(evm_data) if evm_data.nonce.is_none()
+        );
+        if Self::is_final_state(&tx.status) || !nonce_is_unset {
+            return Ok((tx.clone(), false));
+        }
+
+        tx.apply_partial_update(update);
+        Ok((tx.clone(), true))
+    }
+
     async fn update_network_data(
         &self,
         tx_id: String,
@@ -688,6 +716,15 @@ mod tests {
         }
     }
 
+    fn nonce_claim_update(evm_data: &EvmTransactionData, nonce: u64) -> TransactionUpdateRequest {
+        let mut claimed_data = evm_data.clone();
+        claimed_data.nonce = Some(nonce);
+        TransactionUpdateRequest {
+            network_data: Some(NetworkTransactionData::Evm(claimed_data)),
+            ..Default::default()
+        }
+    }
+
     #[tokio::test]
     async fn test_create_transaction() {
         let repo = InMemoryTransactionRepository::new();
@@ -710,6 +747,21 @@ mod tests {
                 assert_eq!(stored_data.hash, tx_data.hash);
             }
         }
+    }
+
+    #[tokio::test]
+    async fn test_get_by_id_on_primary_uses_default_repository_read() {
+        let repo = InMemoryTransactionRepository::new();
+        let tx = create_test_transaction("test-primary-read");
+
+        repo.create(tx.clone()).await.unwrap();
+        let stored = repo
+            .get_by_id_on_primary("test-primary-read".to_string())
+            .await
+            .unwrap();
+
+        assert_eq!(stored.id, tx.id);
+        assert_eq!(stored.relayer_id, tx.relayer_id);
     }
 
     #[tokio::test]
@@ -863,6 +915,95 @@ mod tests {
             .await;
         assert!(result.is_err());
         assert!(matches!(result.unwrap_err(), RepositoryError::NotFound(_)));
+    }
+
+    #[tokio::test]
+    async fn test_partial_update_if_evm_nonce_unset_applies_only_first_claim() {
+        let repo = InMemoryTransactionRepository::new();
+        let mut tx = create_test_transaction_pending_state("test-nonce-claim");
+        let NetworkTransactionData::Evm(ref mut evm_data) = tx.network_data else {
+            panic!("Expected EVM transaction data");
+        };
+        evm_data.nonce = None;
+        let base_evm_data = evm_data.clone();
+        repo.create(tx).await.unwrap();
+
+        let (first, first_applied) = repo
+            .partial_update_if_evm_nonce_unset(
+                "test-nonce-claim".to_string(),
+                nonce_claim_update(&base_evm_data, 11),
+            )
+            .await
+            .unwrap();
+        let (second, second_applied) = repo
+            .partial_update_if_evm_nonce_unset(
+                "test-nonce-claim".to_string(),
+                nonce_claim_update(&base_evm_data, 12),
+            )
+            .await
+            .unwrap();
+
+        assert!(first_applied);
+        assert!(!second_applied);
+        assert_eq!(
+            first.network_data.get_evm_transaction_data().unwrap().nonce,
+            Some(11)
+        );
+        assert_eq!(
+            second
+                .network_data
+                .get_evm_transaction_data()
+                .unwrap()
+                .nonce,
+            Some(11)
+        );
+        assert_eq!(
+            repo.get_by_id("test-nonce-claim".to_string())
+                .await
+                .unwrap()
+                .network_data
+                .get_evm_transaction_data()
+                .unwrap()
+                .nonce,
+            Some(11)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_partial_update_if_evm_nonce_unset_rejects_status_and_hashes() {
+        let repo = InMemoryTransactionRepository::new();
+        let mut tx = create_test_transaction_pending_state("test-claim-reject");
+        let NetworkTransactionData::Evm(ref mut evm_data) = tx.network_data else {
+            panic!("Expected EVM transaction data");
+        };
+        evm_data.nonce = None;
+        let base_evm_data = evm_data.clone();
+        repo.create(tx).await.unwrap();
+
+        let with_status = TransactionUpdateRequest {
+            status: Some(TransactionStatus::Sent),
+            ..nonce_claim_update(&base_evm_data, 11)
+        };
+        let result = repo
+            .partial_update_if_evm_nonce_unset("test-claim-reject".to_string(), with_status)
+            .await;
+        assert!(matches!(result, Err(RepositoryError::InvalidData(_))));
+
+        let with_hashes = TransactionUpdateRequest {
+            hashes: Some(vec!["0xhash".to_string()]),
+            ..nonce_claim_update(&base_evm_data, 11)
+        };
+        let result = repo
+            .partial_update_if_evm_nonce_unset("test-claim-reject".to_string(), with_hashes)
+            .await;
+        assert!(matches!(result, Err(RepositoryError::InvalidData(_))));
+
+        // The record is untouched by rejected patches.
+        let stored = repo
+            .get_by_id("test-claim-reject".to_string())
+            .await
+            .unwrap();
+        assert_eq!(stored.network_data.evm_nonce(), None);
     }
 
     #[tokio::test]

--- a/src/repositories/transaction/transaction_redis.rs
+++ b/src/repositories/transaction/transaction_redis.rs
@@ -168,6 +168,61 @@ impl RedisTransactionRepository {
         (lookup_key, key_prefix, key_suffix)
     }
 
+    /// Like [`Repository::get_by_id`], but reading through the given pool.
+    /// Job-path callers pass the primary pool for read-your-writes consistency.
+    async fn get_by_id_on(
+        &self,
+        pool: &Arc<deadpool_redis::Pool>,
+        id: String,
+        context: &str,
+    ) -> Result<TransactionRepoModel, RepositoryError> {
+        if id.is_empty() {
+            return Err(RepositoryError::InvalidData(
+                "Transaction ID cannot be empty".to_string(),
+            ));
+        }
+
+        let mut conn = self.get_connection(pool, context).await?;
+        debug!(tx_id = %id, "fetching transaction");
+
+        let reverse_key = self.tx_to_relayer_key(&id);
+        let relayer_id: Option<String> = conn
+            .get(&reverse_key)
+            .await
+            .map_err(|e| self.map_redis_error(e, "get_transaction_reverse_lookup"))?;
+
+        let relayer_id = match relayer_id {
+            Some(relayer_id) => relayer_id,
+            None => {
+                debug!(tx_id = %id, "transaction not found (no reverse lookup)");
+                return Err(RepositoryError::NotFound(format!(
+                    "Transaction with ID {id} not found"
+                )));
+            }
+        };
+
+        let key = self.tx_key(&relayer_id, &id);
+        let value: Option<String> = conn
+            .get(&key)
+            .await
+            .map_err(|e| self.map_redis_error(e, "get_transaction_by_id"))?;
+
+        match value {
+            Some(json) => {
+                let tx =
+                    self.deserialize_entity::<TransactionRepoModel>(&json, &id, "transaction")?;
+                debug!(tx_id = %id, "successfully fetched transaction");
+                Ok(tx)
+            }
+            None => {
+                debug!(tx_id = %id, "transaction not found");
+                Err(RepositoryError::NotFound(format!(
+                    "Transaction with ID {id} not found"
+                )))
+            }
+        }
+    }
+
     /// Executes an atomic Lua script with retry/backoff for transient Redis failures.
     ///
     /// Every script receives `KEYS[1]` = tx_to_relayer lookup key and
@@ -1151,54 +1206,8 @@ impl Repository<TransactionRepoModel, String> for RedisTransactionRepository {
     }
 
     async fn get_by_id(&self, id: String) -> Result<TransactionRepoModel, RepositoryError> {
-        if id.is_empty() {
-            return Err(RepositoryError::InvalidData(
-                "Transaction ID cannot be empty".to_string(),
-            ));
-        }
-
-        let mut conn = self
-            .get_connection(self.connections.reader(), "get_by_id")
-            .await?;
-
-        debug!(tx_id = %id, "fetching transaction");
-
-        let reverse_key = self.tx_to_relayer_key(&id);
-        let relayer_id: Option<String> = conn
-            .get(&reverse_key)
+        self.get_by_id_on(self.connections.reader(), id, "get_by_id")
             .await
-            .map_err(|e| self.map_redis_error(e, "get_transaction_reverse_lookup"))?;
-
-        let relayer_id = match relayer_id {
-            Some(relayer_id) => relayer_id,
-            None => {
-                debug!(tx_id = %id, "transaction not found (no reverse lookup)");
-                return Err(RepositoryError::NotFound(format!(
-                    "Transaction with ID {id} not found"
-                )));
-            }
-        };
-
-        let key = self.tx_key(&relayer_id, &id);
-        let value: Option<String> = conn
-            .get(&key)
-            .await
-            .map_err(|e| self.map_redis_error(e, "get_transaction_by_id"))?;
-
-        match value {
-            Some(json) => {
-                let tx =
-                    self.deserialize_entity::<TransactionRepoModel>(&json, &id, "transaction")?;
-                debug!(tx_id = %id, "successfully fetched transaction");
-                Ok(tx)
-            }
-            None => {
-                debug!(tx_id = %id, "transaction not found");
-                Err(RepositoryError::NotFound(format!(
-                    "Transaction with ID {id} not found"
-                )))
-            }
-        }
     }
 
     // Unoptimized implementation of list_paginated. Rarely used. find_by_relayer_id is preferred.
@@ -1544,6 +1553,14 @@ impl Repository<TransactionRepoModel, String> for RedisTransactionRepository {
 
 #[async_trait]
 impl TransactionRepository for RedisTransactionRepository {
+    async fn get_by_id_on_primary(
+        &self,
+        id: String,
+    ) -> Result<TransactionRepoModel, RepositoryError> {
+        self.get_by_id_on(self.connections.primary(), id, "get_by_id_on_primary")
+            .await
+    }
+
     async fn find_by_relayer_id(
         &self,
         relayer_id: &str,
@@ -2127,6 +2144,30 @@ impl TransactionRepository for RedisTransactionRepository {
             local old_snapshot = current
             local old_status = tx["status"]
 
+            -- An empty hashes patch is an explicit reset (Stellar retry). A
+            -- non-empty patch is merged append-only so a writer holding a
+            -- stale snapshot cannot drop hashes recorded by a concurrent
+            -- writer.
+            local patch_hashes = patch["hashes"]
+            if patch_hashes ~= nil and patch_hashes ~= cjson.null and #patch_hashes > 0 then
+                local merged = {}
+                local seen = {}
+                local stored = tx["hashes"]
+                if stored ~= nil and stored ~= cjson.null then
+                    for _, h in ipairs(stored) do
+                        merged[#merged + 1] = h
+                        seen[h] = true
+                    end
+                end
+                for _, h in ipairs(patch_hashes) do
+                    if not seen[h] then
+                        merged[#merged + 1] = h
+                        seen[h] = true
+                    end
+                end
+                patch["hashes"] = merged
+            end
+
             -- lua-cjson cannot distinguish empty Lua tables from empty
             -- arrays, so a decode/encode round-trip turns [] into {}.
             -- Record which keys held [] in the stored doc and the patch
@@ -2265,6 +2306,111 @@ impl TransactionRepository for RedisTransactionRepository {
         }
 
         Ok(updated_tx)
+    }
+
+    async fn partial_update_if_evm_nonce_unset(
+        &self,
+        tx_id: String,
+        update: TransactionUpdateRequest,
+    ) -> Result<(TransactionRepoModel, bool), RepositoryError> {
+        if update.status.is_some() || update.hashes.is_some() {
+            return Err(RepositoryError::InvalidData(
+                "Nonce claim update must not contain status or hashes".to_string(),
+            ));
+        }
+
+        let patch_json = serde_json::to_string(&update).map_err(|e| {
+            RepositoryError::InvalidData(format!("Failed to serialize update patch: {e}"))
+        })?;
+        let (lookup_key, key_prefix, key_suffix) = self.tx_key_parts(&tx_id);
+
+        let claim_script = Script::new(
+            r#"
+            local relayer_id = redis.call('GET', KEYS[1])
+            if not relayer_id then return false end
+
+            local tx_key = ARGV[1] .. relayer_id .. ARGV[2]
+            local current = redis.call('GET', tx_key)
+            if not current then return false end
+
+            local tx = cjson.decode(current)
+            local final_states = {confirmed=true, failed=true, expired=true, canceled=true}
+            if final_states[tx["status"]] then
+                return {current, current, "0"}
+            end
+
+            local network_data = tx["network_data"]
+            local evm_data = network_data and network_data["data"]
+            local nonce = evm_data and evm_data["nonce"]
+            if nonce ~= nil and nonce ~= cjson.null then
+                return {current, current, "0"}
+            end
+
+            local patch = cjson.decode(ARGV[3])
+
+            -- lua-cjson encodes empty Lua tables as objects. Preserve fields
+            -- that were empty arrays in either the stored JSON or the patch.
+            -- Copied from partial_update; see the NOTE there about the
+            -- unique-key-name assumption this gsub restore relies on.
+            local empty_arrs = {}
+            for k in string.gmatch(current, '"([^"]+)"%s*:%s*%[%s*%]') do
+                empty_arrs[k] = true
+            end
+            for k in string.gmatch(ARGV[3], '"([^"]+)"%s*:%s*%[%s*%]') do
+                empty_arrs[k] = true
+            end
+
+            for k, v in pairs(patch) do
+                tx[k] = v
+            end
+
+            local updated = cjson.encode(tx)
+            for k, _ in pairs(empty_arrs) do
+                updated = string.gsub(
+                    updated, '"'..k..'"%s*:%s*{}', '"'..k..'":[]', 1
+                )
+            end
+
+            redis.call('SET', tx_key, updated)
+            return {current, updated, "1"}
+            "#,
+        );
+
+        let result: Option<Vec<String>> = self
+            .run_script_with_retry_vec(
+                &claim_script,
+                &lookup_key,
+                &key_prefix,
+                &key_suffix,
+                &[&patch_json],
+                "partial_update_if_evm_nonce_unset",
+            )
+            .await?;
+
+        let parts = result.ok_or_else(|| {
+            RepositoryError::NotFound(format!("Transaction with ID {tx_id} not found"))
+        })?;
+
+        if parts.len() != 3 {
+            return Err(RepositoryError::UnexpectedError(format!(
+                "partial_update_if_evm_nonce_unset script returned {} elements, expected 3",
+                parts.len()
+            )));
+        }
+
+        let applied = parts[2] == "1";
+        let updated_tx =
+            self.deserialize_entity::<TransactionRepoModel>(&parts[1], &tx_id, "transaction")?;
+
+        if applied {
+            let original_tx =
+                self.deserialize_entity::<TransactionRepoModel>(&parts[0], &tx_id, "transaction")?;
+            self.update_indexes(&updated_tx, Some(&original_tx), false)
+                .await?;
+        }
+
+        debug!(tx_id = %tx_id, applied, "completed conditional transaction nonce claim");
+        Ok((updated_tx, applied))
     }
 
     async fn reconcile_stale_status_indexes(
@@ -2800,6 +2946,15 @@ mod tests {
         tx
     }
 
+    fn nonce_claim_update(evm_data: &EvmTransactionData, nonce: u64) -> TransactionUpdateRequest {
+        let mut claimed_data = evm_data.clone();
+        claimed_data.nonce = Some(nonce);
+        TransactionUpdateRequest {
+            network_data: Some(NetworkTransactionData::Evm(claimed_data)),
+            ..Default::default()
+        }
+    }
+
     async fn setup_test_repo() -> RedisTransactionRepository {
         // Use a mock Redis URL - in real integration tests, this would connect to a test Redis instance
         let redis_url = std::env::var("REDIS_TEST_URL")
@@ -2986,6 +3141,23 @@ mod tests {
 
         repo.create(tx.clone()).await.unwrap();
         let stored = repo.get_by_id(random_id.to_string()).await.unwrap();
+        assert_eq!(stored.id, tx.id);
+        assert_eq!(stored.relayer_id, tx.relayer_id);
+    }
+
+    #[tokio::test]
+    #[ignore = "Requires active Redis instance"]
+    async fn test_get_transaction_on_primary() {
+        let repo = setup_test_repo().await;
+        let random_id = Uuid::new_v4().to_string();
+        let tx = create_test_transaction(&random_id);
+
+        repo.create(tx.clone()).await.unwrap();
+        let stored = repo
+            .get_by_id_on_primary(random_id.to_string())
+            .await
+            .unwrap();
+
         assert_eq!(stored.id, tx.id);
         assert_eq!(stored.relayer_id, tx.relayer_id);
     }
@@ -3632,6 +3804,158 @@ mod tests {
             updated.sent_at,
             Some("2025-01-27T16:00:00.000000+00:00".to_string())
         );
+    }
+
+    #[tokio::test]
+    #[ignore = "Requires active Redis instance"]
+    async fn test_partial_update_merges_hashes_append_only() {
+        let repo = setup_test_repo().await;
+        let random_id = Uuid::new_v4().to_string();
+        let mut tx = create_test_transaction(&random_id);
+        tx.hashes = vec!["0xstored".to_string(), "0xshared".to_string()];
+
+        repo.create(tx).await.unwrap();
+
+        // A patch built from a stale snapshot (missing "0xstored") must not
+        // drop it from the record.
+        let update = TransactionUpdateRequest {
+            hashes: Some(vec!["0xshared".to_string(), "0xnew".to_string()]),
+            ..Default::default()
+        };
+        let updated = repo
+            .partial_update(random_id.clone(), update)
+            .await
+            .unwrap();
+        assert_eq!(
+            updated.hashes,
+            vec![
+                "0xstored".to_string(),
+                "0xshared".to_string(),
+                "0xnew".to_string()
+            ]
+        );
+
+        // An explicit empty patch is a reset (Stellar retry path).
+        let update = TransactionUpdateRequest {
+            hashes: Some(vec![]),
+            ..Default::default()
+        };
+        let updated = repo.partial_update(random_id, update).await.unwrap();
+        assert!(updated.hashes.is_empty());
+    }
+
+    #[test]
+    fn test_evm_nonce_serialization_path_matches_claim_guard() {
+        let mut tx = create_test_transaction("test-serialization-path");
+        let NetworkTransactionData::Evm(ref mut evm_data) = tx.network_data else {
+            panic!("Expected EVM transaction data");
+        };
+        evm_data.nonce = None;
+
+        let value = serde_json::to_value(tx).unwrap();
+
+        assert_eq!(
+            value
+                .pointer("/network_data/network_data")
+                .and_then(serde_json::Value::as_str),
+            Some("Evm")
+        );
+        assert!(value
+            .pointer("/network_data/data/nonce")
+            .is_some_and(serde_json::Value::is_null));
+    }
+
+    #[tokio::test]
+    #[ignore = "Requires active Redis instance"]
+    async fn test_partial_update_if_evm_nonce_unset_applies_only_first_claim() {
+        let repo = setup_test_repo().await;
+        let tx_id = Uuid::new_v4().to_string();
+        let mut tx = create_test_transaction(&tx_id);
+        let NetworkTransactionData::Evm(ref mut evm_data) = tx.network_data else {
+            panic!("Expected EVM transaction data");
+        };
+        evm_data.nonce = None;
+        let base_evm_data = evm_data.clone();
+        repo.create(tx).await.unwrap();
+
+        let (first, first_applied) = repo
+            .partial_update_if_evm_nonce_unset(
+                tx_id.clone(),
+                nonce_claim_update(&base_evm_data, 21),
+            )
+            .await
+            .unwrap();
+        let (second, second_applied) = repo
+            .partial_update_if_evm_nonce_unset(
+                tx_id.clone(),
+                nonce_claim_update(&base_evm_data, 22),
+            )
+            .await
+            .unwrap();
+
+        assert!(first_applied);
+        assert!(!second_applied);
+        assert_eq!(
+            first.network_data.get_evm_transaction_data().unwrap().nonce,
+            Some(21)
+        );
+        assert_eq!(
+            second
+                .network_data
+                .get_evm_transaction_data()
+                .unwrap()
+                .nonce,
+            Some(21)
+        );
+        assert_eq!(
+            repo.get_by_id(tx_id)
+                .await
+                .unwrap()
+                .network_data
+                .get_evm_transaction_data()
+                .unwrap()
+                .nonce,
+            Some(21)
+        );
+    }
+
+    #[tokio::test]
+    #[ignore = "Requires active Redis instance"]
+    async fn test_partial_update_if_evm_nonce_unset_skips_final_transaction() {
+        let repo = setup_test_repo().await;
+        let tx_id = Uuid::new_v4().to_string();
+        let mut tx = create_test_transaction_with_status(
+            &tx_id,
+            "relayer-final-claim",
+            TransactionStatus::Confirmed,
+        );
+        let NetworkTransactionData::Evm(ref mut evm_data) = tx.network_data else {
+            panic!("Expected EVM transaction data");
+        };
+        evm_data.nonce = None;
+        let base_evm_data = evm_data.clone();
+        repo.create(tx).await.unwrap();
+
+        let update = TransactionUpdateRequest {
+            priced_at: Some("2025-01-27T16:00:00Z".to_string()),
+            ..nonce_claim_update(&base_evm_data, 23)
+        };
+        let (stored, applied) = repo
+            .partial_update_if_evm_nonce_unset(tx_id, update)
+            .await
+            .unwrap();
+
+        assert!(!applied);
+        assert_eq!(stored.status, TransactionStatus::Confirmed);
+        assert_eq!(
+            stored
+                .network_data
+                .get_evm_transaction_data()
+                .unwrap()
+                .nonce,
+            None
+        );
+        assert_eq!(stored.priced_at, None);
     }
 
     #[tokio::test]

--- a/src/repositories/transaction/transaction_redis.rs
+++ b/src/repositories/transaction/transaction_redis.rs
@@ -2339,8 +2339,14 @@ impl TransactionRepository for RedisTransactionRepository {
                 return {current, current, "0"}
             end
 
+            -- Only EVM records can be claimed. A non-EVM record has no
+            -- data.nonce, which would read as "unset" and let the patch
+            -- overwrite its payload; refuse instead (matches in-memory).
             local network_data = tx["network_data"]
-            local evm_data = network_data and network_data["data"]
+            if not network_data or network_data["network_data"] ~= "Evm" then
+                return {current, current, "0"}
+            end
+            local evm_data = network_data["data"]
             local nonce = evm_data and evm_data["nonce"]
             if nonce ~= nil and nonce ~= cjson.null then
                 return {current, current, "0"}
@@ -2399,15 +2405,17 @@ impl TransactionRepository for RedisTransactionRepository {
         }
 
         let applied = parts[2] == "1";
+        let original_tx =
+            self.deserialize_entity::<TransactionRepoModel>(&parts[0], &tx_id, "transaction")?;
         let updated_tx =
             self.deserialize_entity::<TransactionRepoModel>(&parts[1], &tx_id, "transaction")?;
 
-        if applied {
-            let original_tx =
-                self.deserialize_entity::<TransactionRepoModel>(&parts[0], &tx_id, "transaction")?;
-            self.update_indexes(&updated_tx, Some(&original_tx), false)
-                .await?;
-        }
+        // Refresh the auxiliary indexes on both outcomes: a retry after a
+        // lost reply reports applied=false for a claim that actually landed,
+        // and the nonce index must not stay unwritten (the occupancy scan
+        // would see a false gap). The index writes are idempotent.
+        self.update_indexes(&updated_tx, Some(&original_tx), false)
+            .await?;
 
         debug!(tx_id = %tx_id, applied, "completed conditional transaction nonce claim");
         Ok((updated_tx, applied))


### PR DESCRIPTION
# Summary

Closes #836.

The EVM pending-recovery path re-queues a prepare job for any transaction still Pending after 20 seconds. Nonce allocation was a non-atomic read-then-write, so two concurrent prepares for one transaction could each read `nonce: None`, allocate distinct nonces, and both sign and broadcast. For transfers this is a double-spend.

The presign write is now a conditional claim: an atomic patch on the Redis primary that assigns the nonce only when the stored record has none, and otherwise returns the stored record untouched. A prepare that loses the race signs with the winner's nonce, so racing prepares converge on one nonce and at most one broadcast can mine. The loser's counter value leaks a gap; the lost claim schedules the existing nonce-health job with the leaked nonce as the scan hint, and gap fill covers it with a NOOP. The transaction record itself is the allocation record, so there is no new key namespace and no TTL to reason about.

Supporting changes, each closing a path that feeds the same race or its fallout:

- The prepare, submit, and status job handlers read the transaction from the Redis primary. With a reader endpoint configured, replica lag could feed a stale `nonce: None` into a re-prepare arbitrarily late.
- `hashes` patches merge append-only, so a writer holding a stale snapshot cannot drop hashes recorded by a concurrent writer. An empty patch stays an explicit reset because the Stellar retry path clears the list.
- Failing a Pending transaction that holds a nonce (prepare timeout, circuit breaker) now schedules a nonce-health job so the abandoned nonce is gap-filled promptly. The Failed transition itself is unchanged.

Two prepares can still both broadcast, now sharing one nonce; the duplicate is rejected or mines harmlessly. Suppressing that entirely needs job-level dedup and is out of scope per the issue.

## Testing Process

- New unit tests cover claim idempotency on both storage backends, the JSON path the Lua guard reads (pinned against serde changes), lost-claim and preset-nonce prepare scenarios, hashes merge-versus-reset semantics, and gap-fill scheduling on Failed-with-nonce.
- Focused suites pass: `evm_transaction` (51), `transaction_in_memory` (62), `repositories::transaction` (107), `models::transaction` (215), status handlers (178), `stellar` (1160), `solana_transaction` (22).
- The Redis-gated tests for the new Lua scripts compile but need a live instance: `REDIS_TEST_URL=<url> cargo test --lib -- --ignored partial_update`. Not yet run; requires a local Redis.

## Checklist

- [x] Add a reference to related issues in the PR description.
- [x] Add unit tests if applicable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction nonce handling during concurrent submissions to prevent conflicting assignments.
  * Added automatic best-effort nonce recovery when assigned transactions time out or fail.
  * Preserved nonce and transaction state correctly for finalized transactions.
  * Improved transaction status consistency by reading the latest data after updates.
  * Transaction hash history now merges new hashes without duplicates, while supporting explicit resets.
* **Reliability**
  * Improved handling of preset nonces and transaction records that do not yet have a nonce.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->