### PR TITLE
fix(evm): Chain Arbitrum delivery to drain nonce-too-high jams

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -150,6 +150,7 @@ rand = "0.9.0"
 redis = { version = "0.32", features = ["aio", "tokio-comp"] }
 tempfile = "3.2"
 serial_test = "3.2"
+tokio = { version = "1.43", features = ["test-util"] }
 zstd = "0.13"
 clap = { version = "4.5", features = ["derive"] }
 

--- a/src/constants/evm_transaction.rs
+++ b/src/constants/evm_transaction.rs
@@ -26,9 +26,8 @@ pub const MAXIMUM_TX_ATTEMPTS: usize = 50;
 pub const MAXIMUM_NOOP_RETRY_ATTEMPTS: u32 = 50;
 
 /// Maximum delivery attempts (recorded hashes) for a rollup transaction before it is
-/// NOOP-replaced. On rollups every broadcast attempt is persisted before broadcast, so
-/// `hashes.len()` counts real delivery attempts; an undeliverable head is burned with a
-/// NOOP after this many attempts so the nonces queued behind it can drain.
+/// NOOP-replaced. Each broadcast is persisted first, so `hashes.len()` counts real
+/// attempts. The NOOP frees the nonces queued behind an undeliverable head.
 pub const ROLLUP_MAX_DELIVERY_ATTEMPTS: usize = 10;
 
 /// Time to resubmit for Arbitrum networks
@@ -135,14 +134,14 @@ pub const NONCE_TOO_HIGH_PATTERNS: &[&str] = &[
 /// escalation happens within ~75s — enough time for transient burst ordering to resolve.
 pub const MAX_NONCE_TOO_HIGH_RETRIES: u32 = 3;
 
-/// Maximum in-process broadcast retries when "nonce too high" is returned on an
-/// Arbitrum-based network. The Nitro sequencer holds such a transaction ~1s and revives
-/// it if the predecessor lands, so short same-bytes retries absorb burst-ordering races
-/// without consuming the `MAX_NONCE_TOO_HIGH_RETRIES` escalation budget.
+/// Maximum in-process broadcast retries on "nonce too high" for Arbitrum-based
+/// networks. The Nitro sequencer holds such a transaction ~1s and revives it if the
+/// predecessor lands. These retries do not consume the `MAX_NONCE_TOO_HIGH_RETRIES`
+/// escalation budget.
 pub const ARBITRUM_NONCE_TOO_HIGH_INPROCESS_RETRIES: u32 = 3;
 
-/// Delay between in-process "nonce too high" broadcast retries on Arbitrum-based
-/// networks. Matched to the ~1s Nitro nonce-failure cache window.
+/// Delay between in-process "nonce too high" broadcast retries. Matches the ~1s
+/// Nitro nonce-failure cache window.
 pub const ARBITRUM_NONCE_TOO_HIGH_RETRY_DELAY_MS: u64 = 1000;
 
 /// Maximum number of nonces to scan when detecting gaps between on-chain and local counter.

--- a/src/constants/evm_transaction.rs
+++ b/src/constants/evm_transaction.rs
@@ -25,6 +25,12 @@ pub const MAXIMUM_TX_ATTEMPTS: usize = 50;
 // Maximum number of NOOP transactions to attempt
 pub const MAXIMUM_NOOP_RETRY_ATTEMPTS: u32 = 50;
 
+/// Maximum delivery attempts (recorded hashes) for a rollup transaction before it is
+/// NOOP-replaced. On rollups every broadcast attempt is persisted before broadcast, so
+/// `hashes.len()` counts real delivery attempts; an undeliverable head is burned with a
+/// NOOP after this many attempts so the nonces queued behind it can drain.
+pub const ROLLUP_MAX_DELIVERY_ATTEMPTS: usize = 10;
+
 /// Time to resubmit for Arbitrum networks
 pub const ARBITRUM_TIME_TO_RESUBMIT: i64 = 20_000;
 
@@ -128,6 +134,16 @@ pub const NONCE_TOO_HIGH_PATTERNS: &[&str] = &[
 /// With ~25s between retries (driven by status checker resend timeout), this means
 /// escalation happens within ~75s — enough time for transient burst ordering to resolve.
 pub const MAX_NONCE_TOO_HIGH_RETRIES: u32 = 3;
+
+/// Maximum in-process broadcast retries when "nonce too high" is returned on an
+/// Arbitrum-based network. The Nitro sequencer holds such a transaction ~1s and revives
+/// it if the predecessor lands, so short same-bytes retries absorb burst-ordering races
+/// without consuming the `MAX_NONCE_TOO_HIGH_RETRIES` escalation budget.
+pub const ARBITRUM_NONCE_TOO_HIGH_INPROCESS_RETRIES: u32 = 3;
+
+/// Delay between in-process "nonce too high" broadcast retries on Arbitrum-based
+/// networks. Matched to the ~1s Nitro nonce-failure cache window.
+pub const ARBITRUM_NONCE_TOO_HIGH_RETRY_DELAY_MS: u64 = 1000;
 
 /// Maximum number of nonces to scan when detecting gaps between on-chain and local counter.
 /// Gaps beyond this range are logged for operator investigation rather than automated recovery.

--- a/src/domain/transaction/evm/evm_transaction.rs
+++ b/src/domain/transaction/evm/evm_transaction.rs
@@ -376,18 +376,23 @@ where
         })
     }
 
-    /// Returns whether the tx's network is Arbitrum-based. Lookup failures return
-    /// `false` so the default (non-Arbitrum) submission behavior is preserved.
-    async fn is_arbitrum_network(&self, tx: &TransactionRepoModel, chain_id: u64) -> bool {
+    /// Loads the network for delivery-behavior gating (`is_arbitrum`,
+    /// `lacks_mempool`). Lookup failures return `None` (logged) so the default
+    /// submission behavior is preserved.
+    async fn delivery_network(
+        &self,
+        tx: &TransactionRepoModel,
+        chain_id: u64,
+    ) -> Option<EvmNetwork> {
         match self.get_evm_network(chain_id).await {
-            Ok(network) => network.is_arbitrum(),
+            Ok(network) => Some(network),
             Err(e) => {
                 warn!(
                     tx_id = %tx.id,
                     error = %e,
-                    "failed to load network; assuming non-Arbitrum submission behavior"
+                    "failed to load network; assuming default submission behavior"
                 );
-                false
+                None
             }
         }
     }
@@ -1034,9 +1039,12 @@ where
             TransactionError::InvalidType("Raw transaction data is missing".to_string())
         })?;
 
-        // Arbitrum-based networks have no mempool: broadcast needs in-process
-        // nonce-too-high retries and success-chained delivery (issue #843).
-        let is_arbitrum = self.is_arbitrum_network(&tx, evm_tx_data.chain_id).await;
+        // Nitro-specific (issue #843): in-process nonce-too-high retries ride the
+        // sequencer's ~1s revive window, and success-chained delivery drains jams.
+        let is_arbitrum = self
+            .delivery_network(&tx, evm_tx_data.chain_id)
+            .await
+            .is_some_and(|n| n.is_arbitrum());
 
         // Send transaction to blockchain - this is the critical operation
         // If this fails, retry is safe due to nonce idempotency
@@ -1231,10 +1239,13 @@ where
 
         let evm_data = tx.network_data.get_evm_transaction_data()?;
 
-        // Arbitrum-based networks have no mempool: resubmission needs pre-broadcast
-        // persistence, in-process nonce-too-high retries and success-chained delivery
-        // (issue #843).
-        let is_arbitrum = self.is_arbitrum_network(&tx, evm_data.chain_id).await;
+        // Issue #843 delivery gates. `lacks_mempool` (any network without a public
+        // mempool) gates pre-broadcast persistence; `is_arbitrum` gates the
+        // Nitro-specific behaviors (in-process nonce-too-high retries riding the
+        // ~1s revive window, success-chained delivery).
+        let network = self.delivery_network(&tx, evm_data.chain_id).await;
+        let is_arbitrum = network.as_ref().is_some_and(|n| n.is_arbitrum());
+        let pre_persist = network.as_ref().is_some_and(|n| n.lacks_mempool());
 
         // Calculate bumped gas price
         // For noop transactions, force_bump=true to skip gas price cap and ensure bump succeeds
@@ -1272,12 +1283,12 @@ where
             TransactionError::InvalidType("Raw transaction data is missing".to_string())
         })?;
 
-        // Persist the new attempt BEFORE broadcast (Arbitrum): any bytes that might
-        // reach the chain are recorded first, and `hashes.len()` becomes a true
-        // delivery-attempt counter (drives the rollup NOOP give-up threshold).
+        // Persist the new attempt BEFORE broadcast (no-mempool networks): any bytes
+        // that might reach the chain are recorded first, and `hashes.len()` becomes a
+        // true delivery-attempt counter (drives the rollup NOOP give-up threshold).
         let mut pre_persisted = false;
         let mut prior_network_data = None;
-        let tx = if is_arbitrum {
+        let tx = if pre_persist {
             prior_network_data = Some(tx.network_data.clone());
             let mut hashes = tx.hashes.clone();
             if let Some(hash) = final_evm_data.hash.clone() {
@@ -1760,6 +1771,18 @@ mod tests {
             Ok(Some(create_test_network_model_with_tags(vec![
                 "rollup".to_string(),
                 "arbitrum-based".to_string(),
+            ])))
+        });
+        mock_network
+    }
+
+    /// A network that lacks a mempool but is NOT Arbitrum: pre-broadcast
+    /// persistence applies, the Nitro-specific behaviors do not.
+    fn no_mempool_mock_network() -> MockNetworkRepository {
+        let mut mock_network = MockNetworkRepository::new();
+        mock_network.expect_get_by_chain_id().returning(|_, _| {
+            Ok(Some(create_test_network_model_with_tags(vec![
+                "no-mempool".to_string(),
             ])))
         });
         mock_network
@@ -5110,6 +5133,94 @@ mod tests {
         counter_service
             .expect_get()
             .returning(|_, _| Box::pin(ready(Ok(Some(43)))));
+        mock_transaction.expect_find_by_nonce().never();
+
+        let evm_transaction = EvmRelayerTransaction {
+            relayer: relayer.clone(),
+            provider: mock_provider,
+            relayer_repository: Arc::new(mock_relayer),
+            network_repository: Arc::new(mock_network),
+            transaction_repository: Arc::new(mock_transaction),
+            transaction_counter_service: Arc::new(counter_service),
+            job_producer: Arc::new(mock_job_producer),
+            price_calculator: mock_price_calculator,
+            signer: mock_signer,
+        };
+
+        let result = evm_transaction.resubmit_transaction(test_tx).await;
+        assert!(result.is_ok(), "Expected Ok, got: {result:?}");
+    }
+
+    /// ① Predicate split: a no-mempool network that is NOT Arbitrum still gets the
+    /// pre-broadcast persistence (gated on `lacks_mempool`), but none of the
+    /// Nitro-specific behaviors — no success-chained delivery.
+    #[tokio::test]
+    async fn test_resubmit_no_mempool_pre_persists_without_chain_link() {
+        let mut mock_transaction = MockTransactionRepository::new();
+        let mock_relayer = MockRelayerRepository::new();
+        let mut mock_provider = MockEvmProviderTrait::new();
+        let mut mock_signer = MockSigner::new();
+        let mock_job_producer = MockJobProducerTrait::new();
+        let mut mock_price_calculator = MockPriceCalculator::new();
+        let mut counter_service = MockTransactionCounterTrait::new();
+        let mock_network = no_mempool_mock_network();
+
+        let relayer = create_test_relayer();
+        let test_tx = create_arbitrum_resubmit_tx();
+
+        setup_arbitrum_resubmit_mocks(
+            &mut mock_price_calculator,
+            &mut mock_provider,
+            &mut mock_signer,
+        );
+
+        let mut seq = mockall::Sequence::new();
+
+        // Pre-broadcast persistence fires on lacks_mempool alone.
+        let test_tx_clone = test_tx.clone();
+        mock_transaction
+            .expect_partial_update()
+            .times(1)
+            .in_sequence(&mut seq)
+            .withf(|_, update| {
+                update.status.is_none()
+                    && update
+                        .hashes
+                        .as_ref()
+                        .is_some_and(|h| h.contains(&"0xarb_new_hash".to_string()))
+            })
+            .returning(move |_, update| {
+                let mut updated_tx = test_tx_clone.clone();
+                updated_tx.hashes = update.hashes.clone().unwrap();
+                updated_tx.network_data = update.network_data.clone().unwrap();
+                Ok(updated_tx)
+            });
+
+        mock_provider
+            .expect_send_raw_transaction()
+            .times(1)
+            .in_sequence(&mut seq)
+            .returning(|_| Box::pin(async { Ok("0xarb_new_hash".to_string()) }));
+
+        // Final update: bookkeeping only.
+        let test_tx_clone2 = test_tx.clone();
+        mock_transaction
+            .expect_partial_update()
+            .times(1)
+            .in_sequence(&mut seq)
+            .withf(|_, update| {
+                update.status == Some(TransactionStatus::Submitted)
+                    && update.hashes.is_none()
+                    && update.network_data.is_none()
+            })
+            .returning(move |_, update| {
+                let mut updated_tx = test_tx_clone2.clone();
+                updated_tx.status = update.status.clone().unwrap();
+                Ok(updated_tx)
+            });
+
+        // Not Arbitrum: no chain link.
+        counter_service.expect_get().never();
         mock_transaction.expect_find_by_nonce().never();
 
         let evm_transaction = EvmRelayerTransaction {

--- a/src/domain/transaction/evm/evm_transaction.rs
+++ b/src/domain/transaction/evm/evm_transaction.rs
@@ -397,12 +397,10 @@ where
         }
     }
 
-    /// Broadcasts raw transaction bytes, retrying the SAME bytes in-process on
-    /// "nonce too high" when the network is Arbitrum-based. The Nitro sequencer holds a
-    /// nonce-too-high tx ~1s and revives it if the predecessor lands, so short retries
-    /// absorb burst-ordering races and ride the revive window during chained drains.
-    /// These retries do not touch `nonce_too_high_retries` — escalation only happens
-    /// after they exhaust, via the caller's existing `handle_nonce_too_high` path.
+    /// Broadcasts raw transaction bytes. On Arbitrum-based networks, "nonce too high"
+    /// is retried in-process with the same bytes: the Nitro sequencer holds such a tx
+    /// ~1s and revives it if the predecessor lands. These retries do not touch
+    /// `nonce_too_high_retries`; the caller escalates after they exhaust.
     async fn send_raw_transaction_with_nonce_retry(
         &self,
         tx_id: &str,
@@ -440,12 +438,11 @@ where
         }
     }
 
-    /// Arbitrum chained delivery (issue #843): after a successful broadcast at nonce N,
-    /// immediately enqueue the submit job for a never-broadcast `Sent` tx at N+1, so a
-    /// jammed region drains at job+RPC latency instead of one tx per resubmit cycle.
-    /// Best-effort: failures only log — the status checker remains the fallback driver.
-    /// Duplicate links are safe: re-submitting already-broadcast bytes yields
-    /// `AlreadyKnown`, which is treated as success.
+    /// Arbitrum chained delivery: after a successful broadcast at nonce N, enqueue the
+    /// submit job for a never-broadcast `Sent` tx at N+1. A jammed region then drains
+    /// at job+RPC latency instead of one tx per resubmit cycle. Best-effort: failures
+    /// only log, and the status checker remains the fallback driver. Duplicate links
+    /// are safe because re-submitting already-broadcast bytes yields `AlreadyKnown`.
     pub(super) async fn enqueue_next_nonce_submit(&self, tx: &TransactionRepoModel) {
         let Ok(evm_data) = tx.network_data.get_evm_transaction_data() else {
             return;
@@ -1039,8 +1036,8 @@ where
             TransactionError::InvalidType("Raw transaction data is missing".to_string())
         })?;
 
-        // Nitro-specific (issue #843): in-process nonce-too-high retries ride the
-        // sequencer's ~1s revive window, and success-chained delivery drains jams.
+        // Nitro-specific: in-process nonce-too-high retries ride the sequencer's
+        // ~1s revive window, and success-chained delivery drains jams.
         let is_arbitrum = self
             .delivery_network(&tx, evm_tx_data.chain_id)
             .await
@@ -1239,10 +1236,9 @@ where
 
         let evm_data = tx.network_data.get_evm_transaction_data()?;
 
-        // Issue #843 delivery gates. `lacks_mempool` (any network without a public
-        // mempool) gates pre-broadcast persistence; `is_arbitrum` gates the
-        // Nitro-specific behaviors (in-process nonce-too-high retries riding the
-        // ~1s revive window, success-chained delivery).
+        // `lacks_mempool` gates pre-broadcast persistence. `is_arbitrum` gates the
+        // Nitro-specific behaviors: in-process nonce-too-high retries and
+        // success-chained delivery.
         let network = self.delivery_network(&tx, evm_data.chain_id).await;
         let is_arbitrum = network.as_ref().is_some_and(|n| n.is_arbitrum());
         let pre_persist = network.as_ref().is_some_and(|n| n.lacks_mempool());
@@ -1283,9 +1279,9 @@ where
             TransactionError::InvalidType("Raw transaction data is missing".to_string())
         })?;
 
-        // Persist the new attempt BEFORE broadcast (no-mempool networks): any bytes
-        // that might reach the chain are recorded first, and `hashes.len()` becomes a
-        // true delivery-attempt counter (drives the rollup NOOP give-up threshold).
+        // Persist the new attempt BEFORE broadcast: any bytes that might reach the
+        // chain are recorded first, and `hashes.len()` stays a true delivery-attempt
+        // counter for the rollup NOOP threshold.
         let mut pre_persisted = false;
         let mut prior_network_data = None;
         let tx = if pre_persist {
@@ -1331,10 +1327,10 @@ where
                             error_kind = ?error_kind,
                             "resubmission indicates transaction already in mempool/mined - keeping original hash"
                         );
-                        // ReplacementUnderpriced means the node rejected the
-                        // candidate bytes, so a pre-persisted network_data
-                        // points at a dead hash and must be rolled back.
-                        // AlreadyKnown keeps it: the node has the candidate.
+                        // ReplacementUnderpriced: the node rejected the candidate,
+                        // so pre-persisted network_data points at a dead hash and
+                        // must be rolled back. AlreadyKnown keeps it because the
+                        // node has the candidate.
                         restore_prior_network_data = pre_persisted
                             && matches!(error_kind, SubmissionErrorKind::ReplacementUnderpriced);
                         true
@@ -1383,9 +1379,9 @@ where
         // If transaction was already submitted, just update status without changing hash
         let update = if was_already_submitted {
             // Keep original hash and data - just ensure status is Submitted.
-            // When the pre-persisted candidate was rejected, put the prior
-            // network_data back; the candidate hash stays in `hashes` as an
-            // attempt record.
+            // If the pre-persisted candidate was rejected, restore the prior
+            // network_data. The candidate hash stays in `hashes` as an attempt
+            // record.
             TransactionUpdateRequest {
                 status: Some(TransactionStatus::Submitted),
                 metadata: metadata_reset,
@@ -4690,7 +4686,7 @@ mod tests {
         test_tx
     }
 
-    /// ② Arbitrum: "nonce too high" at broadcast is retried in-process with the same
+    /// Arbitrum: "nonce too high" at broadcast is retried in-process with the same
     /// bytes and succeeds when the sequencer revives the tx; the escalation budget
     /// (nonce_too_high_retries) is never touched.
     #[tokio::test(start_paused = true)]
@@ -4761,7 +4757,7 @@ mod tests {
         assert_eq!(result.unwrap().status, TransactionStatus::Submitted);
     }
 
-    /// ② Arbitrum: when all in-process retries exhaust, the existing escalation runs
+    /// Arbitrum: when all in-process retries exhaust, the existing escalation runs
     /// exactly once (single nonce_too_high_retries increment for 4 broadcast attempts).
     #[tokio::test(start_paused = true)]
     async fn test_submit_arbitrum_nonce_too_high_exhausts_then_escalates_once() {
@@ -4888,7 +4884,7 @@ mod tests {
             });
     }
 
-    /// ① Arbitrum: the resubmission attempt is persisted BEFORE broadcast, so when the
+    /// Arbitrum: the resubmission attempt is persisted BEFORE broadcast, so when the
     /// broadcast then fails the new hash stays recorded (true attempt counter, no
     /// phantom broadcasts).
     #[tokio::test]
@@ -4962,7 +4958,7 @@ mod tests {
         assert!(result.is_err(), "Expected broadcast error, got: {result:?}");
     }
 
-    /// ① Arbitrum: on broadcast success after pre-persistence, the final update only
+    /// Arbitrum: on broadcast success after pre-persistence, the final update only
     /// carries status/sent_at bookkeeping — the hash is not appended twice.
     #[tokio::test]
     async fn test_resubmit_arbitrum_success_does_not_append_hash_twice() {
@@ -5048,7 +5044,7 @@ mod tests {
         assert_eq!(result.unwrap().status, TransactionStatus::Submitted);
     }
 
-    /// ① Arbitrum: when the node rejects the pre-persisted candidate with
+    /// Arbitrum: when the node rejects the pre-persisted candidate with
     /// "replacement transaction underpriced", the final update restores the prior
     /// network_data (the old bytes keep the slot) while the candidate hash stays
     /// recorded in `hashes`.
@@ -5151,7 +5147,7 @@ mod tests {
         assert!(result.is_ok(), "Expected Ok, got: {result:?}");
     }
 
-    /// ① Predicate split: a no-mempool network that is NOT Arbitrum still gets the
+    /// Predicate split: a no-mempool network that is NOT Arbitrum still gets the
     /// pre-broadcast persistence (gated on `lacks_mempool`), but none of the
     /// Nitro-specific behaviors — no success-chained delivery.
     #[tokio::test]
@@ -5239,7 +5235,7 @@ mod tests {
         assert!(result.is_ok(), "Expected Ok, got: {result:?}");
     }
 
-    /// ③ Arbitrum chain link: broadcast success at nonce N enqueues a submit job for
+    /// Arbitrum chain link: broadcast success at nonce N enqueues a submit job for
     /// the never-broadcast Sent transaction at N+1.
     #[tokio::test]
     async fn test_submit_arbitrum_chain_link_enqueues_next_nonce() {
@@ -5317,7 +5313,7 @@ mod tests {
         assert!(result.is_ok(), "Expected Ok, got: {result:?}");
     }
 
-    /// ③ Arbitrum chain link: no job when the successor was already broadcast
+    /// Arbitrum chain link: no job when the successor was already broadcast
     /// (sent_at set) or when no record exists at N+1.
     #[tokio::test]
     async fn test_submit_arbitrum_chain_link_skips_broadcast_or_missing_next() {

--- a/src/domain/transaction/evm/evm_transaction.rs
+++ b/src/domain/transaction/evm/evm_transaction.rs
@@ -1276,7 +1276,9 @@ where
         // reach the chain are recorded first, and `hashes.len()` becomes a true
         // delivery-attempt counter (drives the rollup NOOP give-up threshold).
         let mut pre_persisted = false;
+        let mut prior_network_data = None;
         let tx = if is_arbitrum {
+            prior_network_data = Some(tx.network_data.clone());
             let mut hashes = tx.hashes.clone();
             if let Some(hash) = final_evm_data.hash.clone() {
                 hashes.push(hash);
@@ -1296,6 +1298,7 @@ where
         };
 
         // Send resubmitted transaction to blockchain - this is the critical operation
+        let mut restore_prior_network_data = false;
         let was_already_submitted = match self
             .send_raw_transaction_with_nonce_retry(&tx.id, raw_tx, is_arbitrum)
             .await
@@ -1317,6 +1320,12 @@ where
                             error_kind = ?error_kind,
                             "resubmission indicates transaction already in mempool/mined - keeping original hash"
                         );
+                        // ReplacementUnderpriced means the node rejected the
+                        // candidate bytes, so a pre-persisted network_data
+                        // points at a dead hash and must be rolled back.
+                        // AlreadyKnown keeps it: the node has the candidate.
+                        restore_prior_network_data = pre_persisted
+                            && matches!(error_kind, SubmissionErrorKind::ReplacementUnderpriced);
                         true
                     }
                     // NonceTooLow: nonce was consumed (possibly externally).
@@ -1362,10 +1371,18 @@ where
 
         // If transaction was already submitted, just update status without changing hash
         let update = if was_already_submitted {
-            // Keep original hash and data - just ensure status is Submitted
+            // Keep original hash and data - just ensure status is Submitted.
+            // When the pre-persisted candidate was rejected, put the prior
+            // network_data back; the candidate hash stays in `hashes` as an
+            // attempt record.
             TransactionUpdateRequest {
                 status: Some(TransactionStatus::Submitted),
                 metadata: metadata_reset,
+                network_data: if restore_prior_network_data {
+                    prior_network_data
+                } else {
+                    None
+                },
                 ..Default::default()
             }
         } else if pre_persisted {
@@ -5006,6 +5023,109 @@ mod tests {
         let result = evm_transaction.resubmit_transaction(test_tx).await;
         assert!(result.is_ok(), "Expected Ok, got: {result:?}");
         assert_eq!(result.unwrap().status, TransactionStatus::Submitted);
+    }
+
+    /// ① Arbitrum: when the node rejects the pre-persisted candidate with
+    /// "replacement transaction underpriced", the final update restores the prior
+    /// network_data (the old bytes keep the slot) while the candidate hash stays
+    /// recorded in `hashes`.
+    #[tokio::test]
+    async fn test_resubmit_arbitrum_replacement_underpriced_restores_network_data() {
+        let mut mock_transaction = MockTransactionRepository::new();
+        let mock_relayer = MockRelayerRepository::new();
+        let mut mock_provider = MockEvmProviderTrait::new();
+        let mut mock_signer = MockSigner::new();
+        let mock_job_producer = MockJobProducerTrait::new();
+        let mut mock_price_calculator = MockPriceCalculator::new();
+        let mut counter_service = MockTransactionCounterTrait::new();
+        let mock_network = arbitrum_mock_network();
+
+        let relayer = create_test_relayer();
+        let test_tx = create_arbitrum_resubmit_tx();
+
+        setup_arbitrum_resubmit_mocks(
+            &mut mock_price_calculator,
+            &mut mock_provider,
+            &mut mock_signer,
+        );
+
+        let mut seq = mockall::Sequence::new();
+
+        // Pre-broadcast persistence stores the candidate.
+        let test_tx_clone = test_tx.clone();
+        mock_transaction
+            .expect_partial_update()
+            .times(1)
+            .in_sequence(&mut seq)
+            .withf(|_, update| {
+                update.status.is_none()
+                    && update
+                        .hashes
+                        .as_ref()
+                        .is_some_and(|h| h.contains(&"0xarb_new_hash".to_string()))
+            })
+            .returning(move |_, update| {
+                let mut updated_tx = test_tx_clone.clone();
+                updated_tx.hashes = update.hashes.clone().unwrap();
+                updated_tx.network_data = update.network_data.clone().unwrap();
+                Ok(updated_tx)
+            });
+
+        // The node keeps the old bytes and rejects the candidate.
+        mock_provider
+            .expect_send_raw_transaction()
+            .times(1)
+            .in_sequence(&mut seq)
+            .returning(|_| {
+                Box::pin(async {
+                    Err(ProviderError::Other(
+                        "replacement transaction underpriced".to_string(),
+                    ))
+                })
+            });
+
+        // Final update: prior network_data restored, hashes not re-sent (the
+        // candidate stays in the history from the pre-persist).
+        let test_tx_clone2 = test_tx.clone();
+        mock_transaction
+            .expect_partial_update()
+            .times(1)
+            .in_sequence(&mut seq)
+            .withf(|_, update| {
+                update.status == Some(TransactionStatus::Submitted)
+                    && update.hashes.is_none()
+                    && update.network_data.as_ref().is_some_and(|data| {
+                        data.get_evm_transaction_data()
+                            .is_ok_and(|d| d.hash == Some("0xoriginal_hash".to_string()))
+                    })
+            })
+            .returning(move |_, update| {
+                let mut updated_tx = test_tx_clone2.clone();
+                updated_tx.status = update.status.clone().unwrap();
+                updated_tx.network_data = update.network_data.clone().unwrap();
+                Ok(updated_tx)
+            });
+
+        // Chain link: no successor allocated.
+        counter_service
+            .expect_get()
+            .returning(|_, _| Box::pin(ready(Ok(Some(43)))));
+        mock_transaction.expect_find_by_nonce().never();
+
+        let evm_transaction = EvmRelayerTransaction {
+            relayer: relayer.clone(),
+            provider: mock_provider,
+            relayer_repository: Arc::new(mock_relayer),
+            network_repository: Arc::new(mock_network),
+            transaction_repository: Arc::new(mock_transaction),
+            transaction_counter_service: Arc::new(counter_service),
+            job_producer: Arc::new(mock_job_producer),
+            price_calculator: mock_price_calculator,
+            signer: mock_signer,
+        };
+
+        let result = evm_transaction.resubmit_transaction(test_tx).await;
+        assert!(result.is_ok(), "Expected Ok, got: {result:?}");
     }
 
     /// ③ Arbitrum chain link: broadcast success at nonce N enqueues a submit job for

--- a/src/domain/transaction/evm/evm_transaction.rs
+++ b/src/domain/transaction/evm/evm_transaction.rs
@@ -4636,4 +4636,529 @@ mod tests {
         // Status should remain Submitted (unchanged)
         assert_eq!(returned_tx.status, TransactionStatus::Submitted);
     }
+
+    /// Helper: a Sent test transaction with nonce 42 and raw bytes, ready to submit.
+    fn create_arbitrum_submit_tx() -> TransactionRepoModel {
+        let mut test_tx = create_test_transaction();
+        test_tx.status = TransactionStatus::Sent;
+        test_tx.network_data = NetworkTransactionData::Evm(EvmTransactionData {
+            nonce: Some(42),
+            hash: Some("0xhash".to_string()),
+            raw: Some(vec![1, 2, 3]),
+            ..test_tx.network_data.get_evm_transaction_data().unwrap()
+        });
+        test_tx
+    }
+
+    /// ② Arbitrum: "nonce too high" at broadcast is retried in-process with the same
+    /// bytes and succeeds when the sequencer revives the tx; the escalation budget
+    /// (nonce_too_high_retries) is never touched.
+    #[tokio::test(start_paused = true)]
+    async fn test_submit_arbitrum_nonce_too_high_inprocess_retry_succeeds() {
+        let mut mock_transaction = MockTransactionRepository::new();
+        let mock_relayer = MockRelayerRepository::new();
+        let mut mock_provider = MockEvmProviderTrait::new();
+        let mock_signer = MockSigner::new();
+        let mut mock_job_producer = MockJobProducerTrait::new();
+        let mock_price_calculator = MockPriceCalculator::new();
+        let mut counter_service = MockTransactionCounterTrait::new();
+        let mock_network = arbitrum_mock_network();
+
+        let relayer = create_test_relayer();
+        let test_tx = create_arbitrum_submit_tx();
+
+        // First two broadcasts hit the sequencer's nonce-failure window, third lands.
+        mock_provider
+            .expect_send_raw_transaction()
+            .times(2)
+            .returning(|_| {
+                Box::pin(async { Err(ProviderError::Other("nonce too high".to_string())) })
+            });
+        mock_provider
+            .expect_send_raw_transaction()
+            .times(1)
+            .returning(|_| Box::pin(async { Ok("0xhash".to_string()) }));
+
+        // Success bookkeeping only — no nonce_too_high_retries increment.
+        let test_tx_clone = test_tx.clone();
+        mock_transaction
+            .expect_partial_update()
+            .times(1)
+            .withf(|_, update| {
+                update.status == Some(TransactionStatus::Submitted) && update.metadata.is_none()
+            })
+            .returning(move |_, update| {
+                let mut updated_tx = test_tx_clone.clone();
+                updated_tx.status = update.status.clone().unwrap();
+                updated_tx.sent_at = update.sent_at.clone();
+                Ok(updated_tx)
+            });
+
+        // Chain link: counter == nonce + 1 → no successor allocated, nothing to enqueue.
+        counter_service
+            .expect_get()
+            .returning(|_, _| Box::pin(ready(Ok(Some(43)))));
+        mock_transaction.expect_find_by_nonce().never();
+
+        mock_job_producer
+            .expect_produce_send_notification_job()
+            .returning(|_, _| Box::pin(ready(Ok(()))));
+
+        let evm_transaction = EvmRelayerTransaction {
+            relayer: relayer.clone(),
+            provider: mock_provider,
+            relayer_repository: Arc::new(mock_relayer),
+            network_repository: Arc::new(mock_network),
+            transaction_repository: Arc::new(mock_transaction),
+            transaction_counter_service: Arc::new(counter_service),
+            job_producer: Arc::new(mock_job_producer),
+            price_calculator: mock_price_calculator,
+            signer: mock_signer,
+        };
+
+        let result = evm_transaction.submit_transaction(test_tx).await;
+        assert!(result.is_ok(), "Expected Ok after revive, got: {result:?}");
+        assert_eq!(result.unwrap().status, TransactionStatus::Submitted);
+    }
+
+    /// ② Arbitrum: when all in-process retries exhaust, the existing escalation runs
+    /// exactly once (single nonce_too_high_retries increment for 4 broadcast attempts).
+    #[tokio::test(start_paused = true)]
+    async fn test_submit_arbitrum_nonce_too_high_exhausts_then_escalates_once() {
+        let mut mock_transaction = MockTransactionRepository::new();
+        let mock_relayer = MockRelayerRepository::new();
+        let mut mock_provider = MockEvmProviderTrait::new();
+        let mock_signer = MockSigner::new();
+        let mock_job_producer = MockJobProducerTrait::new();
+        let mock_price_calculator = MockPriceCalculator::new();
+        let mut counter_service = MockTransactionCounterTrait::new();
+        let mock_network = arbitrum_mock_network();
+
+        let relayer = create_test_relayer();
+        let mut test_tx = create_arbitrum_submit_tx();
+        test_tx.metadata = Some(crate::models::TransactionMetadata {
+            nonce_too_high_retries: 0,
+            ..Default::default()
+        });
+
+        // Initial attempt + ARBITRUM_NONCE_TOO_HIGH_INPROCESS_RETRIES retries, all rejected.
+        mock_provider
+            .expect_send_raw_transaction()
+            .times(4)
+            .returning(|_| {
+                Box::pin(async { Err(ProviderError::Other("nonce too high".to_string())) })
+            });
+
+        // Exactly one escalation: nonce_too_high_retries goes 0 → 1.
+        let test_tx_clone = test_tx.clone();
+        mock_transaction
+            .expect_partial_update()
+            .times(1)
+            .withf(|_, update| {
+                update
+                    .metadata
+                    .as_ref()
+                    .map(|m| m.nonce_too_high_retries == 1)
+                    .unwrap_or(false)
+            })
+            .returning(move |_, _| Ok(test_tx_clone.clone()));
+
+        // No success path: no chain link, no notification.
+        counter_service.expect_get().never();
+
+        let evm_transaction = EvmRelayerTransaction {
+            relayer: relayer.clone(),
+            provider: mock_provider,
+            relayer_repository: Arc::new(mock_relayer),
+            network_repository: Arc::new(mock_network),
+            transaction_repository: Arc::new(mock_transaction),
+            transaction_counter_service: Arc::new(counter_service),
+            job_producer: Arc::new(mock_job_producer),
+            price_calculator: mock_price_calculator,
+            signer: mock_signer,
+        };
+
+        let result = evm_transaction.submit_transaction(test_tx).await;
+        assert!(
+            result.is_ok(),
+            "Expected Ok (no Dead Queue), got: {result:?}"
+        );
+        // Status unchanged — the status checker owns the next step.
+        assert_eq!(result.unwrap().status, TransactionStatus::Sent);
+    }
+
+    /// Helper: a Submitted test transaction ready for resubmission on Arbitrum,
+    /// with one prior hash and nonce 42.
+    fn create_arbitrum_resubmit_tx() -> TransactionRepoModel {
+        let mut test_tx = create_test_transaction();
+        test_tx.status = TransactionStatus::Submitted;
+        test_tx.sent_at = Some(Utc::now().to_rfc3339());
+        test_tx.network_data = NetworkTransactionData::Evm(EvmTransactionData {
+            nonce: Some(42),
+            hash: Some("0xoriginal_hash".to_string()),
+            raw: Some(vec![1, 2, 3]),
+            ..test_tx.network_data.get_evm_transaction_data().unwrap()
+        });
+        test_tx.hashes = vec!["0xoriginal_hash".to_string()];
+        test_tx
+    }
+
+    /// Sets up the price-calculator, balance and signer mocks shared by the
+    /// Arbitrum resubmit tests. The signer produces hash "0xarb_new_hash".
+    fn setup_arbitrum_resubmit_mocks(
+        mock_price_calculator: &mut MockPriceCalculator,
+        mock_provider: &mut MockEvmProviderTrait,
+        mock_signer: &mut MockSigner,
+    ) {
+        mock_price_calculator
+            .expect_calculate_bumped_gas_price()
+            .times(1)
+            .returning(|_, _, _| {
+                Ok(PriceParams {
+                    gas_price: Some(25000000000),
+                    max_fee_per_gas: None,
+                    max_priority_fee_per_gas: None,
+                    is_min_bumped: Some(true),
+                    extra_fee: None,
+                    total_cost: U256::from(525000000000000u64),
+                })
+            });
+        mock_provider
+            .expect_get_balance()
+            .times(1)
+            .returning(|_| Box::pin(async { Ok(U256::from(1000000000000000000u64)) }));
+        mock_signer
+            .expect_sign_transaction()
+            .times(1)
+            .returning(|_| {
+                Box::pin(ready(Ok(
+                    crate::domain::relayer::SignTransactionResponse::Evm(
+                        crate::domain::relayer::SignTransactionResponseEvm {
+                            hash: "0xarb_new_hash".to_string(),
+                            signature: crate::models::EvmTransactionDataSignature {
+                                r: "r".to_string(),
+                                s: "s".to_string(),
+                                v: 1,
+                                sig: "0xsignature".to_string(),
+                            },
+                            raw: vec![4, 5, 6],
+                        },
+                    ),
+                )))
+            });
+    }
+
+    /// ① Arbitrum: the resubmission attempt is persisted BEFORE broadcast, so when the
+    /// broadcast then fails the new hash stays recorded (true attempt counter, no
+    /// phantom broadcasts).
+    #[tokio::test]
+    async fn test_resubmit_arbitrum_persists_attempt_before_broadcast() {
+        let mut mock_transaction = MockTransactionRepository::new();
+        let mock_relayer = MockRelayerRepository::new();
+        let mut mock_provider = MockEvmProviderTrait::new();
+        let mut mock_signer = MockSigner::new();
+        let mock_job_producer = MockJobProducerTrait::new();
+        let mut mock_price_calculator = MockPriceCalculator::new();
+        let counter_service = MockTransactionCounterTrait::new();
+        let mock_network = arbitrum_mock_network();
+
+        let relayer = create_test_relayer();
+        let test_tx = create_arbitrum_resubmit_tx();
+
+        setup_arbitrum_resubmit_mocks(
+            &mut mock_price_calculator,
+            &mut mock_provider,
+            &mut mock_signer,
+        );
+
+        let mut seq = mockall::Sequence::new();
+
+        // Pre-broadcast persistence: new hash appended, network data updated, no
+        // status change yet.
+        let test_tx_clone = test_tx.clone();
+        mock_transaction
+            .expect_partial_update()
+            .times(1)
+            .in_sequence(&mut seq)
+            .withf(|_, update| {
+                update.status.is_none()
+                    && update.network_data.is_some()
+                    && update
+                        .hashes
+                        .as_ref()
+                        .is_some_and(|h| h.contains(&"0xarb_new_hash".to_string()))
+            })
+            .returning(move |_, update| {
+                let mut updated_tx = test_tx_clone.clone();
+                updated_tx.hashes = update.hashes.clone().unwrap();
+                updated_tx.network_data = update.network_data.clone().unwrap();
+                Ok(updated_tx)
+            });
+
+        // Broadcast happens after persistence and fails with a non-nonce error.
+        mock_provider
+            .expect_send_raw_transaction()
+            .times(1)
+            .in_sequence(&mut seq)
+            .returning(|_| {
+                Box::pin(async { Err(ProviderError::Other("execution reverted".to_string())) })
+            });
+
+        let evm_transaction = EvmRelayerTransaction {
+            relayer: relayer.clone(),
+            provider: mock_provider,
+            relayer_repository: Arc::new(mock_relayer),
+            network_repository: Arc::new(mock_network),
+            transaction_repository: Arc::new(mock_transaction),
+            transaction_counter_service: Arc::new(counter_service),
+            job_producer: Arc::new(mock_job_producer),
+            price_calculator: mock_price_calculator,
+            signer: mock_signer,
+        };
+
+        // The broadcast error propagates, but the hash was already recorded — mockall
+        // verifies the persist-before-broadcast ordering and that no rollback happened.
+        let result = evm_transaction.resubmit_transaction(test_tx).await;
+        assert!(result.is_err(), "Expected broadcast error, got: {result:?}");
+    }
+
+    /// ① Arbitrum: on broadcast success after pre-persistence, the final update only
+    /// carries status/sent_at bookkeeping — the hash is not appended twice.
+    #[tokio::test]
+    async fn test_resubmit_arbitrum_success_does_not_append_hash_twice() {
+        let mut mock_transaction = MockTransactionRepository::new();
+        let mock_relayer = MockRelayerRepository::new();
+        let mut mock_provider = MockEvmProviderTrait::new();
+        let mut mock_signer = MockSigner::new();
+        let mock_job_producer = MockJobProducerTrait::new();
+        let mut mock_price_calculator = MockPriceCalculator::new();
+        let mut counter_service = MockTransactionCounterTrait::new();
+        let mock_network = arbitrum_mock_network();
+
+        let relayer = create_test_relayer();
+        let test_tx = create_arbitrum_resubmit_tx();
+
+        setup_arbitrum_resubmit_mocks(
+            &mut mock_price_calculator,
+            &mut mock_provider,
+            &mut mock_signer,
+        );
+
+        let mut seq = mockall::Sequence::new();
+
+        // Pre-broadcast persistence.
+        let test_tx_clone = test_tx.clone();
+        mock_transaction
+            .expect_partial_update()
+            .times(1)
+            .in_sequence(&mut seq)
+            .withf(|_, update| update.status.is_none() && update.hashes.is_some())
+            .returning(move |_, update| {
+                let mut updated_tx = test_tx_clone.clone();
+                updated_tx.hashes = update.hashes.clone().unwrap();
+                updated_tx.network_data = update.network_data.clone().unwrap();
+                Ok(updated_tx)
+            });
+
+        mock_provider
+            .expect_send_raw_transaction()
+            .times(1)
+            .in_sequence(&mut seq)
+            .returning(|_| Box::pin(async { Ok("0xarb_new_hash".to_string()) }));
+
+        // Final update: bookkeeping only — hashes and network_data must not be re-sent.
+        let test_tx_clone2 = test_tx.clone();
+        mock_transaction
+            .expect_partial_update()
+            .times(1)
+            .in_sequence(&mut seq)
+            .withf(|_, update| {
+                update.status == Some(TransactionStatus::Submitted)
+                    && update.sent_at.is_some()
+                    && update.hashes.is_none()
+                    && update.network_data.is_none()
+            })
+            .returning(move |_, update| {
+                let mut updated_tx = test_tx_clone2.clone();
+                updated_tx.status = update.status.clone().unwrap();
+                updated_tx.sent_at = update.sent_at.clone();
+                Ok(updated_tx)
+            });
+
+        // Chain link: no successor allocated.
+        counter_service
+            .expect_get()
+            .returning(|_, _| Box::pin(ready(Ok(Some(43)))));
+        mock_transaction.expect_find_by_nonce().never();
+
+        let evm_transaction = EvmRelayerTransaction {
+            relayer: relayer.clone(),
+            provider: mock_provider,
+            relayer_repository: Arc::new(mock_relayer),
+            network_repository: Arc::new(mock_network),
+            transaction_repository: Arc::new(mock_transaction),
+            transaction_counter_service: Arc::new(counter_service),
+            job_producer: Arc::new(mock_job_producer),
+            price_calculator: mock_price_calculator,
+            signer: mock_signer,
+        };
+
+        let result = evm_transaction.resubmit_transaction(test_tx).await;
+        assert!(result.is_ok(), "Expected Ok, got: {result:?}");
+        assert_eq!(result.unwrap().status, TransactionStatus::Submitted);
+    }
+
+    /// ③ Arbitrum chain link: broadcast success at nonce N enqueues a submit job for
+    /// the never-broadcast Sent transaction at N+1.
+    #[tokio::test]
+    async fn test_submit_arbitrum_chain_link_enqueues_next_nonce() {
+        let mut mock_transaction = MockTransactionRepository::new();
+        let mock_relayer = MockRelayerRepository::new();
+        let mut mock_provider = MockEvmProviderTrait::new();
+        let mock_signer = MockSigner::new();
+        let mut mock_job_producer = MockJobProducerTrait::new();
+        let mock_price_calculator = MockPriceCalculator::new();
+        let mut counter_service = MockTransactionCounterTrait::new();
+        let mock_network = arbitrum_mock_network();
+
+        let relayer = create_test_relayer();
+        let test_tx = create_arbitrum_submit_tx();
+
+        mock_provider
+            .expect_send_raw_transaction()
+            .times(1)
+            .returning(|_| Box::pin(async { Ok("0xhash".to_string()) }));
+
+        let test_tx_clone = test_tx.clone();
+        mock_transaction
+            .expect_partial_update()
+            .times(1)
+            .returning(move |_, update| {
+                let mut updated_tx = test_tx_clone.clone();
+                updated_tx.status = update.status.clone().unwrap();
+                updated_tx.sent_at = update.sent_at.clone();
+                Ok(updated_tx)
+            });
+
+        // Successors are allocated up to nonce 49.
+        counter_service
+            .expect_get()
+            .returning(|_, _| Box::pin(ready(Ok(Some(50)))));
+
+        // Nonce 43 holds a Sent, never-broadcast transaction.
+        let mut next_tx = create_arbitrum_submit_tx();
+        next_tx.id = "next-tx-id".to_string();
+        next_tx.sent_at = None;
+        next_tx.network_data = NetworkTransactionData::Evm(EvmTransactionData {
+            nonce: Some(43),
+            ..next_tx.network_data.get_evm_transaction_data().unwrap()
+        });
+        mock_transaction
+            .expect_find_by_nonce()
+            .times(1)
+            .withf(|relayer_id, nonce| relayer_id == "test-relayer-id" && *nonce == 43)
+            .returning(move |_, _| Ok(Some(next_tx.clone())));
+
+        // The chain link enqueues the successor's submit job.
+        mock_job_producer
+            .expect_produce_submit_transaction_job()
+            .times(1)
+            .withf(|job, _| job.transaction_id == "next-tx-id")
+            .returning(|_, _| Box::pin(ready(Ok(()))));
+
+        mock_job_producer
+            .expect_produce_send_notification_job()
+            .returning(|_, _| Box::pin(ready(Ok(()))));
+
+        let evm_transaction = EvmRelayerTransaction {
+            relayer: relayer.clone(),
+            provider: mock_provider,
+            relayer_repository: Arc::new(mock_relayer),
+            network_repository: Arc::new(mock_network),
+            transaction_repository: Arc::new(mock_transaction),
+            transaction_counter_service: Arc::new(counter_service),
+            job_producer: Arc::new(mock_job_producer),
+            price_calculator: mock_price_calculator,
+            signer: mock_signer,
+        };
+
+        let result = evm_transaction.submit_transaction(test_tx).await;
+        assert!(result.is_ok(), "Expected Ok, got: {result:?}");
+    }
+
+    /// ③ Arbitrum chain link: no job when the successor was already broadcast
+    /// (sent_at set) or when no record exists at N+1.
+    #[tokio::test]
+    async fn test_submit_arbitrum_chain_link_skips_broadcast_or_missing_next() {
+        for next_record in [
+            // Already broadcast → skip.
+            Some({
+                let mut next_tx = create_arbitrum_submit_tx();
+                next_tx.id = "next-tx-id".to_string();
+                next_tx.sent_at = Some(Utc::now().to_rfc3339());
+                next_tx
+            }),
+            // Missing record → skip.
+            None,
+        ] {
+            let mut mock_transaction = MockTransactionRepository::new();
+            let mock_relayer = MockRelayerRepository::new();
+            let mut mock_provider = MockEvmProviderTrait::new();
+            let mock_signer = MockSigner::new();
+            let mut mock_job_producer = MockJobProducerTrait::new();
+            let mock_price_calculator = MockPriceCalculator::new();
+            let mut counter_service = MockTransactionCounterTrait::new();
+            let mock_network = arbitrum_mock_network();
+
+            let relayer = create_test_relayer();
+            let test_tx = create_arbitrum_submit_tx();
+
+            mock_provider
+                .expect_send_raw_transaction()
+                .times(1)
+                .returning(|_| Box::pin(async { Ok("0xhash".to_string()) }));
+
+            let test_tx_clone = test_tx.clone();
+            mock_transaction
+                .expect_partial_update()
+                .times(1)
+                .returning(move |_, update| {
+                    let mut updated_tx = test_tx_clone.clone();
+                    updated_tx.status = update.status.clone().unwrap();
+                    Ok(updated_tx)
+                });
+
+            counter_service
+                .expect_get()
+                .returning(|_, _| Box::pin(ready(Ok(Some(50)))));
+
+            mock_transaction
+                .expect_find_by_nonce()
+                .times(1)
+                .returning(move |_, _| Ok(next_record.clone()));
+
+            // No successor submit job may be produced.
+            mock_job_producer
+                .expect_produce_submit_transaction_job()
+                .never();
+            mock_job_producer
+                .expect_produce_send_notification_job()
+                .returning(|_, _| Box::pin(ready(Ok(()))));
+
+            let evm_transaction = EvmRelayerTransaction {
+                relayer: relayer.clone(),
+                provider: mock_provider,
+                relayer_repository: Arc::new(mock_relayer),
+                network_repository: Arc::new(mock_network),
+                transaction_repository: Arc::new(mock_transaction),
+                transaction_counter_service: Arc::new(counter_service),
+                job_producer: Arc::new(mock_job_producer),
+                price_calculator: mock_price_calculator,
+                signer: mock_signer,
+            };
+
+            let result = evm_transaction.submit_transaction(test_tx).await;
+            assert!(result.is_ok(), "Expected Ok, got: {result:?}");
+        }
+    }
 }

--- a/src/domain/transaction/evm/evm_transaction.rs
+++ b/src/domain/transaction/evm/evm_transaction.rs
@@ -12,8 +12,10 @@ use tracing::{debug, error, info, warn};
 
 use crate::{
     constants::{
-        matches_known_transaction, ALREADY_SUBMITTED_PATTERNS, DEFAULT_EVM_GAS_LIMIT_ESTIMATION,
-        GAS_LIMIT_BUFFER_MULTIPLIER, MAX_NONCE_TOO_HIGH_RETRIES, NONCE_TOO_HIGH_PATTERNS,
+        matches_known_transaction, ALREADY_SUBMITTED_PATTERNS,
+        ARBITRUM_NONCE_TOO_HIGH_INPROCESS_RETRIES, ARBITRUM_NONCE_TOO_HIGH_RETRY_DELAY_MS,
+        DEFAULT_EVM_GAS_LIMIT_ESTIMATION, GAS_LIMIT_BUFFER_MULTIPLIER, MAX_NONCE_TOO_HIGH_RETRIES,
+        NONCE_TOO_HIGH_PATTERNS,
     },
     domain::{
         evm::is_noop,
@@ -40,7 +42,7 @@ use crate::{
     },
     services::{
         gas::evm_gas_price::EvmGasPriceService,
-        provider::{EvmProvider, EvmProviderTrait},
+        provider::{EvmProvider, EvmProviderTrait, ProviderError},
         signer::{EvmSigner, Signer},
     },
     utils::{calculate_scheduled_timestamp, get_evm_default_gas_limit_for_tx},
@@ -352,6 +354,145 @@ where
                 new_count,
                 MAX_NONCE_TOO_HIGH_RETRIES
             );
+        }
+    }
+
+    /// Loads the `EvmNetwork` for a chain id from the network repository.
+    pub(super) async fn get_evm_network(
+        &self,
+        chain_id: u64,
+    ) -> Result<EvmNetwork, TransactionError> {
+        let network_model = self
+            .network_repository
+            .get_by_chain_id(NetworkType::Evm, chain_id)
+            .await?
+            .ok_or(TransactionError::UnexpectedError(format!(
+                "Network with chain id {chain_id} not found"
+            )))?;
+        EvmNetwork::try_from(network_model).map_err(|e| {
+            TransactionError::UnexpectedError(format!(
+                "Error converting network model to EvmNetwork: {e}"
+            ))
+        })
+    }
+
+    /// Returns whether the tx's network is Arbitrum-based. Lookup failures return
+    /// `false` so the default (non-Arbitrum) submission behavior is preserved.
+    async fn is_arbitrum_network(&self, tx: &TransactionRepoModel, chain_id: u64) -> bool {
+        match self.get_evm_network(chain_id).await {
+            Ok(network) => network.is_arbitrum(),
+            Err(e) => {
+                warn!(
+                    tx_id = %tx.id,
+                    error = %e,
+                    "failed to load network; assuming non-Arbitrum submission behavior"
+                );
+                false
+            }
+        }
+    }
+
+    /// Broadcasts raw transaction bytes, retrying the SAME bytes in-process on
+    /// "nonce too high" when the network is Arbitrum-based. The Nitro sequencer holds a
+    /// nonce-too-high tx ~1s and revives it if the predecessor lands, so short retries
+    /// absorb burst-ordering races and ride the revive window during chained drains.
+    /// These retries do not touch `nonce_too_high_retries` — escalation only happens
+    /// after they exhaust, via the caller's existing `handle_nonce_too_high` path.
+    async fn send_raw_transaction_with_nonce_retry(
+        &self,
+        tx_id: &str,
+        raw_tx: &[u8],
+        is_arbitrum: bool,
+    ) -> Result<String, ProviderError> {
+        let mut retries_left = if is_arbitrum {
+            ARBITRUM_NONCE_TOO_HIGH_INPROCESS_RETRIES
+        } else {
+            0
+        };
+        loop {
+            match self.provider.send_raw_transaction(raw_tx).await {
+                Ok(result) => return Ok(result),
+                Err(e) => {
+                    if retries_left > 0
+                        && Self::classify_submission_error(&e) == SubmissionErrorKind::NonceTooHigh
+                    {
+                        retries_left -= 1;
+                        info!(
+                            tx_id = %tx_id,
+                            retries_left = retries_left,
+                            error = %e,
+                            "nonce too high at broadcast; retrying in-process to ride the sequencer revive window"
+                        );
+                        tokio::time::sleep(std::time::Duration::from_millis(
+                            ARBITRUM_NONCE_TOO_HIGH_RETRY_DELAY_MS,
+                        ))
+                        .await;
+                        continue;
+                    }
+                    return Err(e);
+                }
+            }
+        }
+    }
+
+    /// Arbitrum chained delivery (issue #843): after a successful broadcast at nonce N,
+    /// immediately enqueue the submit job for a never-broadcast `Sent` tx at N+1, so a
+    /// jammed region drains at job+RPC latency instead of one tx per resubmit cycle.
+    /// Best-effort: failures only log — the status checker remains the fallback driver.
+    /// Duplicate links are safe: re-submitting already-broadcast bytes yields
+    /// `AlreadyKnown`, which is treated as success.
+    pub(super) async fn enqueue_next_nonce_submit(&self, tx: &TransactionRepoModel) {
+        let Ok(evm_data) = tx.network_data.get_evm_transaction_data() else {
+            return;
+        };
+        let Some(nonce) = evm_data.nonce else {
+            return;
+        };
+
+        let counter = match self
+            .transaction_counter_service
+            .get(&self.relayer.id, &self.relayer.address)
+            .await
+        {
+            Ok(Some(counter)) => counter,
+            Ok(None) => return,
+            Err(e) => {
+                debug!(tx_id = %tx.id, error = %e, "chain link: failed to read nonce counter");
+                return;
+            }
+        };
+
+        // The counter is the next unallocated nonce — no successor exists at N+1.
+        if counter <= nonce + 1 {
+            return;
+        }
+
+        match self
+            .transaction_repository
+            .find_by_nonce(&tx.relayer_id, nonce + 1)
+            .await
+        {
+            Ok(Some(next_tx))
+                if next_tx.status == TransactionStatus::Sent && next_tx.sent_at.is_none() =>
+            {
+                info!(
+                    relayer_id = %tx.relayer_id,
+                    next_nonce = nonce + 1,
+                    next_tx_id = %next_tx.id,
+                    "drain chain advanced: enqueueing submit for next nonce"
+                );
+                if let Err(e) = self.send_transaction_submit_job(&next_tx).await {
+                    warn!(
+                        tx_id = %next_tx.id,
+                        error = %e,
+                        "chain link: failed to enqueue submit job for next nonce"
+                    );
+                }
+            }
+            Ok(_) => {}
+            Err(e) => {
+                debug!(tx_id = %tx.id, error = %e, "chain link: find_by_nonce lookup failed");
+            }
         }
     }
 
@@ -893,9 +1034,16 @@ where
             TransactionError::InvalidType("Raw transaction data is missing".to_string())
         })?;
 
+        // Arbitrum-based networks have no mempool: broadcast needs in-process
+        // nonce-too-high retries and success-chained delivery (issue #843).
+        let is_arbitrum = self.is_arbitrum_network(&tx, evm_tx_data.chain_id).await;
+
         // Send transaction to blockchain - this is the critical operation
         // If this fails, retry is safe due to nonce idempotency
-        match self.provider.send_raw_transaction(raw_tx).await {
+        match self
+            .send_raw_transaction_with_nonce_retry(&tx.id, raw_tx, is_arbitrum)
+            .await
+        {
             Ok(_) => {
                 // Transaction submitted successfully
             }
@@ -1012,6 +1160,11 @@ where
             }
         };
 
+        // Chained delivery: a successful broadcast may unblock the next allocated nonce.
+        if is_arbitrum {
+            self.enqueue_next_nonce_submit(&updated_tx).await;
+        }
+
         if let Err(e) = self.send_transaction_update_notification(&updated_tx).await {
             error!(
                 tx_id = %updated_tx.id,
@@ -1078,6 +1231,11 @@ where
 
         let evm_data = tx.network_data.get_evm_transaction_data()?;
 
+        // Arbitrum-based networks have no mempool: resubmission needs pre-broadcast
+        // persistence, in-process nonce-too-high retries and success-chained delivery
+        // (issue #843).
+        let is_arbitrum = self.is_arbitrum_network(&tx, evm_data.chain_id).await;
+
         // Calculate bumped gas price
         // For noop transactions, force_bump=true to skip gas price cap and ensure bump succeeds
         let bumped_price_params = self
@@ -1114,8 +1272,34 @@ where
             TransactionError::InvalidType("Raw transaction data is missing".to_string())
         })?;
 
+        // Persist the new attempt BEFORE broadcast (Arbitrum): any bytes that might
+        // reach the chain are recorded first, and `hashes.len()` becomes a true
+        // delivery-attempt counter (drives the rollup NOOP give-up threshold).
+        let mut pre_persisted = false;
+        let tx = if is_arbitrum {
+            let mut hashes = tx.hashes.clone();
+            if let Some(hash) = final_evm_data.hash.clone() {
+                hashes.push(hash);
+            }
+            let pre_broadcast_update = TransactionUpdateRequest {
+                network_data: Some(NetworkTransactionData::Evm(final_evm_data.clone())),
+                hashes: Some(hashes),
+                priced_at: Some(Utc::now().to_rfc3339()),
+                ..Default::default()
+            };
+            pre_persisted = true;
+            self.transaction_repository
+                .partial_update(tx.id.clone(), pre_broadcast_update)
+                .await?
+        } else {
+            tx
+        };
+
         // Send resubmitted transaction to blockchain - this is the critical operation
-        let was_already_submitted = match self.provider.send_raw_transaction(raw_tx).await {
+        let was_already_submitted = match self
+            .send_raw_transaction_with_nonce_retry(&tx.id, raw_tx, is_arbitrum)
+            .await
+        {
             Ok(_) => {
                 // Transaction resubmitted successfully with new pricing
                 false
@@ -1184,6 +1368,15 @@ where
                 metadata: metadata_reset,
                 ..Default::default()
             }
+        } else if pre_persisted {
+            // New hash, network_data and priced_at were persisted before broadcast;
+            // only the delivery bookkeeping remains.
+            TransactionUpdateRequest {
+                status: Some(TransactionStatus::Submitted),
+                sent_at: Some(Utc::now().to_rfc3339()),
+                metadata: metadata_reset,
+                ..Default::default()
+            }
         } else {
             // Transaction resubmitted successfully - update with new hash and pricing
             let mut hashes = tx.hashes.clone();
@@ -1218,6 +1411,11 @@ where
                 tx
             }
         };
+
+        // Chained delivery: a successful broadcast may unblock the next allocated nonce.
+        if is_arbitrum {
+            self.enqueue_next_nonce_submit(&updated_tx).await;
+        }
 
         Ok(updated_tx)
     }
@@ -1466,11 +1664,12 @@ mod tests {
 
     use super::*;
     use crate::{
+        config::{EvmNetworkConfig, NetworkConfigCommon},
         domain::evm::price_calculator::PriceParams,
         jobs::MockJobProducerTrait,
         models::{
-            evm::Speed, EvmTransactionData, EvmTransactionRequest, NetworkType,
-            RelayerNetworkPolicy, U256,
+            evm::Speed, EvmTransactionData, EvmTransactionRequest, NetworkConfigData, NetworkType,
+            RelayerNetworkPolicy, RpcConfig, U256,
         },
         repositories::{
             MockNetworkRepository, MockRelayerRepository, MockTransactionCounterTrait,
@@ -1500,6 +1699,53 @@ mod tests {
                 force_bump: bool,
             ) -> Result<PriceParams, TransactionError>;
         }
+    }
+
+    /// Creates a NetworkRepoModel for chain_id 1; `tags` controls rollup/arbitrum gating.
+    fn create_test_network_model_with_tags(tags: Vec<String>) -> NetworkRepoModel {
+        let evm_config = EvmNetworkConfig {
+            common: NetworkConfigCommon {
+                network: "testnet".to_string(),
+                from: None,
+                rpc_urls: Some(vec![RpcConfig::new("https://rpc.example.com".to_string())]),
+                explorer_urls: Some(vec!["https://explorer.example.com".to_string()]),
+                average_blocktime_ms: Some(12000),
+                is_testnet: Some(false),
+                tags: Some(tags),
+            },
+            chain_id: Some(1),
+            required_confirmations: Some(12),
+            features: Some(vec!["eip1559".to_string()]),
+            symbol: Some("ETH".to_string()),
+            gas_price_cache: None,
+        };
+        NetworkRepoModel {
+            id: "evm:testnet".to_string(),
+            name: "testnet".to_string(),
+            network_type: NetworkType::Evm,
+            config: NetworkConfigData::Evm(evm_config),
+        }
+    }
+
+    /// MockNetworkRepository resolving any chain id to a plain (non-rollup) network.
+    fn default_mock_network() -> MockNetworkRepository {
+        let mut mock_network = MockNetworkRepository::new();
+        mock_network
+            .expect_get_by_chain_id()
+            .returning(|_, _| Ok(Some(create_test_network_model_with_tags(vec![]))));
+        mock_network
+    }
+
+    /// MockNetworkRepository resolving any chain id to an Arbitrum-based rollup network.
+    fn arbitrum_mock_network() -> MockNetworkRepository {
+        let mut mock_network = MockNetworkRepository::new();
+        mock_network.expect_get_by_chain_id().returning(|_, _| {
+            Ok(Some(create_test_network_model_with_tags(vec![
+                "rollup".to_string(),
+                "arbitrum-based".to_string(),
+            ])))
+        });
+        mock_network
     }
 
     // Helper to create a relayer model with specific configuration for these tests
@@ -1658,7 +1904,7 @@ mod tests {
             .expect_produce_send_notification_job()
             .returning(|_, _| Box::pin(ready(Ok(()))));
 
-        let mock_network = MockNetworkRepository::new();
+        let mock_network = default_mock_network();
 
         let evm_transaction = EvmRelayerTransaction {
             relayer: relayer.clone(),
@@ -1765,7 +2011,7 @@ mod tests {
             .expect_produce_send_notification_job()
             .returning(|_, _| Box::pin(ready(Ok(()))));
 
-        let mock_network = MockNetworkRepository::new();
+        let mock_network = default_mock_network();
 
         let evm_transaction = EvmRelayerTransaction {
             relayer: relayer.clone(),
@@ -1869,7 +2115,7 @@ mod tests {
             .expect_produce_send_notification_job()
             .returning(|_, _| Box::pin(ready(Ok(()))));
 
-        let mock_network = MockNetworkRepository::new();
+        let mock_network = default_mock_network();
 
         let evm_transaction = EvmRelayerTransaction {
             relayer: relayer.clone(),
@@ -2023,7 +2269,7 @@ mod tests {
             .expect_produce_send_notification_job()
             .returning(|_, _| Box::pin(ready(Ok(()))));
 
-        let mock_network = MockNetworkRepository::new();
+        let mock_network = default_mock_network();
 
         let evm_transaction = EvmRelayerTransaction {
             relayer: relayer.clone(),
@@ -2082,7 +2328,7 @@ mod tests {
                 .expect_produce_send_notification_job()
                 .returning(|_, _| Box::pin(ready(Ok(()))));
 
-            let mock_network = MockNetworkRepository::new();
+            let mock_network = default_mock_network();
 
             // Set up EVM transaction with the mocks
             let evm_transaction = EvmRelayerTransaction {
@@ -2268,7 +2514,7 @@ mod tests {
             let mut test_tx = create_test_transaction();
             test_tx.status = TransactionStatus::Confirmed;
 
-            let mock_network = MockNetworkRepository::new();
+            let mock_network = default_mock_network();
 
             // Set up EVM transaction with the mocks
             let evm_transaction = EvmRelayerTransaction {
@@ -2473,7 +2719,7 @@ mod tests {
             let mut test_tx = create_test_transaction();
             test_tx.status = TransactionStatus::Confirmed;
 
-            let mock_network = MockNetworkRepository::new();
+            let mock_network = default_mock_network();
 
             // Set up EVM transaction with the mocks
             let evm_transaction = EvmRelayerTransaction {
@@ -2523,7 +2769,7 @@ mod tests {
         let mock_job_producer = MockJobProducerTrait::new();
         let mock_price_calculator = MockPriceCalculator::new();
         let counter_service = MockTransactionCounterTrait::new();
-        let mock_network = MockNetworkRepository::new();
+        let mock_network = default_mock_network();
 
         // Create test relayer and pending transaction
         let relayer = create_test_relayer_with_policy(RelayerEvmPolicy {
@@ -2584,7 +2830,7 @@ mod tests {
         let mock_job_producer = MockJobProducerTrait::new();
         let mock_price_calculator = MockPriceCalculator::new();
         let counter_service = MockTransactionCounterTrait::new();
-        let mock_network = MockNetworkRepository::new();
+        let mock_network = default_mock_network();
 
         // Create test relayer and pending transaction
         let relayer = create_test_relayer_with_policy(RelayerEvmPolicy {
@@ -2645,7 +2891,7 @@ mod tests {
         let mock_job_producer = MockJobProducerTrait::new();
         let mock_price_calculator = MockPriceCalculator::new();
         let counter_service = MockTransactionCounterTrait::new();
-        let mock_network = MockNetworkRepository::new();
+        let mock_network = default_mock_network();
 
         let relayer = create_test_relayer_with_policy(RelayerEvmPolicy {
             gas_limit_estimation: None, // Should default to true
@@ -2706,7 +2952,7 @@ mod tests {
         let mock_job_producer = MockJobProducerTrait::new();
         let mock_price_calculator = MockPriceCalculator::new();
         let counter_service = MockTransactionCounterTrait::new();
-        let mock_network = MockNetworkRepository::new();
+        let mock_network = default_mock_network();
 
         let relayer = create_test_relayer_with_policy(RelayerEvmPolicy {
             gas_limit_estimation: Some(true),
@@ -2772,7 +3018,7 @@ mod tests {
         let mut mock_job_producer = MockJobProducerTrait::new();
         let mut mock_price_calculator = MockPriceCalculator::new();
         let mut counter_service = MockTransactionCounterTrait::new();
-        let mock_network = MockNetworkRepository::new();
+        let mock_network = default_mock_network();
 
         // Create test relayer with gas limit estimation enabled
         let relayer = create_test_relayer_with_policy(RelayerEvmPolicy {
@@ -2922,7 +3168,7 @@ mod tests {
         let mut mock_job_producer = MockJobProducerTrait::new();
         let mut mock_price_calculator = MockPriceCalculator::new();
         let mut counter_service = MockTransactionCounterTrait::new();
-        let mock_network = MockNetworkRepository::new();
+        let mock_network = default_mock_network();
 
         let relayer = create_test_relayer_with_policy(RelayerEvmPolicy {
             gas_limit_estimation: Some(true),
@@ -3131,7 +3377,7 @@ mod tests {
         let mut mock_job_producer = MockJobProducerTrait::new();
         let mock_price_calculator = MockPriceCalculator::new();
         let counter_service = MockTransactionCounterTrait::new();
-        let mock_network = MockNetworkRepository::new();
+        let mock_network = default_mock_network();
 
         let relayer = create_test_relayer();
         let mut test_tx = create_test_transaction();
@@ -3202,7 +3448,7 @@ mod tests {
         let mock_job_producer = MockJobProducerTrait::new();
         let mock_price_calculator = MockPriceCalculator::new();
         let counter_service = MockTransactionCounterTrait::new();
-        let mock_network = MockNetworkRepository::new();
+        let mock_network = default_mock_network();
 
         let relayer = create_test_relayer();
         let mut test_tx = create_test_transaction();
@@ -3251,7 +3497,7 @@ mod tests {
         let mock_job_producer = MockJobProducerTrait::new();
         let mut mock_price_calculator = MockPriceCalculator::new();
         let counter_service = MockTransactionCounterTrait::new();
-        let mock_network = MockNetworkRepository::new();
+        let mock_network = default_mock_network();
 
         let relayer = create_test_relayer();
         let mut test_tx = create_test_transaction();
@@ -3373,7 +3619,7 @@ mod tests {
         let mut mock_job_producer = MockJobProducerTrait::new();
         let mock_price_calculator = MockPriceCalculator::new();
         let counter_service = MockTransactionCounterTrait::new();
-        let mock_network = MockNetworkRepository::new();
+        let mock_network = default_mock_network();
 
         let relayer = create_test_relayer();
         let mut test_tx = create_test_transaction();
@@ -3436,7 +3682,7 @@ mod tests {
         let mut mock_job_producer = MockJobProducerTrait::new();
         let mock_price_calculator = MockPriceCalculator::new();
         let counter_service = MockTransactionCounterTrait::new();
-        let mock_network = MockNetworkRepository::new();
+        let mock_network = default_mock_network();
 
         let relayer = create_test_relayer();
         let test_tx = create_test_transaction();
@@ -3480,7 +3726,7 @@ mod tests {
         let mut mock_job_producer = MockJobProducerTrait::new();
         let mock_price_calculator = MockPriceCalculator::new();
         let counter_service = MockTransactionCounterTrait::new();
-        let mock_network = MockNetworkRepository::new();
+        let mock_network = default_mock_network();
 
         let relayer = create_test_relayer();
         let test_tx = create_test_transaction();
@@ -3528,7 +3774,7 @@ mod tests {
         let mut mock_job_producer = MockJobProducerTrait::new();
         let mock_price_calculator = MockPriceCalculator::new();
         let counter_service = MockTransactionCounterTrait::new();
-        let mock_network = MockNetworkRepository::new();
+        let mock_network = default_mock_network();
 
         let relayer = create_test_relayer();
         let test_tx = create_test_transaction();
@@ -3571,7 +3817,7 @@ mod tests {
         let mut mock_job_producer = MockJobProducerTrait::new();
         let mock_price_calculator = MockPriceCalculator::new();
         let counter_service = MockTransactionCounterTrait::new();
-        let mock_network = MockNetworkRepository::new();
+        let mock_network = default_mock_network();
 
         let relayer = create_test_relayer();
         let test_tx = create_test_transaction();
@@ -3619,7 +3865,7 @@ mod tests {
         let mock_job_producer = MockJobProducerTrait::new();
         let mut mock_price_calculator = MockPriceCalculator::new();
         let counter_service = MockTransactionCounterTrait::new();
-        let mock_network = MockNetworkRepository::new();
+        let mock_network = default_mock_network();
 
         let relayer = create_test_relayer();
         let mut test_tx = create_test_transaction();
@@ -3839,7 +4085,7 @@ mod tests {
         let mut mock_job_producer = MockJobProducerTrait::new();
         let mock_price_calculator = MockPriceCalculator::new();
         let counter_service = MockTransactionCounterTrait::new();
-        let mock_network = MockNetworkRepository::new();
+        let mock_network = default_mock_network();
 
         let relayer = create_test_relayer();
         let mut test_tx = create_test_transaction();
@@ -3917,7 +4163,7 @@ mod tests {
         let mut mock_job_producer = MockJobProducerTrait::new();
         let mock_price_calculator = MockPriceCalculator::new();
         let counter_service = MockTransactionCounterTrait::new();
-        let mock_network = MockNetworkRepository::new();
+        let mock_network = default_mock_network();
 
         let relayer = create_test_relayer();
         let mut test_tx = create_test_transaction();
@@ -3995,7 +4241,7 @@ mod tests {
         let mut mock_job_producer = MockJobProducerTrait::new();
         let mut mock_price_calculator = MockPriceCalculator::new();
         let counter_service = MockTransactionCounterTrait::new();
-        let mock_network = MockNetworkRepository::new();
+        let mock_network = default_mock_network();
 
         let relayer = create_test_relayer();
         let mut test_tx = create_test_transaction();
@@ -4125,7 +4371,7 @@ mod tests {
         let mock_job_producer = MockJobProducerTrait::new();
         let mock_price_calculator = MockPriceCalculator::new();
         let counter_service = MockTransactionCounterTrait::new();
-        let mock_network = MockNetworkRepository::new();
+        let mock_network = default_mock_network();
 
         let relayer = create_test_relayer();
         let mut test_tx = create_test_transaction();
@@ -4200,7 +4446,7 @@ mod tests {
         let mut mock_job_producer = MockJobProducerTrait::new();
         let mock_price_calculator = MockPriceCalculator::new();
         let counter_service = MockTransactionCounterTrait::new();
-        let mock_network = MockNetworkRepository::new();
+        let mock_network = default_mock_network();
 
         let relayer = create_test_relayer();
         let mut test_tx = create_test_transaction();
@@ -4280,7 +4526,7 @@ mod tests {
         let mock_job_producer = MockJobProducerTrait::new();
         let mut mock_price_calculator = MockPriceCalculator::new();
         let counter_service = MockTransactionCounterTrait::new();
-        let mock_network = MockNetworkRepository::new();
+        let mock_network = default_mock_network();
 
         let relayer = create_test_relayer();
         let mut test_tx = create_test_transaction();

--- a/src/domain/transaction/evm/status.rs
+++ b/src/domain/transaction/evm/status.rs
@@ -1380,7 +1380,11 @@ where
                 .partial_update(tx.id.clone(), update)
                 .await?;
 
-            self.send_transaction_submit_job(&updated_tx).await?;
+            // Resubmit, not submit: the NOOP rewrote the logical fields but the
+            // stored raw/signature still hold the ORIGINAL payload. The resubmit
+            // path re-prices and re-signs so the NOOP is what gets broadcast
+            // (same as the Submitted-state and cancellation NOOP paths).
+            self.send_transaction_resubmit_job(&updated_tx).await?;
             let res = self.send_transaction_update_notification(&updated_tx).await;
             if let Err(e) = res {
                 error!(
@@ -2717,6 +2721,66 @@ mod tests {
     // Tests for `handle_sent_state`
     mod handle_sent_state_tests {
         use super::*;
+
+        /// A Sent tx over the rollup attempt threshold is NOOP-replaced AND the
+        /// replacement goes out as a RESUBMIT job: the stored raw/signature still
+        /// hold the original payload, so only the re-signing resubmit path
+        /// actually broadcasts the NOOP.
+        #[tokio::test]
+        async fn sent_state_noop_enqueues_resubmit_job() {
+            use crate::jobs::TransactionCommand;
+
+            let mut mocks = default_test_mocks();
+            let relayer = create_test_relayer();
+
+            let mut tx = make_test_transaction(TransactionStatus::Sent);
+            tx.hashes = vec!["0xHash1".to_string(); 11];
+            tx.sent_at = Some((Utc::now() - Duration::seconds(60)).to_rfc3339());
+
+            // should_noop + prepare_noop_update_request both look the network up.
+            mocks
+                .network_repo
+                .expect_get_by_chain_id()
+                .returning(|_, _| Ok(Some(create_test_arbitrum_network_model())));
+
+            // make_noop estimates gas on Arbitrum.
+            mocks
+                .provider
+                .expect_estimate_gas()
+                .returning(|_| Box::pin(async { Ok(50_000u64) }));
+
+            // The persisted update must carry the NOOP'd network_data.
+            let tx_clone = tx.clone();
+            mocks
+                .tx_repo
+                .expect_partial_update()
+                .times(1)
+                .withf(|_, update| {
+                    update.network_data.as_ref().is_some_and(|data| {
+                        data.get_evm_transaction_data().is_ok_and(|d| {
+                            d.value == U256::ZERO && d.to.as_deref() == Some(&d.from)
+                        })
+                    })
+                })
+                .returning(move |_, update| {
+                    let mut updated_tx = tx_clone.clone();
+                    updated_tx.network_data = update.network_data.clone().unwrap();
+                    updated_tx.noop_count = update.noop_count;
+                    Ok(updated_tx)
+                });
+
+            // The job must be a RESUBMIT (re-price + re-sign), not a plain submit.
+            mocks
+                .job_producer
+                .expect_produce_submit_transaction_job()
+                .times(1)
+                .withf(|job, _| matches!(job.command, TransactionCommand::Resubmit))
+                .returning(|_, _| Box::pin(async { Ok(()) }));
+
+            let evm_transaction = make_test_evm_relayer_transaction(relayer, mocks);
+            let result = evm_transaction.handle_sent_state(tx).await.unwrap();
+            assert!(result.noop_count.unwrap_or(0) > 0, "NOOP must be recorded");
+        }
 
         #[tokio::test]
         async fn test_sent_state_recent_no_resend() {

--- a/src/domain/transaction/evm/status.rs
+++ b/src/domain/transaction/evm/status.rs
@@ -1775,6 +1775,35 @@ mod tests {
         }
     }
 
+    /// Creates a test NetworkRepoModel for chain_id 1 with Arbitrum-based rollup tags,
+    /// so `is_arbitrum()` and `is_rollup()` both return true.
+    pub fn create_test_arbitrum_network_model() -> NetworkRepoModel {
+        let evm_config = EvmNetworkConfig {
+            common: NetworkConfigCommon {
+                network: "arbitrum-one".to_string(),
+                from: None,
+                rpc_urls: Some(vec![RpcConfig::new(
+                    "https://arb-rpc.example.com".to_string(),
+                )]),
+                explorer_urls: Some(vec!["https://arb-explorer.example.com".to_string()]),
+                average_blocktime_ms: Some(250),
+                is_testnet: Some(false),
+                tags: Some(vec!["rollup".to_string(), "arbitrum-based".to_string()]),
+            },
+            chain_id: Some(1),
+            required_confirmations: Some(1),
+            features: Some(vec!["eip1559".to_string()]),
+            symbol: Some("ETH".to_string()),
+            gas_price_cache: None,
+        };
+        NetworkRepoModel {
+            id: "evm:arbitrum-one".to_string(),
+            name: "arbitrum-one".to_string(),
+            network_type: NetworkType::Evm,
+            config: NetworkConfigData::Evm(evm_config),
+        }
+    }
+
     /// Minimal "builder" for TransactionRepoModel.
     /// Allows quick creation of a test transaction with default fields,
     /// then updates them based on the provided status or overrides.
@@ -2439,6 +2468,98 @@ mod tests {
             );
         }
 
+        /// ④ Rollup give-up valve: with attempts persisted pre-broadcast, a rollup tx
+        /// is NOOP-replaced after ROLLUP_MAX_DELIVERY_ATTEMPTS (10) recorded hashes —
+        /// long before the generic 50-attempt cap.
+        #[tokio::test]
+        async fn test_rollup_noop_fires_at_rollup_delivery_threshold() {
+            let mut mocks = default_test_mocks();
+            let relayer = create_test_relayer();
+
+            let mut tx = make_test_transaction(TransactionStatus::Sent);
+            // 11 recorded delivery attempts (> 10) on a never-mined transaction.
+            tx.hashes = vec!["0xHash1".to_string(); 11];
+
+            mocks
+                .network_repo
+                .expect_get_by_chain_id()
+                .returning(|_, _| Ok(Some(create_test_arbitrum_network_model())));
+
+            let evm_transaction = make_test_evm_relayer_transaction(relayer, mocks);
+            let (res, reason) = evm_transaction.should_noop(&tx).await.unwrap();
+            assert!(
+                res,
+                "Rollup transaction with 11 delivery attempts should be replaced with NOOP."
+            );
+            assert!(
+                reason.unwrap().contains("too many attempts"),
+                "Reason should mention too many attempts"
+            );
+        }
+
+        /// ④ At exactly the threshold (10 hashes) the rollup NOOP does not fire yet.
+        #[tokio::test]
+        async fn test_rollup_noop_does_not_fire_at_threshold_boundary() {
+            let mut mocks = default_test_mocks();
+            let relayer = create_test_relayer();
+
+            let mut tx = make_test_transaction(TransactionStatus::Sent);
+            tx.hashes = vec!["0xHash1".to_string(); 10];
+
+            mocks
+                .network_repo
+                .expect_get_by_chain_id()
+                .returning(|_, _| Ok(Some(create_test_arbitrum_network_model())));
+
+            // Falls through to the gas-limit check.
+            mocks.provider.expect_get_block_by_number().returning(|| {
+                Box::pin(async {
+                    use alloy::{network::AnyRpcBlock, rpc::types::Block};
+                    let mut block: Block = Block::default();
+                    block.header.gas_limit = 30_000_000u64;
+                    Ok(AnyRpcBlock::from(block))
+                })
+            });
+
+            let evm_transaction = make_test_evm_relayer_transaction(relayer, mocks);
+            let (res, reason) = evm_transaction.should_noop(&tx).await.unwrap();
+            assert!(!res, "10 attempts is at, not above, the rollup threshold.");
+            assert!(reason.is_none());
+        }
+
+        /// ④ Non-rollup networks keep the generic 50-attempt cap: 11 hashes must not
+        /// trigger a NOOP on mainnet.
+        #[tokio::test]
+        async fn test_non_rollup_unaffected_by_rollup_delivery_threshold() {
+            let mut mocks = default_test_mocks();
+            let relayer = create_test_relayer();
+
+            let mut tx = make_test_transaction(TransactionStatus::Sent);
+            tx.hashes = vec!["0xHash1".to_string(); 11];
+
+            mocks
+                .network_repo
+                .expect_get_by_chain_id()
+                .returning(|_, _| Ok(Some(create_test_network_model())));
+
+            mocks.provider.expect_get_block_by_number().returning(|| {
+                Box::pin(async {
+                    use alloy::{network::AnyRpcBlock, rpc::types::Block};
+                    let mut block: Block = Block::default();
+                    block.header.gas_limit = 30_000_000u64;
+                    Ok(AnyRpcBlock::from(block))
+                })
+            });
+
+            let evm_transaction = make_test_evm_relayer_transaction(relayer, mocks);
+            let (res, reason) = evm_transaction.should_noop(&tx).await.unwrap();
+            assert!(
+                !res,
+                "Non-rollup transaction with 11 attempts must not be NOOP-replaced."
+            );
+            assert!(reason.is_none());
+        }
+
         #[tokio::test]
         async fn test_pending_state_timeout_triggers_noop() {
             let mut mocks = default_test_mocks();
@@ -2875,6 +2996,123 @@ mod tests {
             let result = evm_transaction.handle_sent_state(tx.clone()).await.unwrap();
 
             assert_eq!(result.status, TransactionStatus::Sent);
+        }
+
+        /// ⑤ Arbitrum head gate: a stale Sent tx whose nonce is above the on-chain
+        /// nonce gets NO resubmit job — broadcasting it is a guaranteed rejection.
+        #[tokio::test]
+        async fn arbitrum_sent_state_behind_head_skips_resubmit() {
+            let mut mocks = default_test_mocks();
+            let relayer = create_test_relayer();
+
+            let mut tx = make_test_transaction(TransactionStatus::Sent);
+            tx.relayer_id = "arb-head-gate-behind-relayer".to_string();
+            tx.sent_at = Some((Utc::now() - Duration::seconds(60)).to_rfc3339());
+            tx.network_data = NetworkTransactionData::Evm(EvmTransactionData {
+                nonce: Some(7),
+                ..tx.network_data.get_evm_transaction_data().unwrap()
+            });
+
+            mocks
+                .network_repo
+                .expect_get_by_chain_id()
+                .returning(|_, _| Ok(Some(create_test_arbitrum_network_model())));
+
+            mocks.provider.expect_get_block_by_number().returning(|| {
+                Box::pin(async {
+                    use alloy::{network::AnyRpcBlock, rpc::types::Block};
+                    let mut block: Block = Block::default();
+                    block.header.gas_limit = 30_000_000u64;
+                    Ok(AnyRpcBlock::from(block))
+                })
+            });
+
+            // On-chain nonce is 5: the tx at nonce 7 is queued behind others.
+            mocks
+                .provider
+                .expect_get_transaction_count()
+                .returning(|_| Box::pin(async { Ok(5) }));
+
+            // Slots 5 and 6 are actively occupied — no gap, so only the head gate
+            // stands between this tx and a resubmit job.
+            mocks
+                .tx_repo
+                .expect_get_nonce_occupancy()
+                .returning(|_, from, to| {
+                    Ok((from..to)
+                        .map(|n| (n, Some(TransactionStatus::Sent)))
+                        .collect())
+                });
+
+            // No resubmit job may be queued for a tx behind the head.
+            mocks
+                .job_producer
+                .expect_produce_submit_transaction_job()
+                .never();
+
+            let evm_transaction = make_test_evm_relayer_transaction(relayer, mocks);
+            let result = evm_transaction.handle_sent_state(tx.clone()).await.unwrap();
+
+            assert_eq!(result.status, TransactionStatus::Sent);
+        }
+
+        /// ⑤ Arbitrum head gate: the stale Sent tx AT the on-chain nonce (the head)
+        /// does get its resubmit job — it is the only deliverable transaction.
+        #[tokio::test]
+        async fn arbitrum_sent_state_at_head_proceeds_to_resubmit() {
+            use std::sync::atomic::{AtomicUsize, Ordering};
+            use std::sync::Arc as StdArc;
+
+            let mut mocks = default_test_mocks();
+            let relayer = create_test_relayer();
+
+            let mut tx = make_test_transaction(TransactionStatus::Sent);
+            tx.relayer_id = "arb-head-gate-at-head-relayer".to_string();
+            tx.sent_at = Some((Utc::now() - Duration::seconds(60)).to_rfc3339());
+            tx.network_data = NetworkTransactionData::Evm(EvmTransactionData {
+                nonce: Some(5),
+                ..tx.network_data.get_evm_transaction_data().unwrap()
+            });
+
+            mocks
+                .network_repo
+                .expect_get_by_chain_id()
+                .returning(|_, _| Ok(Some(create_test_arbitrum_network_model())));
+
+            mocks.provider.expect_get_block_by_number().returning(|| {
+                Box::pin(async {
+                    use alloy::{network::AnyRpcBlock, rpc::types::Block};
+                    let mut block: Block = Block::default();
+                    block.header.gas_limit = 30_000_000u64;
+                    Ok(AnyRpcBlock::from(block))
+                })
+            });
+
+            // On-chain nonce equals the tx nonce — this tx is the head.
+            mocks
+                .provider
+                .expect_get_transaction_count()
+                .returning(|_| Box::pin(async { Ok(5) }));
+
+            let submit_calls = StdArc::new(AtomicUsize::new(0));
+            let submit_calls_clone = submit_calls.clone();
+            mocks
+                .job_producer
+                .expect_produce_submit_transaction_job()
+                .returning(move |_, _| {
+                    submit_calls_clone.fetch_add(1, Ordering::SeqCst);
+                    Box::pin(async { Ok(()) })
+                });
+
+            let evm_transaction = make_test_evm_relayer_transaction(relayer, mocks);
+            let result = evm_transaction.handle_sent_state(tx.clone()).await.unwrap();
+
+            assert_eq!(result.status, TransactionStatus::Sent);
+            assert_eq!(
+                submit_calls.load(Ordering::SeqCst),
+                1,
+                "the head transaction must get its resubmit job"
+            );
         }
 
         /// A failed enqueue must not hold the debounce window: after `clear`, the

--- a/src/domain/transaction/evm/status.rs
+++ b/src/domain/transaction/evm/status.rs
@@ -1380,10 +1380,9 @@ where
                 .partial_update(tx.id.clone(), update)
                 .await?;
 
-            // Resubmit, not submit: the NOOP rewrote the logical fields but the
-            // stored raw/signature still hold the ORIGINAL payload. The resubmit
-            // path re-prices and re-signs so the NOOP is what gets broadcast
-            // (same as the Submitted-state and cancellation NOOP paths).
+            // Resubmit, not submit: the NOOP rewrote the logical fields, but the
+            // stored raw/signature still hold the original payload. The resubmit
+            // path re-prices and re-signs, so the NOOP is what gets broadcast.
             self.send_transaction_resubmit_job(&updated_tx).await?;
             let res = self.send_transaction_update_notification(&updated_tx).await;
             if let Err(e) = res {
@@ -1411,11 +1410,11 @@ where
                     .await;
             }
 
-            // Arbitrum head gate (issue #843): the sequencer holds a nonce-above-head tx
-            // ~1s then rejects it, so resubmitting anything but the head is a guaranteed
-            // rejection. Only the tx at the on-chain nonce is broadcast; successors are
-            // delivered by the broadcast-success chain link, or by this gate once they
-            // become the head.
+            // Arbitrum head gate: the sequencer holds a nonce-above-head tx ~1s and
+            // then rejects it, so a resubmit of anything but the head always fails.
+            // Only the tx at the on-chain nonce is broadcast. Successors are delivered
+            // by the broadcast-success chain link, or by this gate once they become
+            // the head.
             if self.is_behind_arbitrum_head(&tx).await {
                 debug!(
                     tx_id = %tx.id,
@@ -2472,7 +2471,7 @@ mod tests {
             );
         }
 
-        /// ④ Rollup give-up valve: with attempts persisted pre-broadcast, a rollup tx
+        /// Rollup give-up valve: with attempts persisted pre-broadcast, a rollup tx
         /// is NOOP-replaced after ROLLUP_MAX_DELIVERY_ATTEMPTS (10) recorded hashes —
         /// long before the generic 50-attempt cap.
         #[tokio::test]
@@ -2501,7 +2500,7 @@ mod tests {
             );
         }
 
-        /// ④ At exactly the threshold (10 hashes) the rollup NOOP does not fire yet.
+        /// At exactly the threshold (10 hashes) the rollup NOOP does not fire yet.
         #[tokio::test]
         async fn test_rollup_noop_does_not_fire_at_threshold_boundary() {
             let mut mocks = default_test_mocks();
@@ -2531,7 +2530,7 @@ mod tests {
             assert!(reason.is_none());
         }
 
-        /// ④ Non-rollup networks keep the generic 50-attempt cap: 11 hashes must not
+        /// Non-rollup networks keep the generic 50-attempt cap: 11 hashes must not
         /// trigger a NOOP on mainnet.
         #[tokio::test]
         async fn test_non_rollup_unaffected_by_rollup_delivery_threshold() {
@@ -3062,7 +3061,7 @@ mod tests {
             assert_eq!(result.status, TransactionStatus::Sent);
         }
 
-        /// ⑤ Arbitrum head gate: a stale Sent tx whose nonce is above the on-chain
+        /// Arbitrum head gate: a stale Sent tx whose nonce is above the on-chain
         /// nonce gets NO resubmit job — broadcasting it is a guaranteed rejection.
         #[tokio::test]
         async fn arbitrum_sent_state_behind_head_skips_resubmit() {
@@ -3120,7 +3119,7 @@ mod tests {
             assert_eq!(result.status, TransactionStatus::Sent);
         }
 
-        /// ⑤ Arbitrum head gate: the stale Sent tx AT the on-chain nonce (the head)
+        /// Arbitrum head gate: the stale Sent tx AT the on-chain nonce (the head)
         /// does get its resubmit job — it is the only deliverable transaction.
         #[tokio::test]
         async fn arbitrum_sent_state_at_head_proceeds_to_resubmit() {

--- a/src/domain/transaction/evm/status.rs
+++ b/src/domain/transaction/evm/status.rs
@@ -18,7 +18,7 @@ use super::EvmRelayerTransaction;
 use super::{
     ensure_status, evm_transaction::TX_NONCE_RECONCILE_TRIGGER, get_age_since_status_change,
     has_enough_confirmations, is_noop, is_too_early_to_resubmit, is_transaction_valid, make_noop,
-    too_many_attempts, too_many_noop_attempts,
+    too_many_noop_attempts, too_many_rollup_attempts,
 };
 use crate::constants::{
     get_evm_min_age_for_hash_recovery, get_evm_pending_recovery_trigger_timeout,
@@ -383,7 +383,7 @@ where
             ))
         })?;
 
-        if network.is_rollup() && too_many_attempts(tx) {
+        if network.is_rollup() && too_many_rollup_attempts(tx) {
             let reason =
                 "Rollup transaction has too many attempts. Replacing with NOOP.".to_string();
             debug!(
@@ -1407,6 +1407,22 @@ where
                     .await;
             }
 
+            // Arbitrum head gate (issue #843): the sequencer holds a nonce-above-head tx
+            // ~1s then rejects it, so resubmitting anything but the head is a guaranteed
+            // rejection. Only the tx at the on-chain nonce is broadcast; successors are
+            // delivered by the broadcast-success chain link, or by this gate once they
+            // become the head.
+            if self.is_behind_arbitrum_head(&tx).await {
+                debug!(
+                    tx_id = %tx.id,
+                    relayer_id = %tx.relayer_id,
+                    "stuck Sent tx is queued behind the chain head on Arbitrum; skipping resubmit"
+                );
+                return self
+                    .update_transaction_status_if_needed(tx, TransactionStatus::Sent, None)
+                    .await;
+            }
+
             warn!(
                 tx_id = %tx.id,
                 relayer_id = %tx.relayer_id,
@@ -1420,6 +1436,47 @@ where
 
         self.update_transaction_status_if_needed(tx, TransactionStatus::Sent, None)
             .await
+    }
+
+    /// Arbitrum only: returns `true` when the tx nonce is above the on-chain account
+    /// nonce (queued behind other txs, guaranteed rejection if broadcast). Non-Arbitrum
+    /// networks and lookup failures return `false` so resubmit behavior is preserved.
+    async fn is_behind_arbitrum_head(&self, tx: &TransactionRepoModel) -> bool {
+        let Ok(evm_data) = tx.network_data.get_evm_transaction_data() else {
+            return false;
+        };
+        let Some(tx_nonce) = evm_data.nonce else {
+            return false;
+        };
+
+        match self.get_evm_network(evm_data.chain_id).await {
+            Ok(network) if network.is_arbitrum() => {}
+            Ok(_) => return false,
+            Err(e) => {
+                debug!(
+                    tx_id = %tx.id,
+                    error = %e,
+                    "head gate: failed to load network; allowing resubmit"
+                );
+                return false;
+            }
+        }
+
+        match self
+            .provider()
+            .get_transaction_count(&self.relayer().address)
+            .await
+        {
+            Ok(chain_nonce) => tx_nonce > chain_nonce,
+            Err(e) => {
+                debug!(
+                    tx_id = %tx.id,
+                    error = %e,
+                    "head gate: failed to fetch on-chain nonce; allowing resubmit"
+                );
+                false
+            }
+        }
     }
 
     /// Determines if we should attempt hash recovery for a stuck transaction.

--- a/src/domain/transaction/evm/utils.rs
+++ b/src/domain/transaction/evm/utils.rs
@@ -543,6 +543,12 @@ mod tests {
         // Test with too many attempts
         tx.hashes = vec!["hash".to_string(); MAXIMUM_TX_ATTEMPTS + 1];
         assert!(too_many_attempts(&tx));
+
+        // Rollup threshold: fires above ROLLUP_MAX_DELIVERY_ATTEMPTS, not at it.
+        tx.hashes = vec!["hash".to_string(); ROLLUP_MAX_DELIVERY_ATTEMPTS];
+        assert!(!too_many_rollup_attempts(&tx));
+        tx.hashes = vec!["hash".to_string(); ROLLUP_MAX_DELIVERY_ATTEMPTS + 1];
+        assert!(too_many_rollup_attempts(&tx));
     }
 
     #[test]

--- a/src/domain/transaction/evm/utils.rs
+++ b/src/domain/transaction/evm/utils.rs
@@ -1,6 +1,7 @@
 use crate::constants::{
     ARBITRUM_GAS_LIMIT, DEFAULT_GAS_LIMIT, DEFAULT_TRANSACTION_SPEED, DEFAULT_TX_VALID_TIMESPAN,
     EVM_MIN_AGE_FOR_RESUBMIT_SECONDS, MAXIMUM_NOOP_RETRY_ATTEMPTS, MAXIMUM_TX_ATTEMPTS,
+    ROLLUP_MAX_DELIVERY_ATTEMPTS,
 };
 use crate::domain::get_age_since_created;
 use crate::models::EvmNetwork;
@@ -66,6 +67,13 @@ pub fn is_noop(evm_data: &EvmTransactionData) -> bool {
 /// Checks if a transaction has too many attempts
 pub fn too_many_attempts(tx: &TransactionRepoModel) -> bool {
     tx.hashes.len() > MAXIMUM_TX_ATTEMPTS
+}
+
+/// Checks if a rollup transaction has too many delivery attempts.
+/// Rollups persist every broadcast attempt before broadcast, so `hashes.len()` counts
+/// real delivery attempts and a much lower give-up threshold applies.
+pub fn too_many_rollup_attempts(tx: &TransactionRepoModel) -> bool {
+    tx.hashes.len() > ROLLUP_MAX_DELIVERY_ATTEMPTS
 }
 
 /// Checks if a transaction has too many NOOP attempts


### PR DESCRIPTION
# Summary

Fixes #843.

On Arbitrum-class networks the sequencer has no mempool: a transaction with a nonce above the account nonce is held for about one second and then rejected with "nonce too high". One undelivered broadcast therefore jams every transaction queued behind it, and each stuck transaction retries on its own timer in arbitrary order, so a jam drains slower than new traffic widens it (#843 reached +633 nonces).

This PR makes delivery chained and forward-only on Arbitrum (all changes gated on `network.is_arbitrum()`; the NOOP threshold uses the existing rollup branch):

- Resubmission attempts are persisted before broadcast, so any bytes that might reach the chain are recorded and `hashes.len()` becomes a true delivery-attempt counter.
- A "nonce too high" broadcast is retried in-process with the same signed bytes up to 3 times about 1 second apart, riding the Nitro nonce-failure cache revive window instead of consuming the escalation budget.
- A successful broadcast at nonce N immediately enqueues the submit job for a never-broadcast transaction at N+1, so a jammed region drains at job-plus-RPC latency instead of one transaction per retry cycle.
- Rollup transactions are NOOP-replaced after 10 recorded delivery attempts instead of the generic 50, so a poisoned head is burned and the region behind it drains.
- Stuck Sent transactions only get resubmit jobs when they are at the on-chain nonce; anything above the head is a guaranteed rejection, so it waits. This kills the retry storm and restarts the chain if a link is ever lost.

The nonce-health job, gap fill, and rewind paths are unchanged. One option to consider later: the pre-broadcast persistence looks safe to apply on all networks, but it is kept Arbitrum-gated here to match the reviewed design.

# Testing Process

- `cargo test --lib domain::transaction::evm` (229 passed) and `domain::relayer::evm` (99 passed); new unit tests cover all five behaviors, including boundary and non-Arbitrum cases. Paused-time retry tests add the tokio `test-util` feature to dev-dependencies.
- End-to-end against an Arbitrum-emulating proxy (strict nonce, 1s revive window, per-nonce blackhole) in front of anvil: a 47-transaction jam drained in 4.8 seconds after the head landed (median inter-acceptance gap 0.1s, versus 5.8s serial drain before this fix), with zero failed transactions and zero counter rewinds. With a permanent blackhole, the head was NOOP-replaced after ~11 attempts and the backlog drained once the endpoint recovered.

# Checklist

- [x] Add a reference to related issues in the PR description.
- [x] Add unit tests if applicable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Arbitrum transaction handling with automatic retries for nonce-related errors.
  * Prevented duplicate transaction hashes during resubmission bookkeeping.
  * Improved transaction sequencing by continuing delivery with the next available nonce.
  * Added safeguards to avoid resubmitting stale transactions.

* **Reliability**
  * Rollup transactions are now replaced with a no-op after 10 delivery attempts, reducing repeated failed deliveries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->